### PR TITLE
=act Stash dns query if there is a collision.

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/DnsClientSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/DnsClientSpec.scala
@@ -13,15 +13,16 @@
 
 package org.apache.pekko.io.dns.internal
 
-import java.net.InetSocketAddress
+import java.net.{ InetAddress, InetSocketAddress }
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.immutable.Seq
+import scala.concurrent.duration.DurationInt
 
 import org.apache.pekko
-import pekko.actor.Props
+import pekko.actor.{ ActorRef, Props }
 import pekko.io.Udp
-import pekko.io.dns.{ RecordClass, RecordType }
+import pekko.io.dns.{ ARecord, CachePolicy, RecordClass, RecordType }
 import pekko.io.dns.internal.DnsClient.{ Answer, Question4 }
 import pekko.testkit.{ ImplicitSender, PekkoSpec, TestProbe }
 
@@ -41,7 +42,7 @@ class DnsClientSpec extends PekkoSpec with ImplicitSender {
       val client = system.actorOf(Props(new DnsClient(dnsServerAddress) {
         override val udp = udpExtensionProbe.ref
 
-        override def createTcpClient() = {
+        override def createTcpClient(): ActorRef = {
           tcpClientCreated.set(true)
           TestProbe().ref
         }
@@ -53,11 +54,63 @@ class DnsClientSpec extends PekkoSpec with ImplicitSender {
       udpExtensionProbe.lastSender ! Udp.Bound(InetSocketAddress.createUnresolved("localhost", 41325))
 
       expectMsgType[Udp.Send]
-      client ! Udp.Received(exampleResponseMessage.write(), dnsServerAddress)
+
+      client ! Udp.Received(
+        exampleResponseMessage
+          .copy(questions = exampleRequestMessage.questions)
+          .write(), dnsServerAddress)
 
       expectMsg(exampleResponse)
 
       tcpClientCreated.get() should be(false)
+    }
+
+    "Defer dns query when id collision" in {
+      val udpExtensionProbe = TestProbe()
+      val tcpClientProbe = TestProbe()
+
+      val client = system.actorOf(Props(new DnsClient(dnsServerAddress) {
+        override val udp = udpExtensionProbe.ref
+
+        override def createTcpClient(): ActorRef = tcpClientProbe.ref
+      }))
+
+      udpExtensionProbe.expectMsgType[Udp.Bind]
+      udpExtensionProbe.lastSender ! Udp.Bound(InetSocketAddress.createUnresolved("localhost", 41325))
+
+      client ! exampleRequest
+      client ! exampleRequest.copy(name = "apache.org") // will be stashed
+
+      expectMsgType[Udp.Send]
+      expectNoMessage(3.seconds)
+
+      val pekkoRecord = ARecord("pekko.io", CachePolicy.Ttl.effectivelyForever, InetAddress.getByName("127.0.0.1"))
+      val apacheRecord = ARecord("apache.org", CachePolicy.Ttl.effectivelyForever, InetAddress.getByName("127.0.0.1"))
+
+      val pekkoResponse =
+        Message(42, MessageFlags(answer = true), exampleRequestMessage.questions, Seq(pekkoRecord))
+
+      client ! Udp.Received(
+        pekkoResponse.write(),
+        dnsServerAddress)
+
+      val responsePekko = expectMsgType[Answer]
+      responsePekko.id shouldBe 42
+
+      expectMsgType[Udp.Send] // unstashed
+
+      val apacheResponse =
+        Message(
+          42,
+          MessageFlags(answer = true),
+          Seq(Question("apache.org", RecordType.A, RecordClass.IN)), Seq(apacheRecord))
+
+      client ! Udp.Received(
+        apacheResponse.write(),
+        dnsServerAddress)
+
+      val responseApache = expectMsgType[Answer]
+      responseApache.id shouldBe 42
     }
 
     "Fall back to TCP when the UDP response is truncated" in {
@@ -67,7 +120,7 @@ class DnsClientSpec extends PekkoSpec with ImplicitSender {
       val client = system.actorOf(Props(new DnsClient(dnsServerAddress) {
         override val udp = udpExtensionProbe.ref
 
-        override def createTcpClient() = tcpClientProbe.ref
+        override def createTcpClient(): ActorRef = tcpClientProbe.ref
       }))
 
       client ! exampleRequest
@@ -76,7 +129,10 @@ class DnsClientSpec extends PekkoSpec with ImplicitSender {
       udpExtensionProbe.lastSender ! Udp.Bound(InetSocketAddress.createUnresolved("localhost", 41325))
 
       expectMsgType[Udp.Send]
-      client ! Udp.Received(Message(exampleRequest.id, MessageFlags(truncated = true)).write(), dnsServerAddress)
+      client ! Udp.Received(Message(
+          exampleRequest.id,
+          MessageFlags(truncated = true),
+          exampleRequestMessage.questions).write(), dnsServerAddress)
 
       tcpClientProbe.expectMsg(exampleRequestMessage)
       tcpClientProbe.reply(exampleResponse)

--- a/actor/src/main/scala/org/apache/pekko/io/dns/internal/DnsClient.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/internal/DnsClient.scala
@@ -15,11 +15,10 @@ package org.apache.pekko.io.dns.internal
 
 import java.net.{ InetAddress, InetSocketAddress }
 
+import scala.annotation.nowarn
 import scala.collection.{ immutable => im }
 import scala.concurrent.duration._
 import scala.util.Try
-
-import scala.annotation.nowarn
 
 import org.apache.pekko
 import pekko.actor.{ Actor, ActorLogging, ActorRef, NoSerializationVerificationNeeded, Props, Stash }
@@ -52,14 +51,14 @@ import pekko.pattern.{ BackoffOpts, BackoffSupervisor }
   import DnsClient._
   import context.system
 
-  val udp = IO(Udp)
-  val tcp = IO(Tcp)
+  val udp: ActorRef = IO(Udp)
+  val tcp: ActorRef = IO(Tcp)
 
   private[internal] var inflightRequests: Map[Short, (ActorRef, Message)] = Map.empty
 
   lazy val tcpDnsClient: ActorRef = createTcpClient()
 
-  override def preStart() = {
+  override def preStart(): Unit = {
     udp ! Udp.Bind(self, new InetSocketAddress(InetAddress.getByAddress(Array.ofDim(4)), 0))
   }
 
@@ -88,27 +87,19 @@ import pekko.pattern.{ BackoffOpts, BackoffSupervisor }
     case DropRequest(id) =>
       log.debug("Dropping request [{}]", id)
       inflightRequests -= id
+      unstashAll()
 
     case Question4(id, name) =>
       log.debug("Resolving [{}] (A)", name)
-      val msg = message(name, id, RecordType.A)
-      inflightRequests += (id -> (sender() -> msg))
-      log.debug("Message [{}] to [{}]: [{}]", id, ns, msg)
-      socket ! Udp.Send(msg.write(), ns)
+      sendingQueryOrStash(socket, message(name, id, RecordType.A))
 
     case Question6(id, name) =>
       log.debug("Resolving [{}] (AAAA)", name)
-      val msg = message(name, id, RecordType.AAAA)
-      inflightRequests += (id -> (sender() -> msg))
-      log.debug("Message to [{}]: [{}]", ns, msg)
-      socket ! Udp.Send(msg.write(), ns)
+      sendingQueryOrStash(socket, message(name, id, RecordType.AAAA))
 
     case SrvQuestion(id, name) =>
       log.debug("Resolving [{}] (SRV)", name)
-      val msg = message(name, id, RecordType.SRV)
-      inflightRequests += (id -> (sender() -> msg))
-      log.debug("Message to [{}]: [{}]", ns, msg)
-      socket ! Udp.Send(msg.write(), ns)
+      sendingQueryOrStash(socket, message(name, id, RecordType.SRV))
 
     case Udp.CommandFailed(cmd) =>
       log.debug("Command failed [{}]", cmd)
@@ -121,6 +112,7 @@ import pekko.pattern.{ BackoffOpts, BackoffSupervisor }
               case (s, _) =>
                 s ! Failure(new RuntimeException("Send failed to nameserver"))
                 inflightRequests -= msg.id
+                unstashAll()
             }
           }
         case _ =>
@@ -128,27 +120,44 @@ import pekko.pattern.{ BackoffOpts, BackoffSupervisor }
       }
     case Udp.Received(data, remote) =>
       log.debug("Received message from [{}]: [{}]", remote, data)
-      val msg = Message.parse(data)
+      val msg @ Message(id, flags, questions, answerRecs, _, additionalRecs) = Message.parse(data)
       log.debug("Decoded UDP DNS response [{}]", msg)
-
-      if (msg.flags.isTruncated) {
-        log.debug("DNS response truncated, falling back to TCP")
-        inflightRequests.get(msg.id) match {
-          case Some((_, msg)) =>
-            tcpDnsClient ! msg
-          case _ =>
-            log.debug("Client for id {} not found. Discarding unsuccessful response.", msg.id)
-        }
+      if (questions.isEmpty) {
+        log.debug("Dns response contains no referenced question, discard the response.", id)
       } else {
-        val (recs, additionalRecs) =
-          if (msg.flags.responseCode == ResponseCode.SUCCESS) (msg.answerRecs, msg.additionalRecs) else (Nil, Nil)
-        self ! Answer(msg.id, recs, additionalRecs)
+        inflightRequests.get(id) match {
+          case Some((replyTo, queryMsg)) =>
+            if (flags.isTruncated) {
+              log.debug("DNS response truncated, falling back to TCP")
+              tcpDnsClient ! queryMsg
+            } else {
+              // check if the question is match
+              val previousQuestion = msg.questions
+              if (questions.head != previousQuestion.head) {
+                log.warning(
+                  "Dns response referenced to different question:{} expected:{} for id:{},maybe an error.",
+                  questions.head, previousQuestion.head, id)
+              } else {
+                val response = if (flags.responseCode == ResponseCode.SUCCESS) {
+                  Answer(id, answerRecs, additionalRecs)
+                } else {
+                  Answer(id, Nil, Nil)
+                }
+                replyTo ! response
+                inflightRequests -= response.id
+                unstashAll()
+              }
+            }
+          case None =>
+            log.debug("Client for id {} not found. Discarding response.", id)
+        }
       }
     case response: Answer =>
       inflightRequests.get(response.id) match {
-        case Some((reply, _)) =>
-          reply ! response
+        case Some((replyTo, _)) =>
+          replyTo ! response
           inflightRequests -= response.id
+          unstashAll()
         case None =>
           log.debug("Client for id {} not found. Discarding response.", response.id)
       }
@@ -156,7 +165,20 @@ import pekko.pattern.{ BackoffOpts, BackoffSupervisor }
     case Udp.Unbound => context.stop(self)
   }
 
-  def createTcpClient() = {
+  private def sendingQueryOrStash(socket: ActorRef, message: Message): Unit = {
+    val id = message.id
+    inflightRequests.get(id) match {
+      case None =>
+        inflightRequests += (id -> (sender() -> message))
+        log.debug("Message [{}] to [{}]: [{}]", id, ns, message)
+        socket ! Udp.Send(message.write(), ns)
+      case Some((_, msg)) =>
+        stash()
+        log.debug("There is a in flight dns query with same id [{}], previous query: [{}].", id, msg)
+    }
+  }
+
+  def createTcpClient(): ActorRef = {
     context.actorOf(
       BackoffSupervisor.props(
         BackoffOpts.onFailure(


### PR DESCRIPTION
If there is already an onging query with same id, stash the query, otherwise send it directly.
When receive a response, unstash all and process.

refs: https://github.com/akka/akka/issues/31905

Modification:

1. stash the query if there is a collision and unstash after response received.
2. check the response references questions, if not match the previous question, just drop it.
3. response directly when possible.
