### PR TITLE
POC =act Make use of externalSubmit to yield.

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ActorSystemSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ActorSystemSpec.scala
@@ -99,8 +99,9 @@ object ActorSystemSpec {
       override protected[pekko] def registerForExecution(
           mbox: Mailbox,
           hasMessageHint: Boolean,
-          hasSystemMessageHint: Boolean): Boolean = {
-        val ret = super.registerForExecution(mbox, hasMessageHint, hasSystemMessageHint)
+          hasSystemMessageHint: Boolean,
+          needYield: Boolean): Boolean = {
+        val ret = super.registerForExecution(mbox, hasMessageHint, hasSystemMessageHint, needYield)
         doneIt.switchOn {
           TestKit.awaitCond(mbox.actor.actor != null, 1.second)
           mbox.actor.actor match {

--- a/actor-tests/src/test/scala/org/apache/pekko/dispatch/ForkJoinPoolStarvationSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/dispatch/ForkJoinPoolStarvationSpec.scala
@@ -18,7 +18,6 @@ import com.typesafe.config.ConfigFactory
 import org.apache.pekko
 import pekko.actor.{ Actor, Props }
 import pekko.testkit.{ ImplicitSender, PekkoSpec }
-import pekko.util.JavaVersion
 
 object ForkJoinPoolStarvationSpec {
   val config = ConfigFactory.parseString("""
@@ -63,8 +62,8 @@ class ForkJoinPoolStarvationSpec extends PekkoSpec(ForkJoinPoolStarvationSpec.co
 
     "not starve tasks arriving from external dispatchers under high internal traffic" in {
       // TODO issue #31117: starvation with JDK 17 FJP
-      if (JavaVersion.majorVersion >= 17)
-        pending
+//      if (JavaVersion.majorVersion >= 17)
+//        pending
 
       // Two busy actors that will occupy the threads of the dispatcher
       // Since they submit to the local task queue via fork, they can starve external submissions

--- a/actor/src/main/scala/org/apache/pekko/dispatch/BalancingDispatcher.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/BalancingDispatcher.scala
@@ -106,7 +106,7 @@ private[pekko] class BalancingDispatcher(
 
   override protected[pekko] def dispatch(receiver: ActorCell, invocation: Envelope) = {
     messageQueue.enqueue(receiver.self, invocation)
-    if (!registerForExecution(receiver.mailbox, false, false)) teamWork()
+    if (!registerForExecution(receiver.mailbox, false, false, false)) teamWork()
   }
 
   protected def teamWork(): Unit =
@@ -118,7 +118,7 @@ private[pekko] class BalancingDispatcher(
             case lm: LoadMetrics => !lm.atFullThrottle()
             case _               => true
           })
-          && !registerForExecution(i.next.mailbox, false, false))
+          && !registerForExecution(i.next.mailbox, false, false, true))
           scheduleOne(i)
 
       scheduleOne()

--- a/actor/src/main/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfigurator.scala
@@ -14,8 +14,9 @@
 package org.apache.pekko.dispatch
 
 import java.util.concurrent.{ ExecutorService, ForkJoinPool, ForkJoinTask, ThreadFactory }
-
 import com.typesafe.config.Config
+
+import java.lang.invoke.{ MethodHandle, MethodHandles, MethodType }
 
 object ForkJoinExecutorConfigurator {
 
@@ -28,7 +29,7 @@ object ForkJoinExecutorConfigurator {
       unhandledExceptionHandler: Thread.UncaughtExceptionHandler,
       asyncMode: Boolean)
       extends ForkJoinPool(parallelism, threadFactory, unhandledExceptionHandler, asyncMode)
-      with LoadMetrics {
+      with LoadMetrics with LazyExecuteSupport {
     def this(
         parallelism: Int,
         threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
@@ -41,6 +42,33 @@ object ForkJoinExecutorConfigurator {
           (if (r.isInstanceOf[ForkJoinTask[_]]) r else new PekkoForkJoinTask(r)).asInstanceOf[ForkJoinTask[Any]])
       else
         throw new NullPointerException("Runnable was null")
+
+    private val lazyExecuteHandle: MethodHandle = {
+      import org.apache.pekko.util.JavaVersion._
+      if (11 <= majorVersion && majorVersion <= 18) {
+        val method = classOf[ForkJoinPool].getDeclaredMethod("externalPush", classOf[ForkJoinTask[_]])
+        method.setAccessible(true)
+        MethodHandles.lookup().unreflect(method)
+      } else if (majorVersion >= 20) {
+        val mt = MethodType.methodType(classOf[ForkJoinTask[_]], classOf[ForkJoinTask[_]])
+        MethodHandles.publicLookup()
+          .findVirtual(classOf[ForkJoinPool], "externalSubmit", mt)
+      } else null
+    }
+
+    override def lazyExecute(r: Runnable): Unit = {
+      import org.apache.pekko.util.JavaVersion._
+      if (majorVersion < 11 || majorVersion == 19 || lazyExecuteHandle == null) {
+        super.execute(r)
+      } else {
+        val task: ForkJoinTask[_] = if (r ne null)
+          if (r.isInstanceOf[ForkJoinTask[_]]) r.asInstanceOf[ForkJoinTask[_]] else new PekkoForkJoinTask(r)
+        else
+          throw new NullPointerException("Runnable was null")
+        lazyExecuteHandle.invoke(this, task)
+      }
+
+    }
 
     def atFullThrottle(): Boolean = this.getActiveThreadCount() >= this.getParallelism()
   }

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
@@ -242,7 +242,7 @@ private[pekko] abstract class Mailbox(val messageQueue: MessageQueue)
       }
     } finally {
       setAsIdle() // Volatile write, needed here
-      dispatcher.registerForExecution(this, false, false)
+      dispatcher.registerForExecution(this, false, false, true)
     }
   }
 

--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -38,6 +38,8 @@ object JdkOptions extends AutoPlugin {
     if (isJdk17orHigher) {
       // for aeron
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED" ::
+      // for fork join pool
+      "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED" ::
       // for LevelDB
       "--add-opens=java.base/java.nio=ALL-UNNAMED" :: Nil
     } else Nil

--- a/testkit/src/main/scala/org/apache/pekko/testkit/CallingThreadDispatcher.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/CallingThreadDispatcher.scala
@@ -177,7 +177,8 @@ class CallingThreadDispatcher(_configurator: MessageDispatcherConfigurator) exte
   protected[pekko] override def registerForExecution(
       mbox: Mailbox,
       hasMessageHint: Boolean,
-      hasSystemMessageHint: Boolean): Boolean = false
+      hasSystemMessageHint: Boolean,
+      needYield: Boolean): Boolean = false
 
   protected[pekko] override def shutdownTimeout = 1 second
 


### PR DESCRIPTION
refs: https://github.com/apache/incubator-pekko/issues/661

Some previous work done by @jrudolph years ago?

The Current VirtualThrad in JDK 21 making use of the `externalSubmit`
```java
if (s == YIELDING) {   // Thread.yield
            setState(RUNNABLE);

            // notify JVMTI that unmount has completed, thread is runnable
            notifyJvmtiUnmount(/*hide*/false);

            // external submit if there are no tasks in the local task queue
            if (currentThread() instanceof CarrierThread ct && ct.getQueuedTaskCount() == 0) {
                externalSubmitRunContinuation(ct.getPool());
            } else {
                submitRunContinuation();
            }
        }
```

I think this change will affect the performance.

I think a better way should be explicit yield after some run, just as the `cede` of CE, which @armanbilge metioned.