### PR TITLE
chore: Switch to new new wildcard [?].

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version                                  = 3.7.14
-runner.dialect                           = scala213
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -75,3 +75,14 @@ project.excludeFilters = [
   "scripts/authors.scala"
 ]
 project.layout         = StandardConvention
+
+# Have to turn if off for now, scala-cli fmt not working for rewrite.
+# The rewriting works when do rewriting with `sbt scalafmtAll`.
+//rewrite.scala3.convertToNewSyntax = true
+//runner {
+//  dialectOverride {
+//    allowAsForImportRename = false
+//    allowStarWildcardImport = false
+//    allowPostfixStarVarargSplices = false
+//  }
+//}

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/Effect.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/Effect.scala
@@ -45,7 +45,7 @@ object Effect {
       with Serializable {
 
     override def equals(other: Any) = other match {
-      case o: Spawned[_] =>
+      case o: Spawned[?] =>
         this.behavior == o.behavior &&
         this.childName == o.childName &&
         this.props == o.props
@@ -58,7 +58,7 @@ object Effect {
     override def _1: Behavior[T] = behavior
     override def _2: String = childName
     override def _3: Props = props
-    override def canEqual(o: Any) = o.isInstanceOf[Spawned[_]]
+    override def canEqual(o: Any) = o.isInstanceOf[Spawned[?]]
   }
 
   object Spawned {
@@ -76,7 +76,7 @@ object Effect {
       with Serializable {
 
     override def equals(other: Any) = other match {
-      case o: SpawnedAnonymous[_] => this.behavior == o.behavior && this.props == o.props
+      case o: SpawnedAnonymous[?] => this.behavior == o.behavior && this.props == o.props
       case _                      => false
     }
     override def hashCode: Int = behavior.## * 31 + props.##
@@ -85,7 +85,7 @@ object Effect {
     override def productPrefix = "SpawnedAnonymous"
     override def _1: Behavior[T] = behavior
     override def _2: Props = props
-    override def canEqual(o: Any) = o.isInstanceOf[SpawnedAnonymous[_]]
+    override def canEqual(o: Any) = o.isInstanceOf[SpawnedAnonymous[?]]
   }
 
   object SpawnedAnonymous {
@@ -105,7 +105,7 @@ object Effect {
       with Serializable {
 
     override def equals(other: Any) = other match {
-      case o: SpawnedAdapter[_] => this.name == o.name
+      case o: SpawnedAdapter[?] => this.name == o.name
       case _                    => false
     }
     override def hashCode: Int = name.##
@@ -113,7 +113,7 @@ object Effect {
 
     override def productPrefix = "SpawnedAdapter"
     override def _1: String = name
-    override def canEqual(o: Any) = o.isInstanceOf[SpawnedAdapter[_]]
+    override def canEqual(o: Any) = o.isInstanceOf[SpawnedAdapter[?]]
   }
 
   /**
@@ -137,17 +137,17 @@ object Effect {
       with Serializable {
 
     override def equals(other: Any): Boolean = other match {
-      case _: SpawnedAnonymousAdapter[_] => true
+      case _: SpawnedAnonymousAdapter[?] => true
       case _                             => false
     }
     override def hashCode: Int = Nil.##
     override def toString: String = "SpawnedAnonymousAdapter"
 
     override def productPrefix: String = "SpawnedAnonymousAdapter"
-    override def productIterator: Iterator[_] = Iterator.empty
+    override def productIterator: Iterator[?] = Iterator.empty
     override def productArity: Int = 0
     override def productElement(n: Int) = throw new NoSuchElementException
-    override def canEqual(o: Any): Boolean = o.isInstanceOf[SpawnedAnonymousAdapter[_]]
+    override def canEqual(o: Any): Boolean = o.isInstanceOf[SpawnedAnonymousAdapter[?]]
   }
 
   /**

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/TestKitSettings.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/TestKitSettings.scala
@@ -29,7 +29,7 @@ object TestKitSettings {
   /**
    * Reads configuration settings from `pekko.actor.testkit.typed` section.
    */
-  def apply(system: ActorSystem[_]): TestKitSettings =
+  def apply(system: ActorSystem[?]): TestKitSettings =
     Ext(system).settings
 
   /**
@@ -42,7 +42,7 @@ object TestKitSettings {
   /**
    * Java API: Reads configuration settings from `pekko.actor.testkit.typed` section.
    */
-  def create(system: ActorSystem[_]): TestKitSettings =
+  def create(system: ActorSystem[?]): TestKitSettings =
     apply(system)
 
   /**
@@ -53,11 +53,11 @@ object TestKitSettings {
     new TestKitSettings(config)
 
   private object Ext extends ExtensionId[Ext] {
-    override def createExtension(system: ActorSystem[_]): Ext = new Ext(system)
-    def get(system: ActorSystem[_]): Ext = Ext.apply(system)
+    override def createExtension(system: ActorSystem[?]): Ext = new Ext(system)
+    def get(system: ActorSystem[?]): Ext = Ext.apply(system)
   }
 
-  private class Ext(system: ActorSystem[_]) extends Extension {
+  private class Ext(system: ActorSystem[?]) extends Extension {
     val settings: TestKitSettings = TestKitSettings(system.settings.config.getConfig("pekko.actor.testkit.typed"))
   }
 }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -127,7 +127,7 @@ import pekko.util.FutureConverters._
   override def extension[T <: Extension](ext: ExtensionId[T]): T =
     throw new UnsupportedOperationException("ActorSystemStub cannot register extensions")
 
-  override def hasExtension(ext: ExtensionId[_ <: Extension]): Boolean =
+  override def hasExtension(ext: ExtensionId[? <: Extension]): Boolean =
     throw new UnsupportedOperationException("ActorSystemStub cannot register extensions")
 
   override def log: Logger = LoggerFactory.getLogger(getClass)

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/LoggingTestKitImpl.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/LoggingTestKitImpl.scala
@@ -48,7 +48,7 @@ import pekko.testkit.TestKit
     source: Option[String],
     messageContains: Option[String],
     messageRegex: Option[Regex],
-    cause: Option[Class[_ <: Throwable]],
+    cause: Option[Class[? <: Throwable]],
     mdc: Map[String, String],
     checkExcess: Boolean,
     custom: Option[Function[LoggingEvent, Boolean]])
@@ -95,7 +95,7 @@ import pekko.testkit.TestKit
       todo > 0
   }
 
-  override def expect[T](code: => T)(implicit system: ActorSystem[_]): T = {
+  override def expect[T](code: => T)(implicit system: ActorSystem[?]): T = {
     val effectiveLoggerName = loggerName.getOrElse("")
     checkLogback(system)
     TestAppender.setupTestAppender(effectiveLoggerName)
@@ -120,14 +120,14 @@ import pekko.testkit.TestKit
     }
   }
 
-  override def expect[T](system: ActorSystem[_], code: Supplier[T]): T =
+  override def expect[T](system: ActorSystem[?], code: Supplier[T]): T =
     expect(code.get())(system)
 
   // deprecated (renamed to expect)
-  override def intercept[T](code: => T)(implicit system: ActorSystem[_]): T =
+  override def intercept[T](code: => T)(implicit system: ActorSystem[?]): T =
     expect(code)(system)
 
-  private def checkLogback(system: ActorSystem[_]): Unit = {
+  private def checkLogback(system: ActorSystem[?]): Unit = {
     if (!system.dynamicAccess.classIsOnClasspath("ch.qos.logback.classic.spi.ILoggingEvent")) {
       throw new IllegalStateException("LoggingEventFilter requires logback-classic dependency in classpath.")
     }
@@ -170,7 +170,7 @@ import pekko.testkit.TestKit
   override def withCustom(newCustom: Function[LoggingEvent, Boolean]): LoggingTestKitImpl =
     copy(custom = Option(newCustom))
 
-  override def withCause(newCause: Class[_ <: Throwable]): javadsl.LoggingTestKit =
+  override def withCause(newCause: Class[? <: Throwable]): javadsl.LoggingTestKit =
     copy(cause = Option(newCause))
 
 }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -88,7 +88,7 @@ private[pekko] final class FunctionRef[-T](override val path: ActorPath, send: (
   @InternalApi private[pekko] val selfInbox = new TestInboxImpl[T](path)
 
   override val self = selfInbox.ref
-  private var _children = TreeMap.empty[String, BehaviorTestKitImpl[_]]
+  private var _children = TreeMap.empty[String, BehaviorTestKitImpl[?]]
   private val childName = Iterator.from(0).map(Helpers.base64(_))
   private val substituteLoggerFactory = new SubstituteLoggerFactory
   private val logger: Logger = substituteLoggerFactory.getLogger("StubbedLogger")
@@ -228,7 +228,7 @@ private[pekko] final class FunctionRef[-T](override val path: ActorPath, send: (
     checkCurrentActorThread()
   }
 
-  override def setLoggerName(clazz: Class[_]): Unit = {
+  override def setLoggerName(clazz: Class[?]): Unit = {
     // nop as we don't track logger
     checkCurrentActorThread()
   }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestKitUtils.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestKitUtils.scala
@@ -79,7 +79,7 @@ private[pekko] object TestKitUtils {
   // common internal utility impls for Java and Scala
   private val TestKitRegex = """org\.apache\.pekko\.testkit\.typed\.(?:javadsl|scaladsl)\.ActorTestKit(?:\$.*)?""".r
 
-  def testNameFromCallStack(classToStartFrom: Class[_]): String =
+  def testNameFromCallStack(classToStartFrom: Class[?]): String =
     pekko.testkit.TestKitUtils.testNameFromCallStack(classToStartFrom, TestKitRegex)
 
   /**
@@ -90,7 +90,7 @@ private[pekko] object TestKitUtils {
   def scrubActorSystemName(name: String): String =
     pekko.testkit.TestKitUtils.scrubActorSystemName(name)
 
-  def shutdown(system: ActorSystem[_], timeout: Duration, throwIfShutdownTimesOut: Boolean): Unit = {
+  def shutdown(system: ActorSystem[?], timeout: Duration, throwIfShutdownTimesOut: Boolean): Unit = {
     system.terminate()
     try Await.ready(system.whenTerminated, timeout)
     catch {

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -74,7 +74,7 @@ private[pekko] object TestProbeImpl {
 }
 
 @InternalApi
-private[pekko] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
+private[pekko] final class TestProbeImpl[M](name: String, system: ActorSystem[?])
     extends JavaTestProbe[M]
     with ScalaTestProbe[M]
     with InternalRecipientRef[M] {

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -56,7 +56,7 @@ object ActorTestKit {
    * Config loaded from the provided actor if that exists, otherwise
    * using default configuration from the reference.conf resources that ship with the Akka libraries.
    */
-  def create(system: ActorSystem[_]): ActorTestKit =
+  def create(system: ActorSystem[?]): ActorTestKit =
     new ActorTestKit(scaladsl.ActorTestKit(system))
 
   /**
@@ -122,7 +122,7 @@ object ActorTestKit {
    *                             an error is printed to stdout when the system did not shutdown but
    *                             no exception is thrown.
    */
-  def shutdown(system: ActorSystem[_], duration: Duration, throwIfShutdownTimesOut: Boolean): Unit = {
+  def shutdown(system: ActorSystem[?], duration: Duration, throwIfShutdownTimesOut: Boolean): Unit = {
     TestKitUtils.shutdown(system, duration.asScala, throwIfShutdownTimesOut)
   }
 
@@ -131,7 +131,7 @@ object ActorTestKit {
    * if more time than `system-shutdown-default` passes an exception is thrown
    * (can be configured with `throw-on-shutdown-timeout`).
    */
-  def shutdown(system: ActorSystem[_], duration: Duration): Unit = {
+  def shutdown(system: ActorSystem[?], duration: Duration): Unit = {
     val settings = TestKitSettings.create(system)
     shutdown(system, duration, settings.ThrowOnShutdownTimeout)
   }
@@ -141,7 +141,7 @@ object ActorTestKit {
    * if more time than `system-shutdown-default` passes an exception is thrown
    * (can be configured with `throw-on-shutdown-timeout`).
    */
-  def shutdown(system: ActorSystem[_]): Unit = {
+  def shutdown(system: ActorSystem[?]): Unit = {
     val settings = TestKitSettings.create(system)
     shutdown(system, settings.DefaultActorSystemShutdownTimeout.asJava, settings.ThrowOnShutdownTimeout)
   }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/JUnit5TestKitBuilder.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/JUnit5TestKitBuilder.scala
@@ -25,13 +25,13 @@ import pekko.actor.typed.ActorSystem
 
 final class JUnit5TestKitBuilder() {
 
-  var system: Option[ActorSystem[_]] = None
+  var system: Option[ActorSystem[?]] = None
 
   var customConfig: Config = ApplicationTestConfig
 
   var name: String = TestKitUtils.testNameFromCallStack(classOf[JUnit5TestKitBuilder])
 
-  def withSystem(system: ActorSystem[_]): JUnit5TestKitBuilder = {
+  def withSystem(system: ActorSystem[?]): JUnit5TestKitBuilder = {
     this.system = Some(system)
     this
   }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LoggingTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LoggingTestKit.scala
@@ -78,7 +78,7 @@ import pekko.annotation.DoNotInherit
    * Matching events with an included `throwable` that is a class or subclass of the given
    * `Throwable` class.
    */
-  def withCause(newCause: Class[_ <: Throwable]): LoggingTestKit
+  def withCause(newCause: Class[? <: Throwable]): LoggingTestKit
 
   /**
    * Matching events with MDC containing all entries of the given `Map`.
@@ -109,7 +109,7 @@ import pekko.annotation.DoNotInherit
    *
    * Care is taken to remove the testkit when the block is finished or aborted.
    */
-  def expect[T](system: ActorSystem[_], code: Supplier[T]): T
+  def expect[T](system: ActorSystem[?], code: Supplier[T]): T
 
 }
 
@@ -198,7 +198,7 @@ object LoggingTestKit {
    *
    * More conditions can be added to the returned [LoggingEventFilter].
    */
-  def error(causeClass: Class[_ <: Throwable]): LoggingTestKit =
+  def error(causeClass: Class[? <: Throwable]): LoggingTestKit =
     empty.withLogLevel(Level.ERROR).withCause(causeClass)
 
   /**

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/ManualTime.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/ManualTime.scala
@@ -73,7 +73,7 @@ final class ManualTime(delegate: pekko.testkit.ExplicitlyTriggeredScheduler) {
   def timePasses(amount: Duration): Unit = delegate.timePasses(amount.asScala)
 
   @varargs
-  def expectNoMessageFor(duration: Duration, on: TestProbe[_]*): Unit = {
+  def expectNoMessageFor(duration: Duration, on: TestProbe[?]*): Unit = {
     delegate.timePasses(duration.asScala)
     on.foreach(_.expectNoMessage(Duration.ZERO))
   }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/SerializationTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/SerializationTestKit.scala
@@ -20,7 +20,7 @@ import pekko.actor.typed.ActorSystem
 /**
  * Utilities to test serialization.
  */
-class SerializationTestKit(system: ActorSystem[_]) {
+class SerializationTestKit(system: ActorSystem[?]) {
 
   private val delegate = new scaladsl.SerializationTestKit(system)
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunitResource.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJunitResource.scala
@@ -71,7 +71,7 @@ final class TestKitJunitResource(_kit: ActorTestKit) extends ExternalResource {
   /**
    * Use a custom [[pekko.actor.typed.ActorSystem]] for the actor system.
    */
-  def this(system: ActorSystem[_]) = this(ActorTestKit.create(system))
+  def this(system: ActorSystem[?]) = this(ActorTestKit.create(system))
 
   /**
    * Use a custom config for the actor system.

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestProbe.scala
@@ -54,16 +54,16 @@ object FishingOutcomes {
 
 object TestProbe {
 
-  def create[M](system: ActorSystem[_]): TestProbe[M] =
+  def create[M](system: ActorSystem[?]): TestProbe[M] =
     create(name = "testProbe", system)
 
-  def create[M](@unused clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
+  def create[M](@unused clazz: Class[M], system: ActorSystem[?]): TestProbe[M] =
     create(system)
 
-  def create[M](name: String, system: ActorSystem[_]): TestProbe[M] =
+  def create[M](name: String, system: ActorSystem[?]): TestProbe[M] =
     new TestProbeImpl[M](name, system)
 
-  def create[M](name: String, @unused clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
+  def create[M](name: String, @unused clazz: Class[M], system: ActorSystem[?]): TestProbe[M] =
     new TestProbeImpl[M](name, system)
 }
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -74,7 +74,7 @@ object ActorTestKit {
    * Config loaded from the provided actor if that exists, otherwise
    * using default configuration from the reference.conf resources that ship with the Akka libraries.
    */
-  def apply(system: ActorSystem[_]): ActorTestKit = {
+  def apply(system: ActorSystem[?]): ActorTestKit = {
     val name = testKitGuardianCounter.incrementAndGet() match {
       case 1 => "test"
       case n => s"test-$n"
@@ -159,7 +159,7 @@ object ActorTestKit {
    * Shutdown the given [[pekko.actor.typed.ActorSystem]] and block until it shuts down,
    * if more time than `TestKitSettings.DefaultActorSystemShutdownTimeout` passes an exception is thrown
    */
-  def shutdown(system: ActorSystem[_]): Unit = {
+  def shutdown(system: ActorSystem[?]): Unit = {
     val settings = TestKitSettings(system)
     TestKitUtils.shutdown(system, settings.DefaultActorSystemShutdownTimeout, settings.ThrowOnShutdownTimeout)
   }
@@ -168,7 +168,7 @@ object ActorTestKit {
    * Shutdown the given [[pekko.actor.typed.ActorSystem]] and block until it shuts down
    * or the `duration` hits. If the timeout hits `verifySystemShutdown` decides
    */
-  def shutdown(system: ActorSystem[_], timeout: Duration, throwIfShutdownFails: Boolean = false): Unit =
+  def shutdown(system: ActorSystem[?], timeout: Duration, throwIfShutdownFails: Boolean = false): Unit =
     TestKitUtils.shutdown(system, timeout, throwIfShutdownFails)
 
   /**
@@ -192,7 +192,7 @@ object ActorTestKit {
  * For synchronous testing of a `Behavior` see [[BehaviorTestKit]]
  */
 final class ActorTestKit private[pekko] (
-    val internalSystem: ActorSystem[_],
+    val internalSystem: ActorSystem[?],
     internalTestKitGuardian: ActorRef[ActorTestKitGuardian.TestKitCommand],
     settings: Option[TestKitSettings]) {
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LoggingTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LoggingTestKit.scala
@@ -108,7 +108,7 @@ import pekko.annotation.DoNotInherit
    *
    * Care is taken to remove the testkit when the block is finished or aborted.
    */
-  def expect[T](code: => T)(implicit system: ActorSystem[_]): T
+  def expect[T](code: => T)(implicit system: ActorSystem[?]): T
 
   /**
    * Run the given code block and assert that the criteria of this `LoggingTestKit` has
@@ -118,7 +118,7 @@ import pekko.annotation.DoNotInherit
    * Care is taken to remove the testkit when the block is finished or aborted.
    */
   @deprecated("Use expect instead.", "Akka 2.6.0")
-  def intercept[T](code: => T)(implicit system: ActorSystem[_]): T
+  def intercept[T](code: => T)(implicit system: ActorSystem[?]): T
 
 }
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ManualTime.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ManualTime.scala
@@ -41,7 +41,7 @@ object ManualTime {
    * Access the manual scheduler, note that you need to setup the actor system/testkit with [[ManualTime.config]]
    * for this to work.
    */
-  def apply()(implicit system: ActorSystem[_]): ManualTime =
+  def apply()(implicit system: ActorSystem[?]): ManualTime =
     system.scheduler match {
       case adapter: SchedulerAdapter =>
         adapter.classicScheduler match {
@@ -73,7 +73,7 @@ final class ManualTime(delegate: pekko.testkit.ExplicitlyTriggeredScheduler) {
   def timePasses(amount: FiniteDuration): Unit = delegate.timePasses(amount)
 
   @varargs
-  def expectNoMessageFor(duration: FiniteDuration, on: TestProbe[_]*): Unit = {
+  def expectNoMessageFor(duration: FiniteDuration, on: TestProbe[?]*): Unit = {
     delegate.timePasses(duration)
     on.foreach(_.expectNoMessage(Duration.Zero))
   }

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
@@ -52,7 +52,7 @@ abstract class ScalaTestWithActorTestKit(override val testKit: ActorTestKit)
   /**
    * Use a custom [[pekko.actor.typed.ActorSystem]] for the actor system.
    */
-  def this(system: ActorSystem[_]) = this(ActorTestKit(system))
+  def this(system: ActorSystem[?]) = this(ActorTestKit(system))
 
   /**
    * Use a custom config for the actor system.

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/SerializationTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/SerializationTestKit.scala
@@ -22,7 +22,7 @@ import pekko.serialization.Serializers
 /**
  * Utilities to test serialization.
  */
-class SerializationTestKit(system: ActorSystem[_]) {
+class SerializationTestKit(system: ActorSystem[?]) {
 
   private val serialization = SerializationExtension(system.toClassic)
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestProbe.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestProbe.scala
@@ -52,10 +52,10 @@ object FishingOutcomes {
 }
 
 object TestProbe {
-  def apply[M]()(implicit system: ActorSystem[_]): TestProbe[M] =
+  def apply[M]()(implicit system: ActorSystem[?]): TestProbe[M] =
     apply(name = "testProbe")
 
-  def apply[M](name: String)(implicit system: ActorSystem[_]): TestProbe[M] =
+  def apply[M](name: String)(implicit system: ActorSystem[?]): TestProbe[M] =
     new TestProbeImpl[M](name, system)
 
 }

--- a/actor-testkit-typed/src/test/scala/docs/org/apache/pekko/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
+++ b/actor-testkit-typed/src/test/scala/docs/org/apache/pekko/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
@@ -162,10 +162,10 @@ class SyncTestingExampleSpec extends AnyWordSpec with Matchers {
 
       testKit.run(ConfigAware.SpawnChild(inbox.ref.narrow))
       val childTestKit = inbox.receiveMessage() match {
-        case ar: ActorRef[_] =>
+        case ar: ActorRef[?] =>
           testKit.childTestKit(ar.unsafeUpcast[Any].narrow[ConfigAware.Command])
         case unexpected =>
-          unexpected should be(a[ActorRef[_]])
+          unexpected should be(a[ActorRef[?]])
           ???
       }
 

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -55,7 +55,7 @@ class ActorTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wi
     }
 
     "use name from given class name with replaced package name" in {
-      val testkit2 = ActorTestKit(classOf[Vector[_]].getName)
+      val testkit2 = ActorTestKit(classOf[Vector[?]].getName)
       try {
         // removing package name and such
         testkit2.system.name should ===("Vector")
@@ -170,7 +170,7 @@ class MyConcreteDerivateSpec extends MyBaseSpec {
     }
 
     "use name from given class name" in {
-      val testkit2 = ActorTestKit(classOf[Vector[_]].getName)
+      val testkit2 = ActorTestKit(classOf[Vector[?]].getName)
       try {
         testkit2.system.name should ===("Vector")
       } finally testkit2.shutdownTestKit()

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
@@ -186,7 +186,7 @@ class BehaviorTestKitSpec extends AnyWordSpec with Matchers with LogCapturing {
     "allow assertions on effect type" in {
       val testkit = BehaviorTestKit[Parent.Command](Parent.init)
       testkit.run(SpawnAnonymous(1))
-      val spawnAnonymous = testkit.expectEffectType[Effect.SpawnedAnonymous[_]]
+      val spawnAnonymous = testkit.expectEffectType[Effect.SpawnedAnonymous[?]]
       spawnAnonymous.props should ===(Props.empty)
     }
 
@@ -378,7 +378,7 @@ class BehaviorTestKitSpec extends AnyWordSpec with Matchers with LogCapturing {
 
       val sessionRef = i.receiveMessage()
       i.hasMessages shouldBe false
-      val s = testkit.expectEffectType[SpawnedAnonymous[_]]
+      val s = testkit.expectEffectType[SpawnedAnonymous[?]]
       // must be able to get the created ref, even without explicit reply
       s.ref shouldBe sessionRef
 
@@ -402,7 +402,7 @@ class BehaviorTestKitSpec extends AnyWordSpec with Matchers with LogCapturing {
       testkit.expectEffect(Stopped(child.childName))
 
       testkit.run(SpawnChild)
-      val newChild = testkit.expectEffectType[Spawned[_]]
+      val newChild = testkit.expectEffectType[Spawned[?]]
       child.childName shouldBe newChild.childName
     }
   }

--- a/actor-tests/src/test/scala/org/apache/pekko/PekkoExceptionSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/PekkoExceptionSpec.scala
@@ -36,7 +36,7 @@ class PekkoExceptionSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  def verify(clazz: java.lang.Class[_]): Unit = {
+  def verify(clazz: java.lang.Class[?]): Unit = {
     clazz.getConstructor(Array(classOf[String]): _*)
   }
 }

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ActorMailboxSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ActorMailboxSpec.scala
@@ -241,7 +241,7 @@ class ActorMailboxSpec(conf: Config) extends PekkoSpec(conf) with DefaultTimeout
 
   def this() = this(ActorMailboxSpec.mailboxConf)
 
-  def checkMailboxQueue(props: Props, name: String, types: Seq[Class[_]]): MessageQueue = {
+  def checkMailboxQueue(props: Props, name: String, types: Seq[Class[?]]): MessageQueue = {
     val actor = system.actorOf(props, name)
 
     actor ! "ping"

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/DynamicAccessSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/DynamicAccessSpec.scala
@@ -82,7 +82,7 @@ class DynamicAccessSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll
         case Failure(_: NoSuchMethodException) =>
           dynamicAccess
             .createInstanceFor[TestSuperclass](fqcn, immutable.Seq((classOf[String], "string ctor argument")))
-        case f: Failure[_] => f
+        case f: Failure[?] => f
       }
 
   }

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ExtensionSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ExtensionSpec.scala
@@ -45,7 +45,7 @@ object InstanceCountingExtension extends ExtensionId[InstanceCountingExtension] 
   override def createExtension(system: ExtendedActorSystem): InstanceCountingExtension = {
     new InstanceCountingExtension
   }
-  override def lookup: ExtensionId[_ <: Extension] = this
+  override def lookup: ExtensionId[? <: Extension] = this
 }
 
 class InstanceCountingExtension extends Extension {

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/SupervisorHierarchySpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/SupervisorHierarchySpec.scala
@@ -928,8 +928,8 @@ class SupervisorHierarchySpec extends PekkoSpec(SupervisorHierarchySpec.config) 
 
       fsm ! FSM.SubscribeTransitionCallBack(system.actorOf(Props(new Actor {
         def receive = {
-          case s: FSM.CurrentState[_] => log.info("{}", s)
-          case t: FSM.Transition[_]   => log.info("{}", t)
+          case s: FSM.CurrentState[?] => log.info("{}", s)
+          case t: FSM.Transition[?]   => log.info("{}", t)
         }
       })))
 

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/TypedActorSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/TypedActorSpec.scala
@@ -411,7 +411,7 @@ class TypedActorSpec
             case e: IllegalStateException if e.getMessage == "expected" => SupervisorStrategy.Resume
           }
           def receive = {
-            case p: TypedProps[_] => context.sender() ! pekko.actor.TypedActor(context).typedActorOf(p)
+            case p: TypedProps[?] => context.sender() ! pekko.actor.TypedActor(context).typedActorOf(p)
           }
         }))
         val t = Await.result(
@@ -512,7 +512,7 @@ class TypedActorSpec
         val m = pekko.actor.TypedActor.MethodCall(
           classOf[Foo].getDeclaredMethod(
             "testMethodCallSerialization",
-            Array[Class[_]](classOf[Foo], classOf[String], classOf[Int], classOf[WithStringSerializedClass]): _*),
+            Array[Class[?]](classOf[Foo], classOf[String], classOf[Int], classOf[WithStringSerializedClass]): _*),
           Array[AnyRef](someFoo, null, 1.asInstanceOf[AnyRef], WithStringSerializedClass()))
         val baos = new ByteArrayOutputStream(8192 * 4)
         val out = new ObjectOutputStream(baos)

--- a/actor-tests/src/test/scala/org/apache/pekko/dispatch/MailboxConfigSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/dispatch/MailboxConfigSpec.scala
@@ -128,7 +128,7 @@ abstract class MailboxSpec extends PekkoSpec with BeforeAndAfterAll with BeforeA
   def ensureInitialMailboxState(config: MailboxType, q: MessageQueue): Unit = {
     q should not be null
     q match {
-      case aQueue: BlockingQueue[_] =>
+      case aQueue: BlockingQueue[?] =>
         config match {
           case BoundedMailbox(capacity, _) => aQueue.remainingCapacity should ===(capacity)
           case UnboundedMailbox()          => aQueue.remainingCapacity should ===(Int.MaxValue)

--- a/actor-tests/src/test/scala/org/apache/pekko/pattern/StatusReplySpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/pattern/StatusReplySpec.scala
@@ -44,7 +44,7 @@ class StatusReplySpec extends PekkoSpec with ScalaFutures {
       }
     }
     "not throw exception if null" in {
-      (null: StatusReply[_]) match {
+      (null: StatusReply[?]) match {
         case StatusReply.Success(_) => fail()
         case StatusReply.Error(_)   => fail()
         case _                      =>

--- a/actor-tests/src/test/scala/org/apache/pekko/serialization/SerializationSetupSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/serialization/SerializationSetupSpec.scala
@@ -46,7 +46,7 @@ final class FakeSerializer extends Serializer {
     Array(id.toByte)
   }
 
-  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]) = {
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]) = {
     require(bytes.length == 1)
     val id = bytes(0).toInt
     registry.get(id)

--- a/actor-tests/src/test/scala/org/apache/pekko/serialization/SerializeSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/serialization/SerializeSpec.scala
@@ -365,7 +365,7 @@ class VerifySerializabilitySpec extends PekkoSpec(SerializationTests.verifySeria
 class ReferenceSerializationSpec extends PekkoSpec(SerializationTests.mostlyReferenceSystem) {
 
   val ser = SerializationExtension(system)
-  def serializerMustBe(toSerialize: Class[_], expectedSerializer: Class[_]) =
+  def serializerMustBe(toSerialize: Class[?], expectedSerializer: Class[?]) =
     ser.serializerFor(toSerialize).getClass should ===(expectedSerializer)
 
   "Serialization settings from reference.conf" must {
@@ -403,7 +403,7 @@ class ReferenceSerializationSpec extends PekkoSpec(SerializationTests.mostlyRefe
 class AllowJavaSerializationSpec extends PekkoSpec(SerializationTests.allowJavaSerializationSystem) {
 
   val ser = SerializationExtension(system)
-  def serializerMustBe(toSerialize: Class[_], expectedSerializer: Class[_]) =
+  def serializerMustBe(toSerialize: Class[?], expectedSerializer: Class[?]) =
     ser.serializerFor(toSerialize).getClass should ===(expectedSerializer)
 
   val address = SerializationTests.Address("120", "Monroe Street", "Santa Clara", "95050")
@@ -596,7 +596,7 @@ protected[pekko] class NoopSerializer extends Serializer {
     Array.empty[Byte]
   }
 
-  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = null
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = null
 }
 
 protected[pekko] class NoopSerializer2 extends Serializer {
@@ -608,7 +608,7 @@ protected[pekko] class NoopSerializer2 extends Serializer {
     Array.empty[Byte]
   }
 
-  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = null
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = null
 }
 
 protected[pekko] class NoopSerializerSameId extends NoopSerializer
@@ -629,5 +629,5 @@ class DeadlockSerializer(system: ExtendedActorSystem) extends Serializer {
 
   def toBinary(o: AnyRef): Array[Byte] = Array.empty[Byte]
 
-  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = null
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = null
 }

--- a/actor-tests/src/test/scala/org/apache/pekko/util/BoundedBlockingQueueSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/BoundedBlockingQueueSpec.scala
@@ -740,7 +740,7 @@ trait BlockingHelpers {
   /**
    * Check that a Future does not complete within a set timespan.
    */
-  def mustBlockFor(timeout: Span, action: Future[_])(implicit pos: Position): Unit =
+  def mustBlockFor(timeout: Span, action: Future[?])(implicit pos: Position): Unit =
     Exception.ignoring(classOf[TimeoutException]) {
       Await.ready(action, timeout)
       fail("Expected action to block for at least " + timeout.prettyString + " but it completed.")

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringInitializationSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringInitializationSpec.scala
@@ -29,7 +29,7 @@ class ByteStringInitializationSpec extends AnyWordSpec with Matchers {
       val cleanCl = new ClassLoader(null) {
         val outerCl = ByteStringInitializationSpec.this.getClass.getClassLoader
         val buffer = new Array[Byte](1000000)
-        override def loadClass(name: String): Class[_] =
+        override def loadClass(name: String): Class[?] =
           if (!name.startsWith("org.apache.pekko")) outerCl.loadClass(name)
           else {
             val classFile = name.replace(".", "/") + ".class"

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -196,7 +196,7 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
     (!strict || (bsAIt.toSeq -> bsBIt.toSeq) == (vecAIt.toSeq -> vecBIt.toSeq))
   }
 
-  def likeVecBld(body: Builder[Byte, _] => Unit): Boolean = {
+  def likeVecBld(body: Builder[Byte, ?] => Unit): Boolean = {
     val bsBuilder = ByteString.newBuilder
     val vecBuilder = Vector.newBuilder[Byte]
 

--- a/actor-tests/src/test/scala/org/apache/pekko/util/WildcardIndexSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/WildcardIndexSpec.scala
@@ -20,9 +20,9 @@ class WildcardIndexSpec extends AnyWordSpec with Matchers {
 
   "wildcard index" must {
     "allow to insert elements using Arrays of strings" in {
-      emptyIndex.insert(Array("a", "b"), 1) shouldBe a[WildcardIndex[_]]
-      emptyIndex.insert(Array("a"), 1) shouldBe a[WildcardIndex[_]]
-      emptyIndex.insert(Array.empty[String], 1) shouldBe a[WildcardIndex[_]]
+      emptyIndex.insert(Array("a", "b"), 1) shouldBe a[WildcardIndex[?]]
+      emptyIndex.insert(Array("a"), 1) shouldBe a[WildcardIndex[?]]
+      emptyIndex.insert(Array.empty[String], 1) shouldBe a[WildcardIndex[?]]
     }
 
     "allow to find inserted elements" in {

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/InteractionPatternsSpec.scala
@@ -498,7 +498,7 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with AnyWordSpec
     // the ask is failed with a TimeoutException
     implicit val timeout: Timeout = 3.seconds
     // implicit ActorSystem in scope
-    implicit val system: ActorSystem[_] = theSystem
+    implicit val system: ActorSystem[?] = theSystem
 
     val result: Future[CookieFabric.Reply] = cookieFabric.ask(ref => CookieFabric.GiveMeCookies(3, ref))
 
@@ -563,7 +563,7 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with AnyWordSpec
     // the ask is failed with a TimeoutException
     implicit val timeout: Timeout = 3.seconds
     // implicit ActorSystem in scope
-    implicit val system: ActorSystem[_] = theSystem
+    implicit val system: ActorSystem[?] = theSystem
 
     val result: Future[CookieFabric.Cookies] = cookieFabric.askWithStatus(ref => CookieFabric.GiveMeCookies(3, ref))
 

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/LoggingDocExamples.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/LoggingDocExamples.scala
@@ -104,7 +104,7 @@ object LoggingDocExamples {
   }
 
   def withMdc(): Unit = {
-    val system: ActorSystem[_] = ???
+    val system: ActorSystem[?] = ???
 
     // #withMdc
     val staticMdc = Map("startTime" -> system.startTime.toString)
@@ -118,7 +118,7 @@ object LoggingDocExamples {
   }
 
   def logging(): Unit = {
-    implicit val system: ActorSystem[_] = ???
+    implicit val system: ActorSystem[?] = ???
     final case class Message(s: String)
     val ref: ActorRef[Message] = ???
 

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/StyleGuideDocExamples.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/StyleGuideDocExamples.scala
@@ -311,7 +311,7 @@ object StyleGuideDocExamples {
     // #behavior-factory-method
 
     object Usage {
-      val context: ActorContext[_] = ???
+      val context: ActorContext[?] = ???
       val doneRef: ActorRef[Done] = ???
 
       // #behavior-factory-method-spawn

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/extensions/ExtensionDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/extensions/ExtensionDocSpec.scala
@@ -33,16 +33,16 @@ class ExpensiveDatabaseConnection {
 //#extension-id
 object DatabasePool extends ExtensionId[DatabasePool] {
   // will only be called once
-  def createExtension(system: ActorSystem[_]): DatabasePool = new DatabasePool(system)
+  def createExtension(system: ActorSystem[?]): DatabasePool = new DatabasePool(system)
 
   // Java API
-  def get(system: ActorSystem[_]): DatabasePool = apply(system)
+  def get(system: ActorSystem[?]): DatabasePool = apply(system)
 }
 //#extension-id
 
 @nowarn
 //#extension
-class DatabasePool(system: ActorSystem[_]) extends Extension {
+class DatabasePool(system: ActorSystem[?]) extends Extension {
   // database configuration can be loaded from config
   // from the actor system
   private val _connection = new ExpensiveDatabaseConnection()

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/AskSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/AskSpec.scala
@@ -107,7 +107,7 @@ class AskSpec extends ScalaTestWithActorTestKit("""
 
     "fail the future if the actor doesn't exist" in {
       val noSuchActor: ActorRef[Msg] = system match {
-        case adaptedSys: ActorSystemAdapter[_] =>
+        case adaptedSys: ActorSystemAdapter[?] =>
           import pekko.actor.typed.scaladsl.adapter._
           adaptedSys.system.provider.resolveActorRef("/foo/bar")
         case _ =>

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/ExtensionsSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/ExtensionsSpec.scala
@@ -31,17 +31,17 @@ import pekko.actor.typed.scaladsl.Behaviors
 
 class DummyExtension1 extends Extension
 object DummyExtension1 extends ExtensionId[DummyExtension1] {
-  def createExtension(system: ActorSystem[_]) = new DummyExtension1
-  def get(system: ActorSystem[_]): DummyExtension1 = apply(system)
+  def createExtension(system: ActorSystem[?]) = new DummyExtension1
+  def get(system: ActorSystem[?]): DummyExtension1 = apply(system)
 }
-class DummyExtension1Setup(factory: ActorSystem[_] => DummyExtension1)
+class DummyExtension1Setup(factory: ActorSystem[?] => DummyExtension1)
     extends AbstractExtensionSetup[DummyExtension1](DummyExtension1, factory)
 
 class DummyExtension1ViaSetup extends DummyExtension1
 
 class SlowExtension extends Extension
 object SlowExtension extends ExtensionId[SlowExtension] {
-  def createExtension(system: ActorSystem[_]) = {
+  def createExtension(system: ActorSystem[?]) = {
     Thread.sleep(25)
     new SlowExtension
   }
@@ -49,29 +49,29 @@ object SlowExtension extends ExtensionId[SlowExtension] {
 
 class FailingToLoadExtension extends Extension
 object FailingToLoadExtension extends ExtensionId[FailingToLoadExtension] {
-  def createExtension(system: ActorSystem[_]) = {
+  def createExtension(system: ActorSystem[?]) = {
     throw new RuntimeException("I cannot be trusted!")
   }
 }
 
 class MultiExtension(val n: Int) extends Extension
 class MultiExtensionId(n: Int) extends ExtensionId[MultiExtension] {
-  def createExtension(system: ActorSystem[_]): MultiExtension = new MultiExtension(n)
+  def createExtension(system: ActorSystem[?]): MultiExtension = new MultiExtension(n)
 }
 
 object InstanceCountingExtension extends ExtensionId[DummyExtension1] {
   val createCount = new AtomicInteger(0)
-  override def createExtension(system: ActorSystem[_]): DummyExtension1 = {
+  override def createExtension(system: ActorSystem[?]): DummyExtension1 = {
     createCount.addAndGet(1)
     new DummyExtension1
   }
 }
 
 object AccessSystemFromConstructorExtensionId extends ExtensionId[AccessSystemFromConstructor] {
-  override def createExtension(system: ActorSystem[_]): AccessSystemFromConstructor =
+  override def createExtension(system: ActorSystem[?]): AccessSystemFromConstructor =
     new AccessSystemFromConstructor(system)
 }
-class AccessSystemFromConstructor(system: ActorSystem[_]) extends Extension {
+class AccessSystemFromConstructor(system: ActorSystem[?]) extends Extension {
   system.log.info("I log from the constructor")
   system.receptionist ! Receptionist.Find(ServiceKey[String]("i-just-made-it-up"), system.deadLetters) // or touch the receptionist!
 }
@@ -266,7 +266,7 @@ class ExtensionsSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with
   }
 
   def withEmptyActorSystem[T](name: String, config: Option[Config] = None, setup: Option[ActorSystemSetup] = None)(
-      f: ActorSystem[_] => T): T = {
+      f: ActorSystem[?] => T): T = {
 
     val bootstrap = config match {
       case Some(c) => BootstrapSetup(c)

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/LocalActorRefProviderLogMessagesSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/LocalActorRefProviderLogMessagesSpec.scala
@@ -38,7 +38,7 @@ class LocalActorRefProviderLogMessagesSpec
   "An LocalActorRefProvider" must {
 
     "logs on dedicated 'serialization' logger of unknown path" in {
-      val provider = system.asInstanceOf[ActorSystemAdapter[_]].provider
+      val provider = system.asInstanceOf[ActorSystemAdapter[?]].provider
 
       LoggingTestKit
         .debug("of unknown (invalid) path [dummy/path]")
@@ -49,7 +49,7 @@ class LocalActorRefProviderLogMessagesSpec
     }
 
     "logs on dedicated 'serialization' logger when path doesn't match existing actor" in {
-      val provider = system.asInstanceOf[ActorSystemAdapter[_]].provider
+      val provider = system.asInstanceOf[ActorSystemAdapter[?]].provider
       val invalidPath = provider.rootPath / "user" / "invalid"
 
       LoggingTestKit
@@ -62,10 +62,10 @@ class LocalActorRefProviderLogMessagesSpec
 
     "logs on dedicated 'serialization' logger when of foreign path" in {
 
-      val otherSystem = ActorTestKit("otherSystem").system.asInstanceOf[ActorSystemAdapter[_]]
+      val otherSystem = ActorTestKit("otherSystem").system.asInstanceOf[ActorSystemAdapter[?]]
       val invalidPath = otherSystem.provider.rootPath / "user" / "foo"
 
-      val provider = system.asInstanceOf[ActorSystemAdapter[_]].provider
+      val provider = system.asInstanceOf[ActorSystemAdapter[?]].provider
       try {
         LoggingTestKit
           .debug("Resolve (deserialization) of foreign path [pekko://otherSystem/user/foo]")

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/MailboxSelectorSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/MailboxSelectorSpec.scala
@@ -44,7 +44,7 @@ class MailboxSelectorSpec extends ScalaTestWithActorTestKit("""
       Behaviors.receiveMessage[WhatsYourMailbox] {
         case WhatsYourMailbox(replyTo) =>
           val mailbox = context match {
-            case adapter: ActorContextAdapter[_] =>
+            case adapter: ActorContextAdapter[?] =>
               adapter.classicContext match {
                 case cell: ActorCell =>
                   cell.mailbox.messageQueue

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/SupervisionSpec.scala
@@ -49,8 +49,8 @@ object SupervisionSpec {
   case object IncrementState extends Command
   case object GetState extends Command
   final case class CreateChild[T](behavior: Behavior[T], name: String) extends Command
-  final case class Watch(ref: ActorRef[_]) extends Command
-  final case class WatchWith(ref: ActorRef[_], cmd: Command) extends Command
+  final case class Watch(ref: ActorRef[?]) extends Command
+  final case class WatchWith(ref: ActorRef[?], cmd: Command) extends Command
 
   sealed trait Event
   final case class Pong(n: Int) extends Event
@@ -1408,7 +1408,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
 
       LoggingTestKit.error[DeathPactException].expect {
         actor ! "boom"
-        val child = probe.expectMessageType[ActorRef[_]]
+        val child = probe.expectMessageType[ActorRef[?]]
         probe.expectTerminated(child, 3.seconds)
       }
       actor ! "ping"

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/delivery/DurableProducerControllerSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/delivery/DurableProducerControllerSpec.scala
@@ -97,7 +97,7 @@ class DurableProducerControllerSpec
       val durable = TestDurableProducerQueue[TestConsumer.Job](
         Duration.Zero,
         stateHolder,
-        (_: DurableProducerQueue.Command[_]) => false)
+        (_: DurableProducerQueue.Command[?]) => false)
 
       val producerController =
         spawn(ProducerController[TestConsumer.Job](producerId, Some(durable)), s"producerController-$idCount")
@@ -182,7 +182,7 @@ class DurableProducerControllerSpec
         TestDurableProducerQueue[TestConsumer.Job](
           Duration.Zero,
           stateHolder,
-          (_: DurableProducerQueue.Command[_]) => false)
+          (_: DurableProducerQueue.Command[?]) => false)
 
       val producerController =
         spawn(

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/delivery/DurableWorkPullingSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/delivery/DurableWorkPullingSpec.scala
@@ -167,7 +167,7 @@ class DurableWorkPullingSpec
       val durable = TestDurableProducerQueue[TestConsumer.Job](
         Duration.Zero,
         stateHolder,
-        (_: DurableProducerQueue.Command[_]) => false)
+        (_: DurableProducerQueue.Command[?]) => false)
 
       val workPullingController =
         spawn(
@@ -289,7 +289,7 @@ class DurableWorkPullingSpec
       val durable = TestDurableProducerQueue[TestConsumer.Job](
         Duration.Zero,
         stateHolder,
-        (_: DurableProducerQueue.Command[_]) => false)
+        (_: DurableProducerQueue.Command[?]) => false)
 
       val workPullingController =
         spawn(

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/delivery/ReliableDeliveryRandomSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/delivery/ReliableDeliveryRandomSpec.scala
@@ -105,7 +105,7 @@ class ReliableDeliveryRandomSpec(config: Config)
 
     // RandomFlakyNetwork to simulate lost messages from producerController to consumerController
     val consumerDrop: Any => Double = {
-      case _: ConsumerController.SequencedMessage[_] => consumerDropProbability
+      case _: ConsumerController.SequencedMessage[?] => consumerDropProbability
       case _                                         => 0.0
     }
 
@@ -123,7 +123,7 @@ class ReliableDeliveryRandomSpec(config: Config)
     val producerDrop: Any => Double = {
       case _: ProducerControllerImpl.Request         => producerDropProbability
       case _: ProducerControllerImpl.Resend          => producerDropProbability
-      case _: ProducerController.RegisterConsumer[_] => producerDropProbability
+      case _: ProducerController.RegisterConsumer[?] => producerDropProbability
       case _                                         => 0.0
     }
 

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/internal/ActorSystemSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/internal/ActorSystemSpec.scala
@@ -192,7 +192,7 @@ class ActorSystemSpec
         Behaviors.receive[WhatsYourMailbox] {
           case (context, WhatsYourMailbox(replyTo)) =>
             replyTo ! context
-              .asInstanceOf[ActorContextImpl[_]]
+              .asInstanceOf[ActorContextImpl[?]]
               .classicActorContext
               .asInstanceOf[Dispatch]
               .mailbox

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
@@ -208,7 +208,7 @@ class LocalReceptionistSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
 class LocalReceptionistBehaviorSpec extends AnyWordSpec with Matchers with LogCapturing {
   import LocalReceptionistSpec._
 
-  def assertEmpty(inboxes: TestInbox[_]*): Unit = {
+  def assertEmpty(inboxes: TestInbox[?]*): Unit = {
     inboxes.foreach(i => withClue(s"inbox $i had messages")(i.hasMessages should be(false)))
   }
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/ActorRef.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/ActorRef.scala
@@ -32,7 +32,7 @@ import pekko.annotation.DoNotInherit
  * Not for user extension
  */
 @DoNotInherit
-trait ActorRef[-T] extends RecipientRef[T] with java.lang.Comparable[ActorRef[_]] with java.io.Serializable {
+trait ActorRef[-T] extends RecipientRef[T] with java.lang.Comparable[ActorRef[?]] with java.io.Serializable {
   this: InternalRecipientRef[T] =>
 
   /**

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/ActorRefResolver.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/ActorRefResolver.scala
@@ -18,9 +18,9 @@ import pekko.actor.{ ActorRefWithCell, ExtendedActorSystem }
 import pekko.annotation.{ DoNotInherit, InternalApi }
 
 object ActorRefResolver extends ExtensionId[ActorRefResolver] {
-  def get(system: ActorSystem[_]): ActorRefResolver = apply(system)
+  def get(system: ActorSystem[?]): ActorRefResolver = apply(system)
 
-  override def createExtension(system: ActorSystem[_]): ActorRefResolver =
+  override def createExtension(system: ActorSystem[?]): ActorRefResolver =
     new ActorRefResolverImpl(system)
 }
 
@@ -53,7 +53,7 @@ abstract class ActorRefResolver extends Extension {
 /**
  * INTERNAL API
  */
-@InternalApi private[pekko] class ActorRefResolverImpl(system: ActorSystem[_]) extends ActorRefResolver {
+@InternalApi private[pekko] class ActorRefResolverImpl(system: ActorSystem[?]) extends ActorRefResolver {
   import pekko.actor.typed.scaladsl.adapter._
 
   private val classicSystem = system.toClassic.asInstanceOf[ExtendedActorSystem]
@@ -93,7 +93,7 @@ abstract class ActorRefResolver extends Extension {
 }
 
 object ActorRefResolverSetup {
-  def apply[T <: Extension](createExtension: ActorSystem[_] => ActorRefResolver): ActorRefResolverSetup =
+  def apply[T <: Extension](createExtension: ActorSystem[?] => ActorRefResolver): ActorRefResolverSetup =
     new ActorRefResolverSetup(sys => createExtension(sys))
 
 }
@@ -103,5 +103,5 @@ object ActorRefResolverSetup {
  * to replace the default implementation of the [[ActorRefResolver]] extension. Intended
  * for tests that need to replace extension with stub/mock implementations.
  */
-final class ActorRefResolverSetup(createExtension: java.util.function.Function[ActorSystem[_], ActorRefResolver])
+final class ActorRefResolverSetup(createExtension: java.util.function.Function[ActorSystem[?], ActorRefResolver])
     extends ExtensionSetup[ActorRefResolver](ActorRefResolver, createExtension)

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/BehaviorInterceptor.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/BehaviorInterceptor.scala
@@ -102,7 +102,7 @@ object BehaviorInterceptor {
    */
   @DoNotInherit
   trait PreStartTarget[T] {
-    def start(ctx: TypedActorContext[_]): Behavior[T]
+    def start(ctx: TypedActorContext[?]): Behavior[T]
   }
 
   /**
@@ -112,7 +112,7 @@ object BehaviorInterceptor {
    */
   @DoNotInherit
   trait ReceiveTarget[T] {
-    def apply(ctx: TypedActorContext[_], msg: T): Behavior[T]
+    def apply(ctx: TypedActorContext[?], msg: T): Behavior[T]
 
     /**
      * INTERNAL API
@@ -123,7 +123,7 @@ object BehaviorInterceptor {
      * is taking place.
      */
     @InternalApi
-    private[pekko] def signalRestart(ctx: TypedActorContext[_]): Unit
+    private[pekko] def signalRestart(ctx: TypedActorContext[?]): Unit
   }
 
   /**
@@ -133,7 +133,7 @@ object BehaviorInterceptor {
    */
   @DoNotInherit
   trait SignalTarget[T] {
-    def apply(ctx: TypedActorContext[_], signal: Signal): Behavior[T]
+    def apply(ctx: TypedActorContext[?], signal: Signal): Behavior[T]
   }
 
 }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/Extensions.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/Extensions.scala
@@ -120,12 +120,12 @@ abstract class ExtensionId[T <: Extension] {
   /**
    * Create the extension, will be invoked at most one time per actor system where the extension is registered.
    */
-  def createExtension(system: ActorSystem[_]): T
+  def createExtension(system: ActorSystem[?]): T
 
   /**
    * Lookup or create an instance of the extension identified by this id.
    */
-  final def apply(system: ActorSystem[_]): T = system.registerExtension(this)
+  final def apply(system: ActorSystem[?]): T = system.registerExtension(this)
 
   override final def hashCode: Int = System.identityHashCode(this)
   override final def equals(other: Any): Boolean = this eq other.asInstanceOf[AnyRef]
@@ -163,7 +163,7 @@ trait Extensions {
    * Returns whether the specified extension is already registered, this method can potentially block, waiting for the initialization
    * of the payload, if is in the process of registration from another Thread of execution
    */
-  def hasExtension(ext: ExtensionId[_ <: Extension]): Boolean
+  def hasExtension(ext: ExtensionId[? <: Extension]): Boolean
 }
 
 /**
@@ -174,7 +174,7 @@ trait Extensions {
  */
 abstract class ExtensionSetup[T <: Extension](
     val extId: ExtensionId[T],
-    val createExtension: java.util.function.Function[ActorSystem[_], T])
+    val createExtension: java.util.function.Function[ActorSystem[?], T])
     extends Setup
 
 /**
@@ -183,5 +183,5 @@ abstract class ExtensionSetup[T <: Extension](
  * implementation of the extension. Intended for tests that need to replace
  * extension with stub/mock implementations.
  */
-abstract class AbstractExtensionSetup[T <: Extension](extId: ExtensionId[T], createExtension: ActorSystem[_] => T)
+abstract class AbstractExtensionSetup[T <: Extension](extId: ExtensionId[T], createExtension: ActorSystem[?] => T)
     extends ExtensionSetup[T](extId, createExtension.apply)

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/ConsumerController.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/ConsumerController.scala
@@ -204,7 +204,7 @@ object ConsumerController {
      * Scala API: Factory method from config `pekko.reliable-delivery.consumer-controller`
      * of the `ActorSystem`.
      */
-    def apply(system: ActorSystem[_]): Settings =
+    def apply(system: ActorSystem[?]): Settings =
       apply(system.settings.config.getConfig("pekko.reliable-delivery.consumer-controller"))
 
     /**
@@ -223,7 +223,7 @@ object ConsumerController {
      * Java API: Factory method from config `pekko.reliable-delivery.producer-controller`
      * of the `ActorSystem`.
      */
-    def create(system: ActorSystem[_]): Settings =
+    def create(system: ActorSystem[?]): Settings =
       apply(system)
 
     /**

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/DurableProducerQueue.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/DurableProducerQueue.scala
@@ -173,7 +173,7 @@ object DurableProducerQueue {
 
     override def equals(obj: Any): Boolean = {
       obj match {
-        case other: MessageSent[_] =>
+        case other: MessageSent[?] =>
           seqNr == other.seqNr && message == other.message && ack == other.ack && confirmationQualifier == other.confirmationQualifier && timestampMillis == other.timestampMillis
         case _ => false
       }
@@ -224,7 +224,7 @@ object DurableProducerQueue {
       new MessageSent(seqNr, message, ack, confirmationQualifier, timestampMillis)
 
     def unapply(
-        sent: MessageSent[_]): Option[(SeqNr, MessageOrChunk, Boolean, ConfirmationQualifier, TimestampMillis)] =
+        sent: MessageSent[?]): Option[(SeqNr, MessageOrChunk, Boolean, ConfirmationQualifier, TimestampMillis)] =
       Some((sent.seqNr, sent.message, sent.ack, sent.confirmationQualifier, sent.timestampMillis))
   }
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/ProducerController.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/ProducerController.scala
@@ -157,7 +157,7 @@ object ProducerController {
      * Scala API: Factory method from config `pekko.reliable-delivery.producer-controller`
      * of the `ActorSystem`.
      */
-    def apply(system: ActorSystem[_]): Settings =
+    def apply(system: ActorSystem[?]): Settings =
       apply(system.settings.config.getConfig("pekko.reliable-delivery.producer-controller"))
 
     /**
@@ -181,7 +181,7 @@ object ProducerController {
      * Java API: Factory method from config `pekko.reliable-delivery.producer-controller`
      * of the `ActorSystem`.
      */
-    def create(system: ActorSystem[_]): Settings =
+    def create(system: ActorSystem[?]): Settings =
       apply(system)
 
     /**

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/WorkPullingProducerController.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/WorkPullingProducerController.scala
@@ -154,7 +154,7 @@ object WorkPullingProducerController {
      * Scala API: Factory method from config `pekko.reliable-delivery.work-pulling.producer-controller`
      * of the `ActorSystem`.
      */
-    def apply(system: ActorSystem[_]): Settings =
+    def apply(system: ActorSystem[?]): Settings =
       apply(system.settings.config.getConfig("pekko.reliable-delivery.work-pulling.producer-controller"))
 
     /**
@@ -172,7 +172,7 @@ object WorkPullingProducerController {
      * Java API: Factory method from config `pekko.reliable-delivery.work-pulling.producer-controller`
      * of the `ActorSystem`.
      */
-    def create(system: ActorSystem[_]): Settings =
+    def create(system: ActorSystem[?]): Settings =
       apply(system)
 
     /**

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/internal/ConsumerControllerImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/internal/ConsumerControllerImpl.scala
@@ -89,7 +89,7 @@ import pekko.util.ConstantFun.scalaIdentityFunction
 
   private case object Retry extends InternalCommand
 
-  private final case class ConsumerTerminated(consumer: ActorRef[_]) extends InternalCommand
+  private final case class ConsumerTerminated(consumer: ActorRef[?]) extends InternalCommand
 
   private final case class State[A](
       producerController: ActorRef[ProducerControllerImpl.InternalCommand],
@@ -170,7 +170,7 @@ import pekko.util.ConstantFun.scalaIdentityFunction
                     }
                     Behaviors.same
 
-                  case _: DeliverThenStop[_] =>
+                  case _: DeliverThenStop[?] =>
                     if (stashBuffer.isEmpty) {
                       Behaviors.stopped
                     } else {
@@ -203,7 +203,7 @@ import pekko.util.ConstantFun.scalaIdentityFunction
 
   private def mdcForMessage(msg: InternalCommand): Map[String, String] = {
     msg match {
-      case seqMsg: SequencedMessage[_] => Map("producerId" -> seqMsg.producerId)
+      case seqMsg: SequencedMessage[?] => Map("producerId" -> seqMsg.producerId)
       case _                           => Map.empty
     }
   }
@@ -225,7 +225,7 @@ import pekko.util.ConstantFun.scalaIdentityFunction
       stopping)
   }
 
-  def enforceLocalConsumer(ref: ActorRef[_]): Unit = {
+  def enforceLocalConsumer(ref: ActorRef[?]): Unit = {
     if (ref.path.address.hasGlobalScope)
       throw new IllegalArgumentException(s"Consumer [$ref] should be local.")
   }
@@ -359,7 +359,7 @@ private class ConsumerControllerImpl[A] private (
         case reg: RegisterToProducerController[A @unchecked] =>
           receiveRegisterToProducerController(s, reg, newState => active(newState))
 
-        case _: DeliverThenStop[_] =>
+        case _: DeliverThenStop[?] =>
           receiveDeliverThenStop(s, newState => active(newState))
 
         case _: UnsealedInternalCommand =>
@@ -484,7 +484,7 @@ private class ConsumerControllerImpl[A] private (
         case reg: RegisterToProducerController[A @unchecked] =>
           receiveRegisterToProducerController(s, reg, newState => active(newState))
 
-        case _: DeliverThenStop[_] =>
+        case _: DeliverThenStop[?] =>
           receiveDeliverThenStop(s, newState => resending(newState))
 
         case _: UnsealedInternalCommand =>
@@ -604,7 +604,7 @@ private class ConsumerControllerImpl[A] private (
               scalaIdentityFunction)
           }
 
-        case msg: SequencedMessage[_] =>
+        case msg: SequencedMessage[?] =>
           flightRecorder.consumerReceivedPreviousInProgress(msg.producerId, msg.seqNr, stashBuffer.size + 1)
           val expectedSeqNr = seqMsg.seqNr + stashBuffer.size + 1
           if (msg.seqNr < expectedSeqNr && msg.producerController == seqMsg.producerController) {
@@ -642,7 +642,7 @@ private class ConsumerControllerImpl[A] private (
         case reg: RegisterToProducerController[A @unchecked] =>
           receiveRegisterToProducerController(s, reg, newState => waitingForConfirmation(newState, seqMsg))
 
-        case _: DeliverThenStop[_] =>
+        case _: DeliverThenStop[?] =>
           receiveDeliverThenStop(s, newState => waitingForConfirmation(newState, seqMsg))
 
         case _: UnsealedInternalCommand =>
@@ -708,7 +708,7 @@ private class ConsumerControllerImpl[A] private (
     }
   }
 
-  private def receiveConsumerTerminated(c: ActorRef[_]): Behavior[InternalCommand] = {
+  private def receiveConsumerTerminated(c: ActorRef[?]): Behavior[InternalCommand] = {
     context.log.debug("Consumer [{}] terminated.", c)
     Behaviors.stopped
   }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/internal/ProducerControllerImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/internal/ProducerControllerImpl.scala
@@ -342,7 +342,7 @@ object ProducerControllerImpl {
     }
   }
 
-  def enforceLocalProducer(ref: ActorRef[_]): Unit = {
+  def enforceLocalProducer(ref: ActorRef[?]): Unit = {
     if (ref.path.address.hasGlobalScope)
       throw new IllegalArgumentException(s"Consumer [$ref] should be local.")
   }
@@ -803,7 +803,7 @@ private class ProducerControllerImpl[A: ClassTag](
           active(s.copy(remainingChunks = chunks, storeMessageSentInProgress = seqMsg.seqNr))
         }
 
-      case StoreMessageSentCompleted(sent: MessageSent[_]) =>
+      case StoreMessageSentCompleted(sent: MessageSent[?]) =>
         receiveStoreMessageSentCompleted(sent.seqNr)
 
       case f: StoreMessageSentFailed[A @unchecked] =>

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/eventstream/EventStream.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/eventstream/EventStream.scala
@@ -63,7 +63,7 @@ object EventStream {
     /**
      * INTERNAL API
      */
-    @InternalApi private[pekko] def topic: Class[_] = classTag.runtimeClass
+    @InternalApi private[pekko] def topic: Class[?] = classTag.runtimeClass
   }
 
   /**

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorContextImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorContextImpl.scala
@@ -46,7 +46,7 @@ import scala.util.Success
   // single context for logging as there are a few things that are initialized
   // together that we can cache as long as the actor is alive
   object LoggingContext {
-    def apply(logger: Logger, tags: Set[String], ctx: ActorContextImpl[_]): LoggingContext = {
+    def apply(logger: Logger, tags: Set[String], ctx: ActorContextImpl[?]): LoggingContext = {
       val tagsString =
         // "" means no tags
         if (tags.isEmpty) ""
@@ -59,7 +59,7 @@ import scala.util.Success
 
       val pekkoAddress =
         ctx.system match {
-          case adapter: ActorSystemAdapter[_] => adapter.provider.addressString
+          case adapter: ActorSystemAdapter[?] => adapter.provider.addressString
           case _                              => Address("pekko", ctx.system.name).toString
         }
 
@@ -103,7 +103,7 @@ import scala.util.Success
   private var _logging: OptionVal[LoggingContext] = OptionVal.None
 
   private var messageAdapterRef: OptionVal[ActorRef[Any]] = OptionVal.None
-  private var _messageAdapters: List[(Class[_], Any => T)] = Nil
+  private var _messageAdapters: List[(Class[?], Any => T)] = Nil
   private var _timer: OptionVal[TimerSchedulerCrossDslSupport[T]] = OptionVal.None
 
   // _currentActorThread is on purpose not volatile. Used from `checkCurrentActorThread`.
@@ -162,7 +162,7 @@ import scala.util.Success
     _logging match {
       case OptionVal.Some(l) => l
       case _ =>
-        val logClass = LoggerClass.detectLoggerClassFromStack(classOf[Behavior[_]])
+        val logClass = LoggerClass.detectLoggerClassFromStack(classOf[Behavior[?]])
         val logger = LoggerFactory.getLogger(logClass.getName)
         val l = LoggingContext(logger, classicActorContext.props.deploy.tags, this)
         _logging = OptionVal.Some(l)
@@ -184,7 +184,7 @@ import scala.util.Success
     _logging = OptionVal.Some(loggingContext().withLogger(LoggerFactory.getLogger(name)))
   }
 
-  override def setLoggerName(clazz: Class[_]): Unit =
+  override def setLoggerName(clazz: Class[?]): Unit =
     setLoggerName(clazz.getName)
 
   def hasCustomLoggerName: Boolean = loggingContext().hasCustomName
@@ -236,7 +236,7 @@ import scala.util.Success
     ask(target, createRequest) {
       case Success(StatusReply.Success(t: Res)) => mapResponse(Success(t))
       case Success(StatusReply.Error(why))      => mapResponse(Failure(why))
-      case fail: Failure[_]                     => mapResponse(fail.asInstanceOf[Failure[Res]])
+      case fail: Failure[?]                     => mapResponse(fail.asInstanceOf[Failure[Res]])
       case _                                    => throw new RuntimeException() // won't happen, compiler exhaustiveness check pleaser
     }
 
@@ -333,7 +333,7 @@ import scala.util.Success
   /**
    * INTERNAL API
    */
-  @InternalApi private[pekko] def messageAdapters: List[(Class[_], Any => T)] = _messageAdapters
+  @InternalApi private[pekko] def messageAdapters: List[(Class[?], Any => T)] = _messageAdapters
 
   /**
    * INTERNAL API

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorFlightRecorder.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorFlightRecorder.scala
@@ -25,7 +25,7 @@ import pekko.util.FlightRecorderLoader
 @InternalApi
 object ActorFlightRecorder extends ExtensionId[ActorFlightRecorder] {
 
-  override def createExtension(system: ActorSystem[_]): ActorFlightRecorder =
+  override def createExtension(system: ActorSystem[?]): ActorFlightRecorder =
     FlightRecorderLoader.load[ActorFlightRecorder](
       system,
       "org.apache.pekko.actor.typed.internal.jfr.JFRActorFlightRecorder",

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorRefImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorRefImpl.scala
@@ -33,7 +33,7 @@ private[pekko] trait ActorRefImpl[-T] extends ActorRef[T] { this: InternalRecipi
   /**
    * Comparison takes path and the unique id of the actor cell into account.
    */
-  final override def compareTo(other: ActorRef[_]) = {
+  final override def compareTo(other: ActorRef[?]) = {
     val x = this.path.compareTo(other.path)
     if (x == 0) if (this.path.uid < other.path.uid) -1 else if (this.path.uid == other.path.uid) 0 else 1
     else x
@@ -45,7 +45,7 @@ private[pekko] trait ActorRefImpl[-T] extends ActorRef[T] { this: InternalRecipi
    * Equals takes path and the unique id of the actor cell into account.
    */
   final override def equals(that: Any): Boolean = that match {
-    case other: ActorRef[_] => path.uid == other.path.uid && path == other.path
+    case other: ActorRef[?] => path.uid == other.path.uid && path == other.path
     case _                  => false
   }
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/EventStreamExtension.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/EventStreamExtension.scala
@@ -27,11 +27,11 @@ import pekko.annotation.InternalApi
  *
  * It is used as an extension to ensure a single instance per actor system.
  */
-@InternalApi private[pekko] final class EventStreamExtension(actorSystem: ActorSystem[_]) extends Extension {
+@InternalApi private[pekko] final class EventStreamExtension(actorSystem: ActorSystem[?]) extends Extension {
   val ref: ActorRef[EventStream.Command] =
     actorSystem.internalSystemActorOf(EventStreamAdapter.behavior, "eventstream", Props.empty)
 }
 
 private[pekko] object EventStreamExtension extends ExtensionId[EventStreamExtension] {
-  override def createExtension(system: ActorSystem[_]): EventStreamExtension = new EventStreamExtension(system)
+  override def createExtension(system: ActorSystem[?]): EventStreamExtension = new EventStreamExtension(system)
 }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/InterceptorImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/InterceptorImpl.scala
@@ -56,24 +56,24 @@ private[pekko] final class InterceptorImpl[O, I](
   import BehaviorInterceptor._
 
   private val preStartTarget: PreStartTarget[I] = new PreStartTarget[I] {
-    override def start(ctx: TypedActorContext[_]): Behavior[I] = {
+    override def start(ctx: TypedActorContext[?]): Behavior[I] = {
       Behavior.start[I](nestedBehavior, ctx.asInstanceOf[TypedActorContext[I]])
     }
     override def toString: String = s"PreStartTarget($nestedBehavior)"
   }
 
   private val receiveTarget: ReceiveTarget[I] = new ReceiveTarget[I] {
-    override def apply(ctx: TypedActorContext[_], msg: I): Behavior[I] =
+    override def apply(ctx: TypedActorContext[?], msg: I): Behavior[I] =
       Behavior.interpretMessage(nestedBehavior, ctx.asInstanceOf[TypedActorContext[I]], msg)
 
-    override def signalRestart(ctx: TypedActorContext[_]): Unit =
+    override def signalRestart(ctx: TypedActorContext[?]): Unit =
       Behavior.interpretSignal(nestedBehavior, ctx.asInstanceOf[TypedActorContext[I]], PreRestart)
 
     override def toString: String = s"ReceiveTarget($nestedBehavior)"
   }
 
   private val signalTarget = new SignalTarget[I] {
-    override def apply(ctx: TypedActorContext[_], signal: Signal): Behavior[I] =
+    override def apply(ctx: TypedActorContext[?], signal: Signal): Behavior[I] =
       Behavior.interpretSignal(nestedBehavior, ctx.asInstanceOf[TypedActorContext[I]], signal)
     override def toString: String = s"SignalTarget($nestedBehavior)"
   }
@@ -111,7 +111,7 @@ private[pekko] final class InterceptorImpl[O, I](
     } else {
       // returned behavior could be nested in setups, so we need to start before we deduplicate
       val duplicateInterceptExists = Behavior.existsInStack(started) {
-        case i: InterceptorImpl[_, _]
+        case i: InterceptorImpl[?, ?]
             if interceptor.isSame(i.interceptor.asInstanceOf[BehaviorInterceptor[Any, Any]]) =>
           true
         case _ => false

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/LoggerClass.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/LoggerClass.scala
@@ -27,7 +27,7 @@ private[pekko] object LoggerClass {
 
   // just to get access to the class context
   private final class TrickySecurityManager extends SecurityManager {
-    def getClassStack: Array[Class[_]] = getClassContext
+    def getClassStack: Array[Class[?]] = getClassContext
   }
 
   private val defaultPrefixesToSkip = List("scala.runtime", "org.apache.pekko.actor.typed.internal")
@@ -35,7 +35,7 @@ private[pekko] object LoggerClass {
   /**
    * Try to extract a logger class from the call stack, if not possible the provided default is used
    */
-  def detectLoggerClassFromStack(default: Class[_], additionalPrefixesToSkip: List[String] = Nil): Class[_] = {
+  def detectLoggerClassFromStack(default: Class[?], additionalPrefixesToSkip: List[String] = Nil): Class[?] = {
     // TODO use stack walker API when we no longer need to support Java 8
     try {
       def skip(name: String): Boolean = {
@@ -50,7 +50,7 @@ private[pekko] object LoggerClass {
       }
 
       val trace = new TrickySecurityManager().getClassStack
-      var suitableClass: OptionVal[Class[_]] = OptionVal.None
+      var suitableClass: OptionVal[Class[?]] = OptionVal.None
       var idx = 1 // skip this method/class and right away
       while (suitableClass.isEmpty && idx < trace.length) {
         val clazz = trace(idx)

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/MiscMessageSerializer.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/MiscMessageSerializer.scala
@@ -34,13 +34,13 @@ import pekko.serialization.{ BaseSerializer, SerializerWithStringManifest }
   private val ActorRefManifest = "a"
 
   def manifest(o: AnyRef): String = o match {
-    case _: ActorRef[_] => ActorRefManifest
+    case _: ActorRef[?] => ActorRefManifest
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }
 
   def toBinary(o: AnyRef): Array[Byte] = o match {
-    case ref: ActorRef[_] => resolver.toSerializationFormat(ref).getBytes(StandardCharsets.UTF_8)
+    case ref: ActorRef[?] => resolver.toSerializationFormat(ref).getBytes(StandardCharsets.UTF_8)
     case _ =>
       throw new IllegalArgumentException(s"Cannot serialize object of type [${o.getClass.getName}]")
   }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/PoisonPill.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/PoisonPill.scala
@@ -61,5 +61,5 @@ import pekko.annotation.InternalApi
 
   override def isSame(other: BehaviorInterceptor[Any, Any]): Boolean =
     // only one interceptor per behavior stack is needed
-    other.isInstanceOf[PoisonPillInterceptor[_]]
+    other.isInstanceOf[PoisonPillInterceptor[?]]
 }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/WithMdcBehaviorInterceptor.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/WithMdcBehaviorInterceptor.scala
@@ -59,7 +59,7 @@ import pekko.annotation.InternalApi
     // so we need to look through the stack and eliminate any MCD already existing
     def loop(next: Behavior[T]): Behavior[T] = {
       next match {
-        case i: InterceptorImpl[_, T @unchecked]
+        case i: InterceptorImpl[?, T @unchecked]
             if i.interceptor.isSame(this.asInstanceOf[BehaviorInterceptor[Any, Any]]) =>
           // eliminate that interceptor
           loop(i.nestedBehavior)
@@ -83,7 +83,7 @@ import pekko.annotation.InternalApi
 
   // in the normal case, a new withMDC replaces the previous one
   override def isSame(other: BehaviorInterceptor[Any, Any]): Boolean = other match {
-    case _: WithMdcBehaviorInterceptor[_] => true
+    case _: WithMdcBehaviorInterceptor[?] => true
     case _                                => false
   }
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorAdapter.scala
@@ -180,7 +180,7 @@ import pekko.util.OptionVal
   }
 
   private def adaptAndHandle(msg: Any): Unit = {
-    @tailrec def handle(adapters: List[(Class[_], Any => T)]): Unit = {
+    @tailrec def handle(adapters: List[(Class[?], Any => T)]): Unit = {
       adapters match {
         case Nil =>
           // no adapter function registered for message class
@@ -240,7 +240,7 @@ import pekko.util.OptionVal
           case _ =>
             val isTypedActor = sender() match {
               case afwc: ActorRefWithCell =>
-                afwc.underlying.props.producer.actorClass == classOf[ActorAdapter[_]]
+                afwc.underlying.props.producer.actorClass == classOf[ActorAdapter[?]]
               case _ =>
                 false
             }
@@ -326,7 +326,7 @@ import pekko.util.OptionVal
     try {
       ctx.cancelAllTimers()
       behavior match {
-        case _: DeferredBehavior[_] =>
+        case _: DeferredBehavior[?] =>
         // Do not undefer a DeferredBehavior as that may cause creation side-effects, which we do not want on termination.
         case b => Behavior.interpretSignal(b, ctx, PostStop)
       }
@@ -352,7 +352,7 @@ import pekko.util.OptionVal
     // first pass the signal to the previous behavior, so that it and potential interceptors
     // will get the PostStop signal, unless it is deferred, we don't start a behavior while stopping
     lastBehavior match {
-      case _: DeferredBehavior[_] => // no starting of behaviors on actor stop
+      case _: DeferredBehavior[?] => // no starting of behaviors on actor stop
       case nonDeferred            => Behavior.interpretSignal(nonDeferred, ctx, PostStop)
     }
     // and then to the potential stop hook, which can have a call back or not

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -25,19 +25,19 @@ import pekko.annotation.InternalApi
 @InternalApi
 private[pekko] object ActorContextAdapter {
 
-  private def toClassicImp[U](context: TypedActorContext[_]): classic.ActorContext =
+  private def toClassicImp[U](context: TypedActorContext[?]): classic.ActorContext =
     context match {
-      case adapter: ActorContextAdapter[_] => adapter.classicContext
+      case adapter: ActorContextAdapter[?] => adapter.classicContext
       case _ =>
         throw new UnsupportedOperationException(
           "Only adapted classic ActorContext permissible " +
           s"($context of class ${context.getClass.getName})")
     }
 
-  def toClassic[U](context: scaladsl.ActorContext[_]): classic.ActorContext =
+  def toClassic[U](context: scaladsl.ActorContext[?]): classic.ActorContext =
     toClassicImp(context)
 
-  def toClassic[U](context: javadsl.ActorContext[_]): classic.ActorContext =
+  def toClassic[U](context: javadsl.ActorContext[?]): classic.ActorContext =
     toClassicImp(context)
 }
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorRefAdapter.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorRefAdapter.scala
@@ -59,8 +59,8 @@ private[pekko] object ActorRefAdapter {
 
   def toClassic[U](ref: ActorRef[U]): pekko.actor.InternalActorRef =
     ref match {
-      case adapter: ActorRefAdapter[_]    => adapter.classicRef
-      case adapter: ActorSystemAdapter[_] => adapter.system.guardian
+      case adapter: ActorRefAdapter[?]    => adapter.classicRef
+      case adapter: ActorSystemAdapter[?] => adapter.system.guardian
       case _ =>
         throw new UnsupportedOperationException(
           "Only adapted classic ActorRefs permissible " +

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -104,7 +104,7 @@ import pekko.util.FutureConverters._
   }
   override def dynamicAccess: classic.DynamicAccess = system.dynamicAccess
   implicit override def executionContext: scala.concurrent.ExecutionContextExecutor = classicSystem.dispatcher
-  override val log: Logger = LoggerFactory.getLogger(classOf[ActorSystem[_]])
+  override val log: Logger = LoggerFactory.getLogger(classOf[ActorSystem[?]])
   override def logConfiguration(): Unit = classicSystem.logConfiguration()
   override def name: String = classicSystem.name
   override val scheduler: Scheduler = new SchedulerAdapter(classicSystem.scheduler)
@@ -165,10 +165,10 @@ private[pekko] object ActorSystemAdapter {
   }
 
   object LoadTypedExtensions extends classic.ExtensionId[LoadTypedExtensions] with classic.ExtensionIdProvider {
-    override def lookup: actor.ExtensionId[_ <: actor.Extension] = this
+    override def lookup: actor.ExtensionId[? <: actor.Extension] = this
     override def createExtension(system: ExtendedActorSystem): LoadTypedExtensions =
       new LoadTypedExtensions(system)
   }
 
-  def toClassic[U](sys: ActorSystem[_]): classic.ActorSystem = sys.classicSystem
+  def toClassic[U](sys: ActorSystem[?]): classic.ActorSystem = sys.classicSystem
 }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/receptionist/LocalReceptionist.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/receptionist/LocalReceptionist.scala
@@ -71,9 +71,9 @@ private[pekko] object LocalReceptionist extends ReceptionistBehaviorProvider {
    */
   private final case class State(
       services: TypedMultiMap[AbstractServiceKey, Service],
-      servicesPerActor: Map[ActorRef[_], Set[AbstractServiceKey]],
+      servicesPerActor: Map[ActorRef[?], Set[AbstractServiceKey]],
       subscriptions: TypedMultiMap[AbstractServiceKey, Subscriber],
-      subscriptionsPerActor: Map[ActorRef[_], Set[AbstractServiceKey]]) {
+      subscriptionsPerActor: Map[ActorRef[?], Set[AbstractServiceKey]]) {
 
     def serviceInstanceAdded[Key <: AbstractServiceKey](key: Key)(serviceInstance: ActorRef[key.Protocol]): State = {
       val newServices = services.inserted(key)(serviceInstance)
@@ -101,7 +101,7 @@ private[pekko] object LocalReceptionist extends ReceptionistBehaviorProvider {
       copy(services = newServices, servicesPerActor = newServicePerActor)
     }
 
-    def serviceInstanceRemoved(serviceInstance: ActorRef[_]): State = {
+    def serviceInstanceRemoved(serviceInstance: ActorRef[?]): State = {
       val keys = servicesPerActor.getOrElse(serviceInstance, Set.empty)
       val newServices =
         if (keys.isEmpty) services
@@ -140,7 +140,7 @@ private[pekko] object LocalReceptionist extends ReceptionistBehaviorProvider {
       copy(subscriptions = newSubscriptions, subscriptionsPerActor = newSubscriptionsPerActor)
     }
 
-    def subscriberRemoved(subscriber: ActorRef[_]): State = {
+    def subscriberRemoved(subscriber: ActorRef[?]): State = {
       val keys = subscriptionsPerActor.getOrElse(subscriber, Set.empty)
       if (keys.isEmpty) this
       else {

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/receptionist/ReceptionistImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/receptionist/ReceptionistImpl.scala
@@ -24,7 +24,7 @@ import pekko.annotation.InternalApi
 /**
  * INTERNAL API
  */
-@InternalApi private[pekko] class ReceptionistImpl(system: ActorSystem[_]) extends Receptionist {
+@InternalApi private[pekko] class ReceptionistImpl(system: ActorSystem[?]) extends Receptionist {
 
   override val ref: ActorRef[Receptionist.Command] = {
     val provider: ReceptionistBehaviorProvider =

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/receptionist/ReceptionistMessages.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/receptionist/ReceptionistMessages.scala
@@ -45,7 +45,7 @@ private[pekko] object ReceptionistMessages {
 
   final case class Registered[T] private[pekko] (key: ServiceKey[T], _serviceInstance: ActorRef[T])
       extends Receptionist.Registered {
-    def isForKey(key: ServiceKey[_]): Boolean = key == this.key
+    def isForKey(key: ServiceKey[?]): Boolean = key == this.key
     def serviceInstance[M](key: ServiceKey[M]): ActorRef[M] = {
       if (key != this.key)
         throw new IllegalArgumentException(s"Wrong key [$key] used, must use listing key [${this.key}]")
@@ -58,7 +58,7 @@ private[pekko] object ReceptionistMessages {
 
   final case class Deregistered[T] private[pekko] (key: ServiceKey[T], _serviceInstance: ActorRef[T])
       extends Receptionist.Deregistered {
-    def isForKey(key: ServiceKey[_]): Boolean = key == this.key
+    def isForKey(key: ServiceKey[?]): Boolean = key == this.key
     def serviceInstance[M](key: ServiceKey[M]): ActorRef[M] = {
       if (key != this.key)
         throw new IllegalArgumentException(s"Wrong key [$key] used, must use listing key [${this.key}]")
@@ -78,7 +78,7 @@ private[pekko] object ReceptionistMessages {
       servicesWereAddedOrRemoved: Boolean)
       extends Receptionist.Listing {
 
-    def isForKey(key: ServiceKey[_]): Boolean = key == this.key
+    def isForKey(key: ServiceKey[?]): Boolean = key == this.key
 
     def serviceInstances[M](key: ServiceKey[M]): Set[ActorRef[M]] = {
       if (key != this.key)

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/receptionist/ServiceKeySerializer.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/receptionist/ServiceKeySerializer.scala
@@ -28,13 +28,13 @@ final class ServiceKeySerializer(val system: pekko.actor.ExtendedActorSystem)
     extends SerializerWithStringManifest
     with BaseSerializer {
   def manifest(o: AnyRef): String = o match {
-    case key: DefaultServiceKey[_] => key.typeName
+    case key: DefaultServiceKey[?] => key.typeName
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }
 
   def toBinary(o: AnyRef): Array[Byte] = o match {
-    case serviceKey: DefaultServiceKey[_] => serviceKey.id.getBytes(StandardCharsets.UTF_8)
+    case serviceKey: DefaultServiceKey[?] => serviceKey.id.getBytes(StandardCharsets.UTF_8)
     case _ =>
       throw new IllegalArgumentException(s"Cannot serialize object of type [${o.getClass.getName}]")
   }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/routing/GroupRouterImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/routing/GroupRouterImpl.scala
@@ -33,7 +33,7 @@ import pekko.annotation.InternalApi
 private[pekko] final case class GroupRouterBuilder[T] private[pekko] (
     key: ServiceKey[T],
     preferLocalRoutees: Boolean = false,
-    logicFactory: ActorSystem[_] => RoutingLogic[T] = (_: ActorSystem[_]) => new RoutingLogics.RandomLogic[T]())
+    logicFactory: ActorSystem[?] => RoutingLogic[T] = (_: ActorSystem[?]) => new RoutingLogics.RandomLogic[T]())
     extends javadsl.GroupRouter[T]
     with scaladsl.GroupRouter[T] {
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/routing/PoolRouterImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/routing/PoolRouterImpl.scala
@@ -30,7 +30,7 @@ import java.util.function.Predicate
 private[pekko] final case class PoolRouterBuilder[T](
     poolSize: Int,
     behavior: Behavior[T],
-    logicFactory: ActorSystem[_] => RoutingLogic[T] = (_: ActorSystem[_]) => new RoutingLogics.RoundRobinLogic[T],
+    logicFactory: ActorSystem[?] => RoutingLogic[T] = (_: ActorSystem[?]) => new RoutingLogics.RoundRobinLogic[T],
     broadcastPredicate: T => Boolean = ConstantFun.anyToFalse,
     routeeProps: Props = Props.empty)
     extends javadsl.PoolRouter[T]

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/ActorContext.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/ActorContext.scala
@@ -103,7 +103,7 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
    * *Warning*: This method is not thread-safe and must not be accessed from threads other
    * than the ordinary actor message processing thread, such as [[java.util.concurrent.CompletionStage]] callbacks.
    */
-  def setLoggerName(clazz: Class[_]): Unit
+  def setLoggerName(clazz: Class[?]): Unit
 
   /**
    * The list of child Actors created by this Actor during its lifetime that

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Adapter.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Adapter.scala
@@ -108,10 +108,10 @@ object Adapter {
   def toTyped(sys: pekko.actor.ActorSystem): ActorSystem[Void] =
     sys.toTyped.asInstanceOf[ActorSystem[Void]]
 
-  def toClassic(sys: ActorSystem[_]): pekko.actor.ActorSystem =
+  def toClassic(sys: ActorSystem[?]): pekko.actor.ActorSystem =
     sys.toClassic
 
-  def toClassic(ctx: ActorContext[_]): actor.ActorContext =
+  def toClassic(ctx: ActorContext[?]): actor.ActorContext =
     ActorContextAdapter.toClassic(ctx)
 
   def watch[U](ctx: pekko.actor.ActorContext, other: ActorRef[U]): Unit =
@@ -120,25 +120,25 @@ object Adapter {
   def unwatch[U](ctx: pekko.actor.ActorContext, other: ActorRef[U]): Unit =
     ctx.unwatch(other)
 
-  def stop(ctx: pekko.actor.ActorContext, child: ActorRef[_]): Unit =
+  def stop(ctx: pekko.actor.ActorContext, child: ActorRef[?]): Unit =
     ctx.stop(child)
 
-  def watch[U](ctx: ActorContext[_], other: pekko.actor.ActorRef): Unit =
+  def watch[U](ctx: ActorContext[?], other: pekko.actor.ActorRef): Unit =
     ctx.watch(other)
 
-  def unwatch[U](ctx: ActorContext[_], other: pekko.actor.ActorRef): Unit =
+  def unwatch[U](ctx: ActorContext[?], other: pekko.actor.ActorRef): Unit =
     ctx.unwatch(other)
 
-  def stop(ctx: ActorContext[_], child: pekko.actor.ActorRef): Unit =
+  def stop(ctx: ActorContext[?], child: pekko.actor.ActorRef): Unit =
     ctx.stop(child)
 
-  def actorOf(ctx: ActorContext[_], props: pekko.actor.Props): pekko.actor.ActorRef =
+  def actorOf(ctx: ActorContext[?], props: pekko.actor.Props): pekko.actor.ActorRef =
     ActorContextAdapter.toClassic(ctx).actorOf(props)
 
-  def actorOf(ctx: ActorContext[_], props: pekko.actor.Props, name: String): pekko.actor.ActorRef =
+  def actorOf(ctx: ActorContext[?], props: pekko.actor.Props, name: String): pekko.actor.ActorRef =
     ActorContextAdapter.toClassic(ctx).actorOf(props, name)
 
-  def toClassic(ref: ActorRef[_]): pekko.actor.ActorRef =
+  def toClassic(ref: ActorRef[?]): pekko.actor.ActorRef =
     ref.toClassic
 
   def toTyped[T](ref: pekko.actor.ActorRef): ActorRef[T] =

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/BehaviorBuilder.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/BehaviorBuilder.scala
@@ -81,7 +81,7 @@ final class BehaviorBuilder[T] private (messageHandlers: List[Case[T, T]], signa
    * @param handler action to apply when the type matches
    * @return a new behavior builder with the specified handling appended
    */
-  def onMessageUnchecked[M <: T](`type`: Class[_ <: T], handler: JFunction[M, Behavior[T]]): BehaviorBuilder[T] =
+  def onMessageUnchecked[M <: T](`type`: Class[? <: T], handler: JFunction[M, Behavior[T]]): BehaviorBuilder[T] =
     withMessage[M](OptionVal.Some(`type`.asInstanceOf[Class[M]]), OptionVal.None, handler)
 
   /**
@@ -173,7 +173,7 @@ object BehaviorBuilder {
   /** INTERNAL API */
   @InternalApi
   private[javadsl] final case class Case[BT, MT](
-      `type`: OptionVal[Class[_ <: MT]],
+      `type`: OptionVal[Class[? <: MT]],
       test: OptionVal[MT => Boolean],
       handler: JFunction[MT, Behavior[BT]])
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/ReceiveBuilder.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/ReceiveBuilder.scala
@@ -76,7 +76,7 @@ final class ReceiveBuilder[T] private (
    * @param handler action to apply when the type matches
    * @return this behavior builder
    */
-  def onMessageUnchecked[M <: T](`type`: Class[_ <: T], handler: JFunction[M, Behavior[T]]): ReceiveBuilder[T] =
+  def onMessageUnchecked[M <: T](`type`: Class[? <: T], handler: JFunction[M, Behavior[T]]): ReceiveBuilder[T] =
     withMessage[M](OptionVal.Some(`type`.asInstanceOf[Class[M]]), OptionVal.None, handler)
 
   /**
@@ -173,7 +173,7 @@ object ReceiveBuilder {
   /** INTERNAL API */
   @InternalApi
   private[javadsl] final case class Case[BT, MT](
-      `type`: OptionVal[Class[_ <: MT]],
+      `type`: OptionVal[Class[? <: MT]],
       test: OptionVal[JPredicate[MT]],
       handler: JFunction[MT, Behavior[BT]])
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/receptionist/Receptionist.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/receptionist/Receptionist.scala
@@ -104,8 +104,8 @@ abstract class ServiceKey[T] extends AbstractServiceKey { key =>
  * The receptionist is easiest accessed through the system: [[ActorSystem.receptionist]]
  */
 object Receptionist extends ExtensionId[Receptionist] {
-  def createExtension(system: ActorSystem[_]): Receptionist = new ReceptionistImpl(system)
-  def get(system: ActorSystem[_]): Receptionist = apply(system)
+  def createExtension(system: ActorSystem[?]): Receptionist = new ReceptionistImpl(system)
+  def get(system: ActorSystem[?]): Receptionist = apply(system)
 
   /**
    * The set of commands accepted by a Receptionist.
@@ -172,13 +172,13 @@ object Receptionist extends ExtensionId[Receptionist] {
   @DoNotInherit
   trait Registered {
 
-    def isForKey(key: ServiceKey[_]): Boolean
+    def isForKey(key: ServiceKey[?]): Boolean
 
     /** Scala API */
-    def key: ServiceKey[_]
+    def key: ServiceKey[?]
 
     /** Java API */
-    def getKey: ServiceKey[_] = key
+    def getKey: ServiceKey[?] = key
 
     /**
      * Scala API
@@ -255,13 +255,13 @@ object Receptionist extends ExtensionId[Receptionist] {
   @DoNotInherit
   trait Deregistered {
 
-    def isForKey(key: ServiceKey[_]): Boolean
+    def isForKey(key: ServiceKey[?]): Boolean
 
     /** Scala API */
-    def key: ServiceKey[_]
+    def key: ServiceKey[?]
 
     /** Java API */
-    def getKey: ServiceKey[_] = key
+    def getKey: ServiceKey[?] = key
 
     /**
      * Scala API
@@ -354,12 +354,12 @@ object Receptionist extends ExtensionId[Receptionist] {
   trait Listing {
 
     /** Scala API */
-    def key: ServiceKey[_]
+    def key: ServiceKey[?]
 
     /** Java API */
-    def getKey: ServiceKey[_] = key
+    def getKey: ServiceKey[?] = key
 
-    def isForKey(key: ServiceKey[_]): Boolean
+    def isForKey(key: ServiceKey[?]): Boolean
 
     /**
      * Scala API: Return the reachable service instances.
@@ -463,7 +463,7 @@ object Receptionist extends ExtensionId[Receptionist] {
 }
 
 object ReceptionistSetup {
-  def apply[T <: Extension](createExtension: ActorSystem[_] => Receptionist): ReceptionistSetup =
+  def apply[T <: Extension](createExtension: ActorSystem[?] => Receptionist): ReceptionistSetup =
     new ReceptionistSetup(createExtension(_))
 
 }
@@ -473,5 +473,5 @@ object ReceptionistSetup {
  * to replace the default implementation of the [[Receptionist]] extension. Intended
  * for tests that need to replace extension with stub/mock implementations.
  */
-final class ReceptionistSetup(createExtension: java.util.function.Function[ActorSystem[_], Receptionist])
+final class ReceptionistSetup(createExtension: java.util.function.Function[ActorSystem[?], Receptionist])
     extends ExtensionSetup[Receptionist](Receptionist, createExtension)

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/ActorContext.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/ActorContext.scala
@@ -103,7 +103,7 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
    * *Warning*: This method is not thread-safe and must not be accessed from threads other
    * than the ordinary actor message processing thread, such as [[scala.concurrent.Future]] callbacks.
    */
-  def setLoggerName(clazz: Class[_]): Unit
+  def setLoggerName(clazz: Class[?]): Unit
 
   /**
    * The list of child Actors created by this Actor during its lifetime that

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/AskPattern.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/AskPattern.scala
@@ -40,7 +40,7 @@ object AskPattern {
    * Provides a scheduler from an actor system (that will likely already be implicit in the scope) to minimize ask
    * boilerplate.
    */
-  implicit def schedulerFromActorSystem(implicit system: ActorSystem[_]): Scheduler = system.scheduler
+  implicit def schedulerFromActorSystem(implicit system: ActorSystem[?]): Scheduler = system.scheduler
 
   /**
    * See [[ask]]
@@ -140,7 +140,7 @@ object AskPattern {
 
   private val onTimeout: String => Throwable = msg => new TimeoutException(msg)
 
-  private final class PromiseRef[U](target: InternalRecipientRef[_], timeout: Timeout) {
+  private final class PromiseRef[U](target: InternalRecipientRef[?], timeout: Timeout) {
 
     // Note: _promiseRef mustn't have a type pattern, since it can be null
     private[this] val (_ref: ActorRef[U], _future: Future[U], _promiseRef) =

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/adapter/package.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/adapter/package.scala
@@ -83,7 +83,7 @@ package object adapter {
   /**
    * Extension methods added to [[pekko.actor.typed.ActorSystem]].
    */
-  implicit class TypedActorSystemOps(val sys: ActorSystem[_]) extends AnyVal {
+  implicit class TypedActorSystemOps(val sys: ActorSystem[?]) extends AnyVal {
     def toClassic: pekko.actor.ActorSystem = sys.classicSystem
 
     /**
@@ -132,14 +132,14 @@ package object adapter {
     def watch[U](other: ActorRef[U]): Unit = ctx.watch(ActorRefAdapter.toClassic(other))
     def unwatch[U](other: ActorRef[U]): Unit = ctx.unwatch(ActorRefAdapter.toClassic(other))
 
-    def stop(child: ActorRef[_]): Unit =
+    def stop(child: ActorRef[?]): Unit =
       ctx.stop(ActorRefAdapter.toClassic(child))
   }
 
   /**
    * Extension methods added to [[pekko.actor.typed.scaladsl.ActorContext]].
    */
-  implicit class TypedActorContextOps(val ctx: scaladsl.ActorContext[_]) extends AnyVal {
+  implicit class TypedActorContextOps(val ctx: scaladsl.ActorContext[?]) extends AnyVal {
     def actorOf(props: pekko.actor.Props): pekko.actor.ActorRef =
       ActorContextAdapter.toClassic(ctx).actorOf(props)
 
@@ -154,7 +154,7 @@ package object adapter {
   /**
    * Extension methods added to [[pekko.actor.typed.ActorRef]].
    */
-  implicit class TypedActorRefOps(val ref: ActorRef[_]) extends AnyVal {
+  implicit class TypedActorRefOps(val ref: ActorRef[?]) extends AnyVal {
     def toClassic: pekko.actor.ActorRef = ActorRefAdapter.toClassic(ref)
   }
 

--- a/actor/src/main/scala/org/apache/pekko/actor/AbstractProps.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/AbstractProps.scala
@@ -31,7 +31,7 @@ private[pekko] trait AbstractProps {
   /**
    * INTERNAL API
    */
-  private[pekko] def validate(clazz: Class[_]): Unit = {
+  private[pekko] def validate(clazz: Class[?]): Unit = {
     if (Modifier.isAbstract(clazz.getModifiers)) {
       throw new IllegalArgumentException(s"Actor class [${clazz.getName}] must not be abstract")
     } else if (!classOf[Actor].isAssignableFrom(clazz) &&
@@ -45,7 +45,7 @@ private[pekko] trait AbstractProps {
    * Java API: create a Props given a class and its constructor arguments.
    */
   @varargs
-  def create(clazz: Class[_], args: AnyRef*): Props =
+  def create(clazz: Class[?], args: AnyRef*): Props =
     new Props(deploy = Props.defaultDeploy, clazz = clazz, args = args.toList)
 
   /**
@@ -63,16 +63,16 @@ private[pekko] trait AbstractProps {
     checkCreatorClosingOver(cc)
 
     val ac = classOf[Actor]
-    val coc = classOf[Creator[_]]
+    val coc = classOf[Creator[?]]
     val actorClass = Reflect.findMarker(cc, coc) match {
       case t: ParameterizedType =>
         t.getActualTypeArguments.head match {
-          case c: Class[_] => c // since T <: Actor
-          case v: TypeVariable[_] =>
-            v.getBounds.collectFirst { case c: Class[_] if ac.isAssignableFrom(c) && c != ac => c }.getOrElse(ac)
+          case c: Class[?] => c // since T <: Actor
+          case v: TypeVariable[?] =>
+            v.getBounds.collectFirst { case c: Class[?] if ac.isAssignableFrom(c) && c != ac => c }.getOrElse(ac)
           case x => throw new IllegalArgumentException(s"unsupported type found in Creator argument [$x]")
         }
-      case c: Class[_] if c == coc =>
+      case c: Class[?] if c == coc =>
         throw new IllegalArgumentException(
           "erased Creator types (e.g. lambdas) are unsupported, use Props.create(actorClass, creator) instead")
       case unexpected =>
@@ -89,10 +89,10 @@ private[pekko] trait AbstractProps {
     create(classOf[CreatorConsumer], actorClass, creator)
   }
 
-  private def checkCreatorClosingOver(clazz: Class[_]): Unit = {
+  private def checkCreatorClosingOver(clazz: Class[?]): Unit = {
     val enclosingClass = clazz.getEnclosingClass
 
-    def hasDeclaredConstructorWithEmptyParams(declaredConstructors: Array[Constructor[_]]): Boolean = {
+    def hasDeclaredConstructorWithEmptyParams(declaredConstructors: Array[Constructor[?]]): Boolean = {
       @tailrec def loop(i: Int): Boolean = {
         if (i == declaredConstructors.length) false
         else {
@@ -105,7 +105,7 @@ private[pekko] trait AbstractProps {
       loop(0)
     }
 
-    def hasDeclaredConstructorWithEnclosingClassParam(declaredConstructors: Array[Constructor[_]]): Boolean = {
+    def hasDeclaredConstructorWithEnclosingClassParam(declaredConstructors: Array[Constructor[?]]): Boolean = {
       @tailrec def loop(i: Int): Boolean = {
         if (i == declaredConstructors.length) false
         else {

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
@@ -729,5 +729,5 @@ private[pekko] class ActorCell(
     try system.eventStream.publish(e)
     catch { case NonFatal(_) => }
 
-  protected final def clazz(o: AnyRef): Class[_] = if (o eq null) this.getClass else o.getClass
+  protected final def clazz(o: AnyRef): Class[?] = if (o eq null) this.getClass else o.getClass
 }

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
@@ -719,7 +719,7 @@ abstract class ActorSystem extends ActorRefFactory with ClassicActorSystemProvid
    * Returns whether the specified extension is already registered, this method can potentially block, waiting for the initialization
    * of the payload, if is in the process of registration from another Thread of execution
    */
-  def hasExtension(ext: ExtensionId[_ <: Extension]): Boolean
+  def hasExtension(ext: ExtensionId[? <: Extension]): Boolean
 }
 
 /**
@@ -1142,7 +1142,7 @@ private[pekko] class ActorSystemImpl(
   // 1) a CountDownLatch (if it's still in the process of being registered),
   // 2) a Throwable (if it failed initializing), or
   // 3) the registered extension.
-  private val extensions = new ConcurrentHashMap[ExtensionId[_], AnyRef]
+  private val extensions = new ConcurrentHashMap[ExtensionId[?], AnyRef]
 
   /**
    * Returns any extension registered to the specified Extension or returns null if not registered
@@ -1199,7 +1199,7 @@ private[pekko] class ActorSystemImpl(
     case some => some.asInstanceOf[T]
   }
 
-  def hasExtension(ext: ExtensionId[_ <: Extension]): Boolean = findExtension(ext) != null
+  def hasExtension(ext: ExtensionId[? <: Extension]): Boolean = findExtension(ext) != null
 
   private def loadExtensions(): Unit = {
 
@@ -1217,7 +1217,7 @@ private[pekko] class ActorSystemImpl(
         } match {
           case Success(p: ExtensionIdProvider) =>
             registerExtension(p.lookup)
-          case Success(p: ExtensionId[_]) =>
+          case Success(p: ExtensionId[?]) =>
             registerExtension(p)
           case Success(_) =>
             if (!throwOnLoadFail) log.error("[{}] is not an 'ExtensionIdProvider' or 'ExtensionId', skipping...", fqcn)

--- a/actor/src/main/scala/org/apache/pekko/actor/CoordinatedShutdown.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/CoordinatedShutdown.scala
@@ -319,7 +319,7 @@ object CoordinatedShutdown extends ExtensionId[CoordinatedShutdown] with Extensi
       depends-on = []
     """)
     phasesConf.root.unwrapped.asScala.toMap.map {
-      case (k, _: java.util.Map[_, _]) =>
+      case (k, _: java.util.Map[?, ?]) =>
         val c = phasesConf.getConfig(k).withFallback(defaultPhaseConfig)
         val dependsOn = c.getStringList("depends-on").asScala.toSet
         val timeout = c.getDuration("timeout", MILLISECONDS).millis

--- a/actor/src/main/scala/org/apache/pekko/actor/Deployer.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Deployer.scala
@@ -293,7 +293,7 @@ private[pekko] class Deployer(val settings: ActorSystem.Settings, val dynamicAcc
 
       val fqn = routerTypeMapping.getOrElse(routerType, routerType)
 
-      def throwCannotInstantiateRouter(args: Seq[(Class[_], AnyRef)], cause: Throwable) =
+      def throwCannotInstantiateRouter(args: Seq[(Class[?], AnyRef)], cause: Throwable) =
         throw new IllegalArgumentException(
           s"Cannot instantiate router [$fqn], defined in [$key], " +
           s"make sure it extends [${classOf[RouterConfig]}] and has constructor with " +

--- a/actor/src/main/scala/org/apache/pekko/actor/DynamicAccess.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/DynamicAccess.scala
@@ -40,13 +40,13 @@ import pekko.annotation.DoNotInherit
    * val obj = DynamicAccess.createInstanceFor(clazz, Seq(classOf[Config] -> config, classOf[String] -> name))
    * }}}
    */
-  def createInstanceFor[T: ClassTag](clazz: Class[_], args: immutable.Seq[(Class[_], AnyRef)]): Try[T]
+  def createInstanceFor[T: ClassTag](clazz: Class[?], args: immutable.Seq[(Class[?], AnyRef)]): Try[T]
 
   /**
    * Obtain a `Class[_]` object loaded with the right class loader (i.e. the one
    * returned by `classLoader`).
    */
-  def getClassFor[T: ClassTag](fqcn: String): Try[Class[_ <: T]]
+  def getClassFor[T: ClassTag](fqcn: String): Try[Class[? <: T]]
 
   def classIsOnClasspath(fqcn: String): Boolean
 
@@ -57,7 +57,7 @@ import pekko.annotation.DoNotInherit
    * `args` argument. The exact usage of args depends on which type is requested,
    * see the relevant requesting code for details.
    */
-  def createInstanceFor[T: ClassTag](fqcn: String, args: immutable.Seq[(Class[_], AnyRef)]): Try[T]
+  def createInstanceFor[T: ClassTag](fqcn: String, args: immutable.Seq[(Class[?], AnyRef)]): Try[T]
 
   /**
    * Obtain the Scala “object” instance for the given fully-qualified class name, if there is one.

--- a/actor/src/main/scala/org/apache/pekko/actor/Extension.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Extension.scala
@@ -139,5 +139,5 @@ trait ExtensionIdProvider {
   /**
    * Returns the canonical ExtensionId for this Extension
    */
-  def lookup: ExtensionId[_ <: Extension]
+  def lookup: ExtensionId[? <: Extension]
 }

--- a/actor/src/main/scala/org/apache/pekko/actor/FSM.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/FSM.scala
@@ -229,13 +229,13 @@ object FSM {
 
     def canEqual(that: Any): Boolean = {
       that match {
-        case _: State[_, _] => true
+        case _: State[?, ?] => true
         case _              => false
       }
     }
 
     override def equals(that: Any) = that match {
-      case other: State[_, _] =>
+      case other: State[?, ?] =>
         other.canEqual(this) &&
         this.stateName == other.stateName &&
         this.stateData == other.stateData &&

--- a/actor/src/main/scala/org/apache/pekko/actor/FaultHandling.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/FaultHandling.scala
@@ -245,17 +245,17 @@ object SupervisorStrategy extends SupervisorStrategyLowPriorityImplicits {
    * Implicit conversion from `Seq` of Throwables to a `Decider`.
    * This maps the given Throwables to restarts, otherwise escalates.
    */
-  implicit def seqThrowable2Decider(trapExit: immutable.Seq[Class[_ <: Throwable]]): Decider = makeDecider(trapExit)
+  implicit def seqThrowable2Decider(trapExit: immutable.Seq[Class[? <: Throwable]]): Decider = makeDecider(trapExit)
 
   type Decider = PartialFunction[Throwable, Directive]
   type JDecider = pekko.japi.Function[Throwable, Directive]
-  type CauseDirective = (Class[_ <: Throwable], Directive)
+  type CauseDirective = (Class[? <: Throwable], Directive)
 
   /**
    * Decider builder which just checks whether one of
    * the given Throwables matches the cause and restarts, otherwise escalates.
    */
-  def makeDecider(trapExit: immutable.Seq[Class[_ <: Throwable]]): Decider = {
+  def makeDecider(trapExit: immutable.Seq[Class[? <: Throwable]]): Decider = {
     case x => if (trapExit.exists(_.isInstance(x))) Restart else Escalate
   }
 
@@ -263,7 +263,7 @@ object SupervisorStrategy extends SupervisorStrategyLowPriorityImplicits {
    * Decider builder which just checks whether one of
    * the given Throwables matches the cause and restarts, otherwise escalates.
    */
-  def makeDecider(trapExit: JIterable[Class[_ <: Throwable]]): Decider = makeDecider(immutableSeq(trapExit))
+  def makeDecider(trapExit: JIterable[Class[? <: Throwable]]): Decider = makeDecider(immutableSeq(trapExit))
 
   /**
    * Decider builder for Iterables of cause-directive pairs, e.g. a map obtained
@@ -506,13 +506,13 @@ case class AllForOneStrategy(
   /**
    * Java API
    */
-  def this(maxNrOfRetries: Int, withinTimeRange: Duration, trapExit: JIterable[Class[_ <: Throwable]]) =
+  def this(maxNrOfRetries: Int, withinTimeRange: Duration, trapExit: JIterable[Class[? <: Throwable]]) =
     this(maxNrOfRetries, withinTimeRange)(SupervisorStrategy.makeDecider(trapExit))
 
   /**
    * Java API
    */
-  def this(maxNrOfRetries: Int, withinTimeRange: java.time.Duration, trapExit: JIterable[Class[_ <: Throwable]]) =
+  def this(maxNrOfRetries: Int, withinTimeRange: java.time.Duration, trapExit: JIterable[Class[? <: Throwable]]) =
     this(maxNrOfRetries, withinTimeRange.asScala)(SupervisorStrategy.makeDecider(trapExit))
 
   /**
@@ -618,13 +618,13 @@ case class OneForOneStrategy(
   /**
    * Java API
    */
-  def this(maxNrOfRetries: Int, withinTimeRange: Duration, trapExit: JIterable[Class[_ <: Throwable]]) =
+  def this(maxNrOfRetries: Int, withinTimeRange: Duration, trapExit: JIterable[Class[? <: Throwable]]) =
     this(maxNrOfRetries, withinTimeRange)(SupervisorStrategy.makeDecider(trapExit))
 
   /**
    * Java API
    */
-  def this(maxNrOfRetries: Int, withinTimeRange: java.time.Duration, trapExit: JIterable[Class[_ <: Throwable]]) =
+  def this(maxNrOfRetries: Int, withinTimeRange: java.time.Duration, trapExit: JIterable[Class[? <: Throwable]]) =
     this(maxNrOfRetries, withinTimeRange.asScala)(SupervisorStrategy.makeDecider(trapExit))
 
   /**

--- a/actor/src/main/scala/org/apache/pekko/actor/IndirectActorProducer.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/IndirectActorProducer.scala
@@ -45,7 +45,7 @@ trait IndirectActorProducer {
    * that the instance created for calling `actorClass` is not necessarily reused
    * later to produce the actor.
    */
-  def actorClass: Class[_ <: Actor]
+  def actorClass: Class[? <: Actor]
 }
 
 private[pekko] object IndirectActorProducer {
@@ -53,7 +53,7 @@ private[pekko] object IndirectActorProducer {
   val CreatorConsumerClass = classOf[CreatorConsumer]
   val TypedCreatorFunctionConsumerClass = classOf[TypedCreatorFunctionConsumer]
   @nowarn
-  def apply(clazz: Class[_], args: immutable.Seq[Any]): IndirectActorProducer = {
+  def apply(clazz: Class[?], args: immutable.Seq[Any]): IndirectActorProducer = {
     if (classOf[IndirectActorProducer].isAssignableFrom(clazz)) {
       def get1stArg[T]: T = args.head.asInstanceOf[T]
       def get2ndArg[T]: T = args.tail.head.asInstanceOf[T]
@@ -70,8 +70,8 @@ private[pekko] object IndirectActorProducer {
           Reflect.instantiate(clazz, args).asInstanceOf[IndirectActorProducer]
       }
     } else if (classOf[Actor].isAssignableFrom(clazz)) {
-      if (args.isEmpty) new NoArgsReflectConstructor(clazz.asInstanceOf[Class[_ <: Actor]])
-      else new ArgsReflectConstructor(clazz.asInstanceOf[Class[_ <: Actor]], args)
+      if (args.isEmpty) new NoArgsReflectConstructor(clazz.asInstanceOf[Class[? <: Actor]])
+      else new ArgsReflectConstructor(clazz.asInstanceOf[Class[? <: Actor]], args)
     } else throw new IllegalArgumentException(s"unknown actor creator [$clazz]")
   }
 }
@@ -87,7 +87,7 @@ private[pekko] class CreatorFunctionConsumer(creator: () => Actor) extends Indir
 /**
  * INTERNAL API
  */
-private[pekko] class CreatorConsumer(clazz: Class[_ <: Actor], creator: Creator[Actor]) extends IndirectActorProducer {
+private[pekko] class CreatorConsumer(clazz: Class[? <: Actor], creator: Creator[Actor]) extends IndirectActorProducer {
   override def actorClass = clazz
   override def produce() = creator.create()
 }
@@ -95,7 +95,7 @@ private[pekko] class CreatorConsumer(clazz: Class[_ <: Actor], creator: Creator[
 /**
  * INTERNAL API
  */
-private[pekko] class TypedCreatorFunctionConsumer(clz: Class[_ <: Actor], creator: () => Actor)
+private[pekko] class TypedCreatorFunctionConsumer(clz: Class[? <: Actor], creator: () => Actor)
     extends IndirectActorProducer {
   override def actorClass = clz
   override def produce() = creator()
@@ -104,7 +104,7 @@ private[pekko] class TypedCreatorFunctionConsumer(clz: Class[_ <: Actor], creato
 /**
  * INTERNAL API
  */
-private[pekko] class ArgsReflectConstructor(clz: Class[_ <: Actor], args: immutable.Seq[Any])
+private[pekko] class ArgsReflectConstructor(clz: Class[? <: Actor], args: immutable.Seq[Any])
     extends IndirectActorProducer {
   private[this] val constructor = Reflect.findConstructor(clz, args)
   override def actorClass = clz
@@ -114,7 +114,7 @@ private[pekko] class ArgsReflectConstructor(clz: Class[_ <: Actor], args: immuta
 /**
  * INTERNAL API
  */
-private[pekko] class NoArgsReflectConstructor(clz: Class[_ <: Actor]) extends IndirectActorProducer {
+private[pekko] class NoArgsReflectConstructor(clz: Class[? <: Actor]) extends IndirectActorProducer {
   Reflect.findConstructor(clz, List.empty)
   override def actorClass = clz
   override def produce() = Reflect.instantiate(clz)

--- a/actor/src/main/scala/org/apache/pekko/actor/Props.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Props.scala
@@ -87,13 +87,13 @@ object Props extends AbstractProps {
   def apply[T <: Actor: ClassTag](creator: => T): Props =
     mkProps(implicitly[ClassTag[T]].runtimeClass, () => creator)
 
-  private def mkProps(classOfActor: Class[_], ctor: () => Actor): Props =
+  private def mkProps(classOfActor: Class[?], ctor: () => Actor): Props =
     Props(classOf[TypedCreatorFunctionConsumer], classOfActor, ctor)
 
   /**
    * Scala API: create a Props given a class and its constructor arguments.
    */
-  def apply(clazz: Class[_], args: Any*): Props = apply(defaultDeploy, clazz, args.toList)
+  def apply(clazz: Class[?], args: Any*): Props = apply(defaultDeploy, clazz, args.toList)
 
 }
 
@@ -121,7 +121,7 @@ object Props extends AbstractProps {
  * }}}
  */
 @SerialVersionUID(2L)
-final case class Props(deploy: Deploy, clazz: Class[_], args: immutable.Seq[Any]) {
+final case class Props(deploy: Deploy, clazz: Class[?], args: immutable.Seq[Any]) {
 
   Props.validate(clazz)
 
@@ -131,7 +131,7 @@ final case class Props(deploy: Deploy, clazz: Class[_], args: immutable.Seq[Any]
 
   // derived property, does not need to be serialized
   @transient
-  private[this] var _cachedActorClass: Class[_ <: Actor] = _
+  private[this] var _cachedActorClass: Class[? <: Actor] = _
 
   /**
    * INTERNAL API
@@ -143,7 +143,7 @@ final case class Props(deploy: Deploy, clazz: Class[_], args: immutable.Seq[Any]
     _producer
   }
 
-  private[this] def cachedActorClass: Class[_ <: Actor] = {
+  private[this] def cachedActorClass: Class[? <: Actor] = {
     if (_cachedActorClass eq null)
       _cachedActorClass = producer.actorClass
 
@@ -223,7 +223,7 @@ final case class Props(deploy: Deploy, clazz: Class[_], args: immutable.Seq[Any]
    * the actor system to select special dispatchers or mailboxes in case
    * dependencies are encoded in the actor type.
    */
-  def actorClass(): Class[_ <: Actor] = cachedActorClass
+  def actorClass(): Class[? <: Actor] = cachedActorClass
 
   /**
    * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/actor/ReflectiveDynamicAccess.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ReflectiveDynamicAccess.scala
@@ -34,14 +34,14 @@ import pekko.annotation.DoNotInherit
 @DoNotInherit
 class ReflectiveDynamicAccess(val classLoader: ClassLoader) extends DynamicAccess {
 
-  override def getClassFor[T: ClassTag](fqcn: String): Try[Class[_ <: T]] =
-    Try[Class[_ <: T]] {
-      val c = Class.forName(fqcn, false, classLoader).asInstanceOf[Class[_ <: T]]
+  override def getClassFor[T: ClassTag](fqcn: String): Try[Class[? <: T]] =
+    Try[Class[? <: T]] {
+      val c = Class.forName(fqcn, false, classLoader).asInstanceOf[Class[? <: T]]
       val t = implicitly[ClassTag[T]].runtimeClass
       if (t.isAssignableFrom(c)) c else throw new ClassCastException(t.toString + " is not assignable from " + c)
     }
 
-  override def createInstanceFor[T: ClassTag](clazz: Class[_], args: immutable.Seq[(Class[_], AnyRef)]): Try[T] =
+  override def createInstanceFor[T: ClassTag](clazz: Class[?], args: immutable.Seq[(Class[?], AnyRef)]): Try[T] =
     Try {
       val types = args.map(_._1).toArray
       val values = args.map(_._2).toArray
@@ -53,7 +53,7 @@ class ReflectiveDynamicAccess(val classLoader: ClassLoader) extends DynamicAcces
       else throw new ClassCastException(clazz.getName + " is not a subtype of " + t)
     }.recover { case i: InvocationTargetException if i.getTargetException ne null => throw i.getTargetException }
 
-  override def createInstanceFor[T: ClassTag](fqcn: String, args: immutable.Seq[(Class[_], AnyRef)]): Try[T] =
+  override def createInstanceFor[T: ClassTag](fqcn: String, args: immutable.Seq[(Class[?], AnyRef)]): Try[T] =
     getClassFor(fqcn).flatMap { c =>
       createInstanceFor(c, args)
     }

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/ChildrenContainer.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/ChildrenContainer.scala
@@ -59,14 +59,14 @@ private[pekko] object ChildrenContainer {
   final case class Creation() extends SuspendReason with WaitingForChildren
   case object Termination extends SuspendReason
 
-  class ChildRestartsIterable(stats: immutable.Map[_, ChildStats])
+  class ChildRestartsIterable(stats: immutable.Map[?, ChildStats])
       extends PartialImmutableValuesIterable[ChildStats, ChildRestartStats] {
     override final def apply(c: ChildStats) = c.asInstanceOf[ChildRestartStats]
     override final def isDefinedAt(c: ChildStats) = c.isInstanceOf[ChildRestartStats]
     override final def valuesIterator = stats.valuesIterator
   }
 
-  class ChildrenIterable(stats: immutable.Map[_, ChildStats])
+  class ChildrenIterable(stats: immutable.Map[?, ChildStats])
       extends PartialImmutableValuesIterable[ChildStats, ActorRef] {
     override final def apply(c: ChildStats) = c.asInstanceOf[ChildRestartStats].child
     override final def isDefinedAt(c: ChildStats) = c.isInstanceOf[ChildRestartStats]

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/Dispatch.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/Dispatch.scala
@@ -89,7 +89,7 @@ private[pekko] trait Dispatch { this: ActorCell =>
     // it properly in the normal way
     val actorClass = props.actorClass()
     val createMessage = mailboxType match {
-      case _: ProducesMessageQueue[_] if system.mailboxes.hasRequiredType(actorClass) =>
+      case _: ProducesMessageQueue[?] if system.mailboxes.hasRequiredType(actorClass) =>
         val req = system.mailboxes.getRequiredType(actorClass)
         if (req.isInstance(mbox.messageQueue)) Create(None)
         else {

--- a/actor/src/main/scala/org/apache/pekko/actor/setup/ActorSystemSetup.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/setup/ActorSystemSetup.scala
@@ -61,7 +61,7 @@ object ActorSystemSetup {
  * Constructor is *Internal API*. Use the factory methods [[ActorSystemSetup#create]] and [[ActorSystemSetup#apply]] to create
  * instances.
  */
-final class ActorSystemSetup private[pekko] (@InternalApi private[pekko] val setups: Map[Class[_], AnyRef]) {
+final class ActorSystemSetup private[pekko] (@InternalApi private[pekko] val setups: Map[Class[?], AnyRef]) {
 
   /**
    * Java API: Extract a concrete [[pekko.actor.setup.Setup]] of type `T` if it is defined in the settings.

--- a/actor/src/main/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfigurator.scala
@@ -38,7 +38,7 @@ object ForkJoinExecutorConfigurator {
     override def execute(r: Runnable): Unit =
       if (r ne null)
         super.execute(
-          (if (r.isInstanceOf[ForkJoinTask[_]]) r else new PekkoForkJoinTask(r)).asInstanceOf[ForkJoinTask[Any]])
+          (if (r.isInstanceOf[ForkJoinTask[?]]) r else new PekkoForkJoinTask(r)).asInstanceOf[ForkJoinTask[Any]])
       else
         throw new NullPointerException("Runnable was null")
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/ThreadPoolBuilder.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/ThreadPoolBuilder.scala
@@ -243,14 +243,14 @@ trait ExecutorServiceDelegate extends ExecutorService {
 
   def submit(runnable: Runnable) = executor.submit(runnable)
 
-  def invokeAll[T](callables: Collection[_ <: Callable[T]]) = executor.invokeAll(callables)
+  def invokeAll[T](callables: Collection[? <: Callable[T]]) = executor.invokeAll(callables)
 
-  def invokeAll[T](callables: Collection[_ <: Callable[T]], l: Long, timeUnit: TimeUnit) =
+  def invokeAll[T](callables: Collection[? <: Callable[T]], l: Long, timeUnit: TimeUnit) =
     executor.invokeAll(callables, l, timeUnit)
 
-  def invokeAny[T](callables: Collection[_ <: Callable[T]]) = executor.invokeAny(callables)
+  def invokeAny[T](callables: Collection[? <: Callable[T]]) = executor.invokeAny(callables)
 
-  def invokeAny[T](callables: Collection[_ <: Callable[T]], l: Long, timeUnit: TimeUnit) =
+  def invokeAny[T](callables: Collection[? <: Callable[T]], l: Long, timeUnit: TimeUnit) =
     executor.invokeAny(callables, l, timeUnit)
 }
 

--- a/actor/src/main/scala/org/apache/pekko/event/EventStream.scala
+++ b/actor/src/main/scala/org/apache/pekko/event/EventStream.scala
@@ -36,24 +36,24 @@ class EventStream(sys: ActorSystem, private val debug: Boolean) extends LoggingB
   def this(sys: ActorSystem) = this(sys, debug = false)
 
   type Event = Any
-  type Classifier = Class[_]
+  type Classifier = Class[?]
 
   /** Either the list of subscribed actors, or a ref to an [[pekko.event.EventStreamUnsubscriber]] */
   private val initiallySubscribedOrUnsubscriber = new AtomicReference[Either[Set[ActorRef], ActorRef]](Left(Set.empty))
 
-  protected implicit val subclassification: Subclassification[Classifier] = new Subclassification[Class[_]] {
-    def isEqual(x: Class[_], y: Class[_]) = x == y
-    def isSubclass(x: Class[_], y: Class[_]) = y.isAssignableFrom(x)
+  protected implicit val subclassification: Subclassification[Classifier] = new Subclassification[Class[?]] {
+    def isEqual(x: Class[?], y: Class[?]) = x == y
+    def isSubclass(x: Class[?], y: Class[?]) = y.isAssignableFrom(x)
   }
 
-  protected def classify(event: Any): Class[_] = event.getClass
+  protected def classify(event: Any): Class[?] = event.getClass
 
   protected def publish(event: Any, subscriber: ActorRef) = {
     if (sys == null && subscriber.isTerminated) unsubscribe(subscriber)
     else subscriber ! event
   }
 
-  override def subscribe(subscriber: ActorRef, channel: Class[_]): Boolean = {
+  override def subscribe(subscriber: ActorRef, channel: Class[?]): Boolean = {
     if (subscriber eq null) throw new IllegalArgumentException("subscriber is null")
     if (debug)
       publish(Logging.Debug(simpleName(this), this.getClass, "subscribing " + subscriber + " to channel " + channel))
@@ -61,7 +61,7 @@ class EventStream(sys: ActorSystem, private val debug: Boolean) extends LoggingB
     super.subscribe(subscriber, channel)
   }
 
-  override def unsubscribe(subscriber: ActorRef, channel: Class[_]): Boolean = {
+  override def unsubscribe(subscriber: ActorRef, channel: Class[?]): Boolean = {
     if (subscriber eq null) throw new IllegalArgumentException("subscriber is null")
     val ret = super.unsubscribe(subscriber, channel)
     unregisterIfNoMoreSubscribedChannels(subscriber)

--- a/actor/src/main/scala/org/apache/pekko/event/jul/JavaLogger.scala
+++ b/actor/src/main/scala/org/apache/pekko/event/jul/JavaLogger.scala
@@ -82,7 +82,7 @@ object Logger {
    * @param logSource - the textual representation of the source of this log stream
    * @return a Logger for the specified parameters
    */
-  def apply(logClass: Class[_], logSource: String): logging.Logger = logClass match {
+  def apply(logClass: Class[?], logSource: String): logging.Logger = logClass match {
     case c if c == classOf[DummyClassForStringSources] => apply(logSource)
     case _                                             => logging.Logger.getLogger(logClass.getName)
   }
@@ -110,12 +110,12 @@ object Logger {
 class JavaLoggingFilter(@unused settings: ActorSystem.Settings, eventStream: EventStream) extends LoggingFilter {
   import Logger.mapLevel
 
-  def isErrorEnabled(logClass: Class[_], logSource: String) =
+  def isErrorEnabled(logClass: Class[?], logSource: String) =
     (eventStream.logLevel >= ErrorLevel) && Logger(logClass, logSource).isLoggable(mapLevel(ErrorLevel))
-  def isWarningEnabled(logClass: Class[_], logSource: String) =
+  def isWarningEnabled(logClass: Class[?], logSource: String) =
     (eventStream.logLevel >= WarningLevel) && Logger(logClass, logSource).isLoggable(mapLevel(WarningLevel))
-  def isInfoEnabled(logClass: Class[_], logSource: String) =
+  def isInfoEnabled(logClass: Class[?], logSource: String) =
     (eventStream.logLevel >= InfoLevel) && Logger(logClass, logSource).isLoggable(mapLevel(InfoLevel))
-  def isDebugEnabled(logClass: Class[_], logSource: String) =
+  def isDebugEnabled(logClass: Class[?], logSource: String) =
     (eventStream.logLevel >= DebugLevel) && Logger(logClass, logSource).isLoggable(mapLevel(DebugLevel))
 }

--- a/actor/src/main/scala/org/apache/pekko/io/DnsProvider.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/DnsProvider.scala
@@ -36,12 +36,12 @@ trait DnsProvider {
    * DNS resolver actor. Should respond to [[pekko.io.dns.DnsProtocol.Resolve]] with
    * [[pekko.io.dns.DnsProtocol.Resolved]]
    */
-  def actorClass: Class[_ <: Actor]
+  def actorClass: Class[? <: Actor]
 
   /**
    * DNS manager class. Is responsible for creating resolvers and doing any cache cleanup.
    * The DNS extension will create one of these Actors. It should have a ctr that accepts
    * a [[DnsExt]]
    */
-  def managerClass: Class[_ <: Actor]
+  def managerClass: Class[? <: Actor]
 }

--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -255,7 +255,7 @@ object Util {
    * Returns an immutable.Seq representing the provided array of Classes,
    * an overloading of the generic immutableSeq in Util, to accommodate for erasure.
    */
-  def immutableSeq(arr: Array[Class[_]]): immutable.Seq[Class[_]] = immutableSeq[Class[_]](arr)
+  def immutableSeq(arr: Array[Class[?]]): immutable.Seq[Class[?]] = immutableSeq[Class[?]](arr)
 
   /**
    * Turns an array into an immutable Scala sequence (by copying it).
@@ -268,7 +268,7 @@ object Util {
    */
   def immutableSeq[T](iterable: java.lang.Iterable[T]): immutable.Seq[T] =
     iterable match {
-      case imm: immutable.Seq[_] => imm.asInstanceOf[immutable.Seq[T]]
+      case imm: immutable.Seq[?] => imm.asInstanceOf[immutable.Seq[T]]
       case other =>
         val i = other.iterator()
         if (i.hasNext) {

--- a/actor/src/main/scala/org/apache/pekko/pattern/CircuitBreaker.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/CircuitBreaker.scala
@@ -802,8 +802,8 @@ class CircuitBreaker(
       case _                       => allowExceptions.contains(ex.getClass.getName)
     })
 
-  private val failureFn: Try[_] => Boolean = {
-    case _: Success[_]                       => false
+  private val failureFn: Try[?] => Boolean = {
+    case _: Success[?]                       => false
     case Failure(t) if isIgnoredException(t) => false
     case _                                   => true
   }
@@ -862,7 +862,7 @@ class CircuitBreaker(
         val f = materialize(body)
 
         f.onComplete {
-          case _: Success[_] =>
+          case _: Success[?] =>
             notifyCallSuccessListeners(start)
             callSucceeds()
           case Failure(_) =>

--- a/actor/src/main/scala/org/apache/pekko/pattern/CircuitBreakersRegistry.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/CircuitBreakersRegistry.scala
@@ -42,7 +42,7 @@ object CircuitBreakersRegistry extends ExtensionId[CircuitBreakersRegistry] with
   /**
    * Returns the canonical ExtensionId for this Extension
    */
-  override def lookup: ExtensionId[_ <: Extension] = CircuitBreakersRegistry
+  override def lookup: ExtensionId[? <: Extension] = CircuitBreakersRegistry
 
   /**
    * Returns an instance of the extension identified by this ExtensionId instance.

--- a/actor/src/main/scala/org/apache/pekko/pattern/StatusReply.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/StatusReply.scala
@@ -56,7 +56,7 @@ final class StatusReply[+T] private (private val status: Try[T]) {
   def isSuccess: Boolean = status.isSuccess
 
   override def equals(other: Any): Boolean = other match {
-    case that: StatusReply[_] => status == that.status
+    case that: StatusReply[?] => status == that.status
     case _                    => false
   }
 
@@ -161,7 +161,7 @@ object StatusReply {
      * Also note that Pekko does not contain pre-build serializers for arbitrary exceptions.
      */
     def apply[T](exception: Throwable): StatusReply[T] = new StatusReply(ScalaFailure(exception))
-    def unapply(status: StatusReply[_]): Option[Throwable] =
+    def unapply(status: StatusReply[?]): Option[Throwable] =
       if (status != null && status.isError) Some(status.getError)
       else None
   }

--- a/actor/src/main/scala/org/apache/pekko/serialization/PrimitiveSerializers.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/PrimitiveSerializers.scala
@@ -51,7 +51,7 @@ import pekko.util.ByteString
     result
   }
 
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = {
     var result = 0L
     var i = 7
     while (i >= 0) {
@@ -89,7 +89,7 @@ import pekko.util.ByteString
     result
   }
 
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = {
     var result = 0
     var i = 3
     while (i >= 0) {
@@ -121,7 +121,7 @@ import pekko.util.ByteString
 
   override def toBinary(o: AnyRef): Array[Byte] = o.asInstanceOf[String].getBytes(StandardCharsets.UTF_8)
 
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef =
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef =
     new String(bytes, StandardCharsets.UTF_8)
 
 }
@@ -154,7 +154,7 @@ import pekko.util.ByteString
     result
   }
 
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = {
     ByteString(bytes)
   }
 
@@ -204,7 +204,7 @@ import pekko.util.ByteString
     result
   }
 
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = {
     bytes(0) match {
       case TrueB  => TRUE
       case FalseB => FALSE

--- a/actor/src/main/scala/org/apache/pekko/serialization/SerializationSetup.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/SerializationSetup.scala
@@ -55,7 +55,7 @@ object SerializerDetails {
    * @param useFor A set of classes or superclasses to bind to the serializer, selection works just as if
    *               the classes, the alias and the serializer had been in the config.
    */
-  def apply(alias: String, serializer: Serializer, useFor: immutable.Seq[Class[_]]): SerializerDetails =
+  def apply(alias: String, serializer: Serializer, useFor: immutable.Seq[Class[?]]): SerializerDetails =
     new SerializerDetails(alias, serializer, useFor)
 
   /**
@@ -65,7 +65,7 @@ object SerializerDetails {
    * @param useFor A set of classes or superclasses to bind to the serializer, selection works just as if
    *               the classes, the alias and the serializer had been in the config.
    */
-  def create(alias: String, serializer: Serializer, useFor: java.util.List[Class[_]]): SerializerDetails =
+  def create(alias: String, serializer: Serializer, useFor: java.util.List[Class[?]]): SerializerDetails =
     apply(alias, serializer, useFor.asScala.toVector)
 
 }
@@ -77,4 +77,4 @@ object SerializerDetails {
 final class SerializerDetails private (
     val alias: String,
     val serializer: Serializer,
-    val useFor: immutable.Seq[Class[_]])
+    val useFor: immutable.Seq[Class[?]])

--- a/actor/src/main/scala/org/apache/pekko/serialization/Serializer.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/Serializer.scala
@@ -74,7 +74,7 @@ trait Serializer {
    * the class should be loaded using ActorSystem.dynamicAccess.
    */
   @throws(classOf[NotSerializableException])
-  def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef
+  def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef
 
   /**
    * Java API: deserialize without type hint
@@ -85,7 +85,7 @@ trait Serializer {
    * Java API: deserialize with type hint
    */
   @throws(classOf[NotSerializableException])
-  final def fromBinary(bytes: Array[Byte], clazz: Class[_]): AnyRef = fromBinary(bytes, Option(clazz))
+  final def fromBinary(bytes: Array[Byte], clazz: Class[?]): AnyRef = fromBinary(bytes, Option(clazz))
 }
 
 object Serializers {
@@ -163,7 +163,7 @@ abstract class SerializerWithStringManifest extends Serializer {
   @throws(classOf[NotSerializableException])
   def fromBinary(bytes: Array[Byte], manifest: String): AnyRef
 
-  final def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
+  final def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = {
     val manifestString = manifest match {
       case Some(c) => c.getName
       case None    => ""
@@ -274,7 +274,7 @@ object BaseSerializer {
 
   /** INTERNAL API */
   @InternalApi
-  private[pekko] def identifierFromConfig(clazz: Class[_], system: ExtendedActorSystem): Int =
+  private[pekko] def identifierFromConfig(clazz: Class[?], system: ExtendedActorSystem): Int =
     system.settings.config.getInt(s"""$SerializationIdentifiers."${clazz.getName}"""")
 
   /** INTERNAL API */
@@ -292,13 +292,13 @@ object BaseSerializer {
 abstract class JSerializer extends Serializer {
 
   @throws(classOf[NotSerializableException])
-  final def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef =
+  final def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef =
     fromBinaryJava(bytes, manifest.orNull)
 
   /**
    * This method must be implemented, manifest may be null.
    */
-  protected def fromBinaryJava(bytes: Array[Byte], manifest: Class[_]): AnyRef
+  protected def fromBinaryJava(bytes: Array[Byte], manifest: Class[?]): AnyRef
 }
 
 object NullSerializer extends NullSerializer
@@ -353,7 +353,7 @@ class JavaSerializer(val system: ExtendedActorSystem) extends BaseSerializer {
   }
 
   @throws(classOf[NotSerializableException])
-  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = {
     val in = new ClassLoaderObjectInputStream(system.dynamicAccess.classLoader, new ByteArrayInputStream(bytes))
     val obj = JavaSerializer.currentSystem.withValue(system) { in.readObject }
     in.close()
@@ -386,7 +386,7 @@ final case class DisabledJavaSerializer(system: ExtendedActorSystem) extends Ser
   }
 
   @throws(classOf[NotSerializableException])
-  override def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = {
     log.warning(
       LogMarker.Security,
       "Incoming message attempted to use Java Serialization even though `pekko.actor.allow-java-serialization = off` was set!")
@@ -426,7 +426,7 @@ class NullSerializer extends Serializer {
   def identifier = 0
   def toBinary(o: AnyRef): Array[Byte] = nullAsBytes
   @throws(classOf[NotSerializableException])
-  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = null
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = null
 }
 
 /**
@@ -445,7 +445,7 @@ class ByteArraySerializer(val system: ExtendedActorSystem) extends BaseSerialize
   }
 
   @throws(classOf[NotSerializableException])
-  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = bytes
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = bytes
 
   override def toBinary(o: AnyRef, buf: ByteBuffer): Unit =
     o match {

--- a/actor/src/main/scala/org/apache/pekko/util/BoundedBlockingQueue.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/BoundedBlockingQueue.scala
@@ -30,11 +30,11 @@ class BoundedBlockingQueue[E <: AnyRef](val maxCapacity: Int, private val backin
 
   backing match {
     case null => throw new IllegalArgumentException("Backing Queue may not be null")
-    case b: BlockingQueue[_] =>
+    case b: BlockingQueue[?] =>
       require(maxCapacity > 0)
       require(b.size() == 0)
       require(b.remainingCapacity >= maxCapacity)
-    case b: Queue[_] =>
+    case b: Queue[?] =>
       require(b.size() == 0)
       require(maxCapacity > 0)
   }
@@ -186,9 +186,9 @@ class BoundedBlockingQueue[E <: AnyRef](val maxCapacity: Int, private val backin
     finally lock.unlock()
   }
 
-  def drainTo(c: Collection[_ >: E]): Int = drainTo(c, Int.MaxValue)
+  def drainTo(c: Collection[? >: E]): Int = drainTo(c, Int.MaxValue)
 
-  def drainTo(c: Collection[_ >: E], maxElements: Int): Int = {
+  def drainTo(c: Collection[? >: E], maxElements: Int): Int = {
     if (c eq null) throw new NullPointerException
     if (c eq this) throw new IllegalArgumentException
     if (c eq backing) throw new IllegalArgumentException
@@ -211,13 +211,13 @@ class BoundedBlockingQueue[E <: AnyRef](val maxCapacity: Int, private val backin
     }
   }
 
-  override def containsAll(c: Collection[_]): Boolean = {
+  override def containsAll(c: Collection[?]): Boolean = {
     lock.lock()
     try backing.containsAll(c)
     finally lock.unlock()
   }
 
-  override def removeAll(c: Collection[_]): Boolean = {
+  override def removeAll(c: Collection[?]): Boolean = {
     lock.lock()
     try {
       if (backing.removeAll(c)) {
@@ -229,7 +229,7 @@ class BoundedBlockingQueue[E <: AnyRef](val maxCapacity: Int, private val backin
     } finally lock.unlock()
   }
 
-  override def retainAll(c: Collection[_]): Boolean = {
+  override def retainAll(c: Collection[?]): Boolean = {
     lock.lock()
     try {
       if (backing.retainAll(c)) {

--- a/actor/src/main/scala/org/apache/pekko/util/BoxedType.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/BoxedType.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.util
 object BoxedType {
   import java.{ lang => jl }
 
-  private val toBoxed = Map[Class[_], Class[_]](
+  private val toBoxed = Map[Class[?], Class[?]](
     classOf[Boolean] -> classOf[jl.Boolean],
     classOf[Byte] -> classOf[jl.Byte],
     classOf[Char] -> classOf[jl.Character],
@@ -27,5 +27,5 @@ object BoxedType {
     classOf[Double] -> classOf[jl.Double],
     classOf[Unit] -> classOf[scala.runtime.BoxedUnit])
 
-  final def apply(c: Class[_]): Class[_] = if (c.isPrimitive) toBoxed(c) else c
+  final def apply(c: Class[?]): Class[?] = if (c.isPrimitive) toBoxed(c) else c
 }

--- a/actor/src/main/scala/org/apache/pekko/util/ClassLoaderObjectInputStream.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ClassLoaderObjectInputStream.scala
@@ -23,7 +23,7 @@ import java.io.{ InputStream, ObjectInputStream, ObjectStreamClass }
  * @param is - the InputStream that is wrapped
  */
 class ClassLoaderObjectInputStream(classLoader: ClassLoader, is: InputStream) extends ObjectInputStream(is) {
-  override protected def resolveClass(objectStreamClass: ObjectStreamClass): Class[_] =
+  override protected def resolveClass(objectStreamClass: ObjectStreamClass): Class[?] =
     try Class.forName(objectStreamClass.getName, false, classLoader)
     catch {
       case _: ClassNotFoundException => super.resolveClass(objectStreamClass)

--- a/actor/src/main/scala/org/apache/pekko/util/LineNumbers.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/LineNumbers.scala
@@ -196,7 +196,7 @@ object LineNumbers {
     }
   }
 
-  private def getStreamForClass(c: Class[_]): Option[(InputStream, None.type)] = {
+  private def getStreamForClass(c: Class[?]): Option[(InputStream, None.type)] = {
     val resource = c.getName.replace('.', '/') + ".class"
     val cl = c.getClassLoader
     val r = cl.getResourceAsStream(resource)

--- a/actor/src/main/scala/org/apache/pekko/util/TypedMultiMap.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/TypedMultiMap.scala
@@ -109,7 +109,7 @@ class TypedMultiMap[T <: AnyRef, K[_ <: T]] private (private val map: Map[T, Set
 
   override def toString: String = s"TypedMultiMap($map)"
   override def equals(other: Any) = other match {
-    case o: TypedMultiMap[_, _] => map == o.map
+    case o: TypedMultiMap[?, ?] => map == o.map
     case _                      => false
   }
   override def hashCode: Int = map.hashCode

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/typed/TypedBenchmarkActors.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/typed/TypedBenchmarkActors.scala
@@ -161,7 +161,7 @@ object TypedBenchmarkActors {
   }
 
   private def startPingPongActorPairs(
-      ctx: ActorContext[_],
+      ctx: ActorContext[?],
       messagesPerPair: Int,
       numPairs: Int,
       dispatcher: String): (Vector[(ActorRef[Message], ActorRef[Message])], CountDownLatch) = {

--- a/bench-jmh/src/main/scala/org/apache/pekko/remote/artery/CodecBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/remote/artery/CodecBenchmark.scala
@@ -294,7 +294,7 @@ object CodecBenchmark {
 
     override def toBinary(o: AnyRef): Array[Byte] = Preserialized
 
-    override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef =
+    override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef =
       fromBinary(ByteBuffer.wrap(bytes), "NoManifestForYou")
   }
 

--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/FlowMapBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/FlowMapBenchmark.scala
@@ -110,7 +110,7 @@ class FlowMapBenchmark {
   }
 
   // source setup
-  private def mkMaps[O, Mat](source: Source[O, Mat], count: Int)(flow: => Graph[FlowShape[O, O], _]): Source[O, Mat] = {
+  private def mkMaps[O, Mat](source: Source[O, Mat], count: Int)(flow: => Graph[FlowShape[O, O], ?]): Source[O, Mat] = {
     var f = source
     for (_ <- 1 to count)
       f = f.via(flow)

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/StackBench.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/StackBench.scala
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.{ Benchmark, Measurement, Scope, State }
 class StackBench {
 
   class CustomSecurtyManager extends SecurityManager {
-    def getTrace: Array[Class[_]] =
+    def getTrace: Array[Class[?]] =
       getClassContext
   }
 
@@ -32,7 +32,7 @@ class StackBench {
   }
 
   @Benchmark
-  def securityManager(): Array[Class[_]] = {
+  def securityManager(): Array[Class[?]] = {
     (new CustomSecurtyManager).getTrace
   }
 

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ClusterShardingQuery.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ClusterShardingQuery.scala
@@ -36,7 +36,7 @@ sealed trait ClusterShardingQuery
  *
  * For the statistics for the entire cluster, see [[GetClusterShardingStats]].
  */
-final case class GetShardRegionState(entityTypeKey: EntityTypeKey[_], replyTo: ActorRef[CurrentShardRegionState])
+final case class GetShardRegionState(entityTypeKey: EntityTypeKey[?], replyTo: ActorRef[CurrentShardRegionState])
     extends ClusterShardingQuery {
 
   /**
@@ -45,7 +45,7 @@ final case class GetShardRegionState(entityTypeKey: EntityTypeKey[_], replyTo: A
    * Query the ShardRegion state for the given entity type key. This will get the state of the
    * local ShardRegion's state.
    */
-  def this(entityTypeKey: javadsl.EntityTypeKey[_], replyTo: ActorRef[CurrentShardRegionState]) =
+  def this(entityTypeKey: javadsl.EntityTypeKey[?], replyTo: ActorRef[CurrentShardRegionState]) =
     this(entityTypeKey.asScala, replyTo)
 }
 
@@ -61,7 +61,7 @@ final case class GetShardRegionState(entityTypeKey: EntityTypeKey[_], replyTo: A
  * @param replyTo the actor to send the result to
  */
 final case class GetClusterShardingStats(
-    entityTypeKey: EntityTypeKey[_],
+    entityTypeKey: EntityTypeKey[?],
     timeout: FiniteDuration,
     replyTo: ActorRef[ClusterShardingStats])
     extends ClusterShardingQuery {
@@ -74,7 +74,7 @@ final case class GetClusterShardingStats(
    * shard regions the reply will contain an empty map of regions.
    */
   def this(
-      entityTypeKey: javadsl.EntityTypeKey[_],
+      entityTypeKey: javadsl.EntityTypeKey[?],
       timeout: java.time.Duration,
       replyTo: ActorRef[ClusterShardingStats]) =
     this(entityTypeKey.asScala, JavaDurationConverters.asFiniteDuration(timeout), replyTo)

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -34,7 +34,7 @@ import pekko.util.JavaDurationConverters._
 object ClusterShardingSettings {
 
   /** Scala API: Creates new cluster sharding settings object */
-  def apply(system: ActorSystem[_]): ClusterShardingSettings =
+  def apply(system: ActorSystem[?]): ClusterShardingSettings =
     fromConfig(system.settings.config.getConfig("pekko.cluster.sharding"))
 
   def fromConfig(config: Config): ClusterShardingSettings = {
@@ -44,7 +44,7 @@ object ClusterShardingSettings {
   }
 
   /** Java API: Creates new cluster sharding settings object */
-  def create(system: ActorSystem[_]): ClusterShardingSettings =
+  def create(system: ActorSystem[?]): ClusterShardingSettings =
     apply(system)
 
   /** INTERNAL API: Intended only for internal use, it is not recommended to keep converting between the setting types */

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingExtension.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingExtension.scala
@@ -29,10 +29,10 @@ import java.util.{ Map => JMap }
  */
 object ReplicatedShardingExtension extends ExtensionId[ReplicatedShardingExtension] {
 
-  override def createExtension(system: ActorSystem[_]): ReplicatedShardingExtension =
+  override def createExtension(system: ActorSystem[?]): ReplicatedShardingExtension =
     new ReplicatedShardingExtensionImpl(system)
 
-  def get(system: ActorSystem[_]): ReplicatedShardingExtension = apply(system)
+  def get(system: ActorSystem[?]): ReplicatedShardingExtension = apply(system)
 
 }
 

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ShardedDaemonProcessSettings.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ShardedDaemonProcessSettings.scala
@@ -27,12 +27,12 @@ import pekko.util.JavaDurationConverters._
 object ShardedDaemonProcessSettings {
 
   /** Scala API: Create default settings for system */
-  def apply(system: ActorSystem[_]): ShardedDaemonProcessSettings = {
+  def apply(system: ActorSystem[?]): ShardedDaemonProcessSettings = {
     fromConfig(system.settings.config.getConfig("pekko.cluster.sharded-daemon-process"))
   }
 
   /** Java API: Create default settings for system */
-  def create(system: ActorSystem[_]): ShardedDaemonProcessSettings =
+  def create(system: ActorSystem[?]): ShardedDaemonProcessSettings =
     apply(system)
 
   /**

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingConsumerController.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingConsumerController.scala
@@ -55,7 +55,7 @@ object ShardingConsumerController {
      * Scala API: Factory method from config `pekko.reliable-delivery.sharding.consumer-controller`
      * of the `ActorSystem`.
      */
-    def apply(system: ActorSystem[_]): Settings =
+    def apply(system: ActorSystem[?]): Settings =
       apply(system.settings.config.getConfig("pekko.reliable-delivery.sharding.consumer-controller"))
 
     /**
@@ -70,7 +70,7 @@ object ShardingConsumerController {
      * Java API: Factory method from config `pekko.reliable-delivery.sharding.consumer-controller`
      * of the `ActorSystem`.
      */
-    def create(system: ActorSystem[_]): Settings =
+    def create(system: ActorSystem[?]): Settings =
       apply(system)
 
     /**

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
@@ -175,7 +175,7 @@ object ShardingProducerController {
      * Scala API: Factory method from config `pekko.reliable-delivery.sharding.producer-controller`
      * of the `ActorSystem`.
      */
-    def apply(system: ActorSystem[_]): Settings =
+    def apply(system: ActorSystem[?]): Settings =
       apply(system.settings.config.getConfig("pekko.reliable-delivery.sharding.producer-controller"))
 
     /**
@@ -195,7 +195,7 @@ object ShardingProducerController {
      * Java API: Factory method from config `pekko.reliable-delivery.sharding.producer-controller`
      * of the `ActorSystem`.
      */
-    def create(system: ActorSystem[_]): Settings =
+    def create(system: ActorSystem[?]): Settings =
       apply(system)
 
     /**

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/internal/ShardingConsumerControllerImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/internal/ShardingConsumerControllerImpl.scala
@@ -46,7 +46,7 @@ import pekko.cluster.sharding.typed.delivery.ShardingConsumerController
   private def waitForStart[A](
       context: ActorContext[ConsumerController.Command[A]],
       settings: ShardingConsumerController.Settings,
-      consumer: ActorRef[_]): Behavior[ConsumerController.Command[A]] = {
+      consumer: ActorRef[?]): Behavior[ConsumerController.Command[A]] = {
     Behaviors.withStash(settings.bufferSize) { stashBuffer =>
       Behaviors
         .receiveMessage[ConsumerController.Command[A]] {

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -100,14 +100,14 @@ import pekko.util.JavaDurationConverters._
 }
 
 /** INTERNAL API */
-@InternalApi private[pekko] final class ClusterShardingImpl(system: ActorSystem[_])
+@InternalApi private[pekko] final class ClusterShardingImpl(system: ActorSystem[?])
     extends javadsl.ClusterSharding
     with scaladsl.ClusterSharding {
 
   import pekko.actor.typed.scaladsl.adapter._
 
   require(
-    system.isInstanceOf[ActorSystemAdapter[_]],
+    system.isInstanceOf[ActorSystemAdapter[?]],
     "only adapted classic actor systems can be used for cluster features")
 
   private val cluster = Cluster(system)
@@ -333,7 +333,7 @@ import pekko.util.JavaDurationConverters._
 
   override def equals(other: Any): Boolean =
     other match {
-      case eri: EntityRefImpl[_] =>
+      case eri: EntityRefImpl[?] =>
         (eri.entityId == entityId) &&
         (eri.typeKey == typeKey) &&
         (eri.dataCenter == dataCenter)
@@ -412,13 +412,13 @@ import pekko.util.JavaDurationConverters._
   // impl InternalRecipientRef
   override def provider: ActorRefProvider = {
     import pekko.actor.typed.scaladsl.adapter._
-    shardRegion.toTyped.asInstanceOf[InternalRecipientRef[_]].provider
+    shardRegion.toTyped.asInstanceOf[InternalRecipientRef[?]].provider
   }
 
   // impl InternalRecipientRef
   def isTerminated: Boolean = {
     import pekko.actor.typed.scaladsl.adapter._
-    shardRegion.toTyped.asInstanceOf[InternalRecipientRef[_]].isTerminated
+    shardRegion.toTyped.asInstanceOf[InternalRecipientRef[?]].isTerminated
   }
 
   override def toString: String = s"EntityRef($typeKey, $entityId)"
@@ -440,7 +440,7 @@ import pekko.util.JavaDurationConverters._
   import pekko.cluster.sharding.ShardRegion.{ Passivate => ClassicPassivate }
 
   def behavior(stopMessage: Any): Behavior[scaladsl.ClusterSharding.ShardCommand] = {
-    def sendClassicPassivate(entity: ActorRef[_], ctx: TypedActorContext[_]): Unit = {
+    def sendClassicPassivate(entity: ActorRef[?], ctx: TypedActorContext[?]): Unit = {
       val pathToShard = entity.toClassic.path.elements.take(4).mkString("/")
       ctx.asScala.system.toClassic.actorSelection(pathToShard).tell(ClassicPassivate(stopMessage), entity.toClassic)
     }

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ReplicatedShardingExtensionImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ReplicatedShardingExtensionImpl.scala
@@ -37,7 +37,7 @@ import pekko.util.ccompat.JavaConverters._
  * INTERNAL API
  */
 @InternalApi
-private[pekko] final class ReplicatedShardingExtensionImpl(system: ActorSystem[_]) extends ReplicatedShardingExtension {
+private[pekko] final class ReplicatedShardingExtensionImpl(system: ActorSystem[?]) extends ReplicatedShardingExtension {
 
   private val counter = new AtomicLong(0)
 

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -101,7 +101,7 @@ private[pekko] object ShardedDaemonProcessImpl {
  * INTERNAL API
  */
 @InternalApi
-private[pekko] final class ShardedDaemonProcessImpl(system: ActorSystem[_])
+private[pekko] final class ShardedDaemonProcessImpl(system: ActorSystem[?])
     extends javadsl.ShardedDaemonProcess
     with scaladsl.ShardedDaemonProcess {
 

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardingSerializer.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardingSerializer.scala
@@ -39,13 +39,13 @@ import java.nio.ByteBuffer
   private val ShardingEnvelopeManifest = "a"
 
   override def manifest(o: AnyRef): String = o match {
-    case _: ShardingEnvelope[_] => ShardingEnvelopeManifest
+    case _: ShardingEnvelope[?] => ShardingEnvelopeManifest
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }
 
   override def toBinary(o: AnyRef): Array[Byte] = o match {
-    case env: ShardingEnvelope[_] =>
+    case env: ShardingEnvelope[?] =>
       val builder = ShardingMessages.ShardingEnvelope.newBuilder()
       builder.setEntityId(env.entityId)
       builder.setMessage(payloadSupport.payloadBuilder(env.message))
@@ -68,7 +68,7 @@ import java.nio.ByteBuffer
 
   // buffer based avoiding a copy for artery
   override def toBinary(o: AnyRef, buf: ByteBuffer): Unit = o match {
-    case env: ShardingEnvelope[_] =>
+    case env: ShardingEnvelope[?] =>
       val builder = ShardingMessages.ShardingEnvelope.newBuilder()
       builder.setEntityId(env.entityId)
       builder.setMessage(payloadSupport.payloadBuilder(env.message))

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/testkit/TestEntityRefImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/testkit/TestEntityRefImpl.scala
@@ -67,12 +67,12 @@ import pekko.util.Timeout
 
   // impl InternalRecipientRef
   override def provider: ActorRefProvider = {
-    probe.asInstanceOf[InternalRecipientRef[_]].provider
+    probe.asInstanceOf[InternalRecipientRef[?]].provider
   }
 
   // impl InternalRecipientRef
   def isTerminated: Boolean = {
-    probe.asInstanceOf[InternalRecipientRef[_]].isTerminated
+    probe.asInstanceOf[InternalRecipientRef[?]].isTerminated
   }
 
   override def toString: String = s"TestEntityRef($entityId)"

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -40,7 +40,7 @@ trait EntityFactory[M] {
 }
 
 object ClusterSharding {
-  def get(system: ActorSystem[_]): ClusterSharding =
+  def get(system: ActorSystem[?]): ClusterSharding =
     scaladsl.ClusterSharding(system).asJava
 
   /**

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ShardedDaemonProcess.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ShardedDaemonProcess.scala
@@ -24,7 +24,7 @@ import pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import pekko.cluster.sharding.typed.ShardedDaemonProcessSettings
 
 object ShardedDaemonProcess {
-  def get(system: ActorSystem[_]): ShardedDaemonProcess =
+  def get(system: ActorSystem[?]): ShardedDaemonProcess =
     pekko.cluster.sharding.typed.scaladsl.ShardedDaemonProcess(system).asJava
 }
 

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/scaladsl/ClusterSharding.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/scaladsl/ClusterSharding.scala
@@ -38,7 +38,7 @@ import pekko.util.Timeout
 
 object ClusterSharding extends ExtensionId[ClusterSharding] {
 
-  override def createExtension(system: ActorSystem[_]): ClusterSharding =
+  override def createExtension(system: ActorSystem[?]): ClusterSharding =
     new ClusterShardingImpl(system)
 
   /**
@@ -538,7 +538,7 @@ object EntityTypeKey {
 }
 
 object ClusterShardingSetup {
-  def apply[T <: Extension](createExtension: ActorSystem[_] => ClusterSharding): ClusterShardingSetup =
+  def apply[T <: Extension](createExtension: ActorSystem[?] => ClusterSharding): ClusterShardingSetup =
     new ClusterShardingSetup(createExtension(_))
 
 }
@@ -548,5 +548,5 @@ object ClusterShardingSetup {
  * to replace the default implementation of the [[ClusterSharding]] extension. Intended
  * for tests that need to replace extension with stub/mock implementations.
  */
-final class ClusterShardingSetup(createExtension: java.util.function.Function[ActorSystem[_], ClusterSharding])
+final class ClusterShardingSetup(createExtension: java.util.function.Function[ActorSystem[?], ClusterSharding])
     extends ExtensionSetup[ClusterSharding](ClusterSharding, createExtension)

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/scaladsl/ShardedDaemonProcess.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/scaladsl/ShardedDaemonProcess.scala
@@ -28,7 +28,7 @@ import pekko.cluster.sharding.typed.internal.ShardedDaemonProcessImpl
 import pekko.cluster.sharding.typed.javadsl
 
 object ShardedDaemonProcess extends ExtensionId[ShardedDaemonProcess] {
-  override def createExtension(system: ActorSystem[_]): ShardedDaemonProcess = new ShardedDaemonProcessImpl(system)
+  override def createExtension(system: ActorSystem[?]): ShardedDaemonProcess = new ShardedDaemonProcessImpl(system)
 }
 
 /**

--- a/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/DurableStateStoreQueryUsageCompileOnlySpec.scala
+++ b/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/DurableStateStoreQueryUsageCompileOnlySpec.scala
@@ -35,7 +35,7 @@ object DurableStateStoreQueryUsageCompileOnlySpec {
     val source: Source[DurableStateChange[Record], NotUsed] = durableStateStoreQuery.changes("tag", offset)
     source.map {
       case UpdatedDurableState(persistenceId, revision, value, offset, timestamp) => Some(value)
-      case _: DeletedDurableState[_]                                              => None
+      case _: DeletedDurableState[?]                                              => None
     }
     // #get-durable-state-store-query-example
   }

--- a/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlySpec.scala
+++ b/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlySpec.scala
@@ -30,7 +30,7 @@ import docs.org.apache.pekko.cluster.sharding.typed.ShardingCompileOnlySpec.Basi
 import scala.concurrent.Future
 
 class ExternalShardAllocationCompileOnlySpec {
-  val system: ActorSystem[_] = ???
+  val system: ActorSystem[?] = ???
 
   val sharding = ClusterSharding(system)
 

--- a/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/HelloWorldPersistentEntityExample.scala
+++ b/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/HelloWorldPersistentEntityExample.scala
@@ -32,7 +32,7 @@ object HelloWorldPersistentEntityExample {
   import pekko.cluster.sharding.typed.scaladsl.Entity
   import pekko.util.Timeout
 
-  class HelloWorldService(system: ActorSystem[_]) {
+  class HelloWorldService(system: ActorSystem[?]) {
     import system.executionContext
 
     private val sharding = ClusterSharding(system)

--- a/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingCompileOnlySpec.scala
+++ b/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingCompileOnlySpec.scala
@@ -31,7 +31,7 @@ object ReplicatedShardingCompileOnlySpec {
 
   sealed trait Command
 
-  val system: ActorSystem[_] = ???
+  val system: ActorSystem[?] = ???
 
   object MyEventSourcedBehavior {
     def apply(replicationId: ReplicationId): Behavior[Command] = ???

--- a/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/JoinConfigCompatCheckerClusterShardingSpec.scala
+++ b/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/JoinConfigCompatCheckerClusterShardingSpec.scala
@@ -61,10 +61,10 @@ class JoinConfigCompatCheckerClusterShardingSpec
 
   private val clusterWaitDuration = 5.seconds
 
-  private def configured(system: ActorSystem[_]): Int =
+  private def configured(system: ActorSystem[?]): Int =
     system.settings.config.getInt(Key)
 
-  private def join(sys: ActorSystem[_]): ClassicCluster = {
+  private def join(sys: ActorSystem[?]): ClassicCluster = {
     if (sys eq system) {
       configured(system) should ===(Shards)
       val seedNode = ClassicCluster(system)

--- a/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingSpec.scala
+++ b/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingSpec.scala
@@ -264,7 +264,7 @@ abstract class ReplicatedShardingSpec(replicationType: ReplicationType, configA:
     }
 
     "start replicated sharding on both nodes" in {
-      def start(sys: ActorSystem[_]) = {
+      def start(sys: ActorSystem[?]) = {
         ReplicatedShardingExtension(sys).init(MyReplicatedStringSet.provider(replicationType))
         ReplicatedShardingExtension(sys).init(MyReplicatedIntSet.provider(replicationType))
       }

--- a/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/delivery/DurableShardingSpec.scala
+++ b/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/delivery/DurableShardingSpec.scala
@@ -114,7 +114,7 @@ class DurableShardingSpec
       (1 to 4).foreach { n =>
         producerProbe.receiveMessage().sendNextTo ! ShardingEnvelope("entity-1", TestConsumer.Job(s"msg-$n"))
         journalOperations.expectMessageType[InmemJournal.Write].event.getClass should ===(
-          classOf[DurableProducerQueue.MessageSent[_]])
+          classOf[DurableProducerQueue.MessageSent[?]])
       }
 
       journalOperations.expectNoMessage()
@@ -183,7 +183,7 @@ class DurableShardingSpec
       val next5 = producerProbe.receiveMessage()
       next5.sendNextTo ! ShardingEnvelope("entity-1", TestConsumer.Job(s"msg-5"))
       journalOperations.expectMessageType[InmemJournal.Write].event.getClass should ===(
-        classOf[DurableProducerQueue.MessageSent[_]])
+        classOf[DurableProducerQueue.MessageSent[?]])
 
       // issue #30489: the consumer controller may have stopped after msg-5, so allow for resend on timeout (10-15s)
       val delivery5 = consumerProbe.receiveMessage(20.seconds)
@@ -225,7 +225,7 @@ class DurableShardingSpec
         TestConsumer.Job(s"msg-1"),
         replyProbe.ref)
       journalOperations.expectMessageType[InmemJournal.Write].event.getClass should ===(
-        classOf[DurableProducerQueue.MessageSent[_]])
+        classOf[DurableProducerQueue.MessageSent[?]])
       replyProbe.expectMessage(Done)
 
       producerProbe.receiveMessage().askNextTo ! MessageWithConfirmation(
@@ -233,7 +233,7 @@ class DurableShardingSpec
         TestConsumer.Job(s"msg-2"),
         replyProbe.ref)
       journalOperations.expectMessageType[InmemJournal.Write].event.getClass should ===(
-        classOf[DurableProducerQueue.MessageSent[_]])
+        classOf[DurableProducerQueue.MessageSent[?]])
       replyProbe.expectMessage(Done)
 
       testKit.stop(shardingProducerController)

--- a/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -166,7 +166,7 @@ class ClusterShardingPersistenceSpec
     _entityId.toString
   }
 
-  private def awaitEntityTerminatedAndRemoved(ref: ActorRef[_], entityId: String): Unit = {
+  private def awaitEntityTerminatedAndRemoved(ref: ActorRef[?], entityId: String): Unit = {
     val p = TestProbe[Any]()
     p.expectTerminated(ref, p.remainingOrDefault)
 

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardingFlightRecorder.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardingFlightRecorder.scala
@@ -23,7 +23,7 @@ import pekko.util.FlightRecorderLoader
 @InternalApi
 object ShardingFlightRecorder extends ExtensionId[ShardingFlightRecorder] with ExtensionIdProvider {
 
-  override def lookup: ExtensionId[_ <: Extension] = this
+  override def lookup: ExtensionId[? <: Extension] = this
 
   override def createExtension(system: ExtendedActorSystem): ShardingFlightRecorder =
     FlightRecorderLoader.load[ShardingFlightRecorder](

--- a/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/MultiNodeClusterShardingConfig.scala
+++ b/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/MultiNodeClusterShardingConfig.scala
@@ -24,7 +24,7 @@ import pekko.remote.testkit.MultiNodeConfig
 
 object MultiNodeClusterShardingConfig {
 
-  private[sharding] def testNameFromCallStack(classToStartFrom: Class[_]): String = {
+  private[sharding] def testNameFromCallStack(classToStartFrom: Class[?]): String = {
 
     def isAbstractClass(className: String): Boolean = {
       try {

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/ShardingQueriesSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/ShardingQueriesSpec.scala
@@ -27,13 +27,13 @@ class ShardingQueriesSpec extends PekkoSpec {
 
   "ShardsQueryResult" must {
 
-    def nonEmpty(qr: ShardsQueryResult[_]): Boolean =
+    def nonEmpty(qr: ShardsQueryResult[?]): Boolean =
       qr.total > 0 && qr.queried > 0
 
-    def isTotalFailed(qr: ShardsQueryResult[_]): Boolean =
+    def isTotalFailed(qr: ShardsQueryResult[?]): Boolean =
       nonEmpty(qr) && qr.failed.size == qr.total
 
-    def isAllSubsetFailed(qr: ShardsQueryResult[_]): Boolean =
+    def isAllSubsetFailed(qr: ShardsQueryResult[?]): Boolean =
       nonEmpty(qr) && qr.queried < qr.total && qr.failed.size == qr.queried
 
     "reflect nothing to acquire metadata from - 0 shards" in {

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/internal/ReplicatorBehavior.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/internal/ReplicatorBehavior.scala
@@ -76,7 +76,7 @@ import pekko.util.Timeout
         Behaviors
           .receive[SReplicator.Command] { (ctx, msg) =>
             msg match {
-              case cmd: SReplicator.Get[_] =>
+              case cmd: SReplicator.Get[?] =>
                 classicReplicator.tell(dd.Replicator.Get(cmd.key, cmd.consistency), sender = cmd.replyTo.toClassic)
                 Behaviors.same
 
@@ -102,7 +102,7 @@ import pekko.util.Timeout
                 reply.foreach { cmd.replyTo ! _ }
                 Behaviors.same
 
-              case cmd: SReplicator.Update[_] =>
+              case cmd: SReplicator.Update[?] =>
                 classicReplicator.tell(
                   dd.Replicator.Update(cmd.key, cmd.writeConsistency, None)(cmd.modify),
                   sender = cmd.replyTo.toClassic)
@@ -131,7 +131,7 @@ import pekko.util.Timeout
                 reply.foreach { cmd.replyTo ! _ }
                 Behaviors.same
 
-              case cmd: SReplicator.Subscribe[_] =>
+              case cmd: SReplicator.Subscribe[?] =>
                 // For the Scala API the SubscribeResponse messages can be sent directly to the subscriber
                 classicReplicator.tell(
                   dd.Replicator.Subscribe(cmd.key, cmd.subscriber.toClassic),
@@ -157,12 +157,12 @@ import pekko.util.Timeout
 
               case InternalSubscribeResponse(rsp, subscriber) =>
                 rsp match {
-                  case chg: dd.Replicator.Changed[_] => subscriber ! JReplicator.Changed(chg.key)(chg.dataValue)
-                  case del: dd.Replicator.Deleted[_] => subscriber ! JReplicator.Deleted(del.key)
+                  case chg: dd.Replicator.Changed[?] => subscriber ! JReplicator.Changed(chg.key)(chg.dataValue)
+                  case del: dd.Replicator.Deleted[?] => subscriber ! JReplicator.Deleted(del.key)
                 }
                 Behaviors.same
 
-              case cmd: SReplicator.Unsubscribe[_] =>
+              case cmd: SReplicator.Unsubscribe[?] =>
                 classicReplicator.tell(
                   dd.Replicator.Unsubscribe(cmd.key, cmd.subscriber.toClassic),
                   sender = cmd.subscriber.toClassic)
@@ -171,7 +171,7 @@ import pekko.util.Timeout
               case cmd: JReplicator.Unsubscribe[ReplicatedData] @unchecked =>
                 stopSubscribeAdapter(cmd.subscriber)
 
-              case cmd: SReplicator.Delete[_] =>
+              case cmd: SReplicator.Delete[?] =>
                 classicReplicator.tell(dd.Replicator.Delete(cmd.key, cmd.consistency), sender = cmd.replyTo.toClassic)
                 Behaviors.same
 

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/javadsl/DistributedData.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/javadsl/DistributedData.scala
@@ -30,9 +30,9 @@ import pekko.cluster.ddata.SelfUniqueAddress
 import pekko.util.JavaDurationConverters._
 
 object DistributedData extends ExtensionId[DistributedData] {
-  def get(system: ActorSystem[_]): DistributedData = apply(system)
+  def get(system: ActorSystem[?]): DistributedData = apply(system)
 
-  override def createExtension(system: ActorSystem[_]): DistributedData =
+  override def createExtension(system: ActorSystem[?]): DistributedData =
     new DistributedDataImpl(system)
 
   /**
@@ -97,7 +97,7 @@ abstract class DistributedData extends Extension {
 /**
  * INTERNAL API
  */
-@InternalApi private[pekko] class DistributedDataImpl(system: ActorSystem[_]) extends DistributedData {
+@InternalApi private[pekko] class DistributedDataImpl(system: ActorSystem[?]) extends DistributedData {
 
   override val replicator: ActorRef[Replicator.Command] =
     pekko.cluster.ddata.typed.scaladsl.DistributedData(system).replicator.narrow[Replicator.Command]
@@ -108,7 +108,7 @@ abstract class DistributedData extends Extension {
 }
 
 object DistributedDataSetup {
-  def apply[T <: Extension](createExtension: ActorSystem[_] => DistributedData): DistributedDataSetup =
+  def apply[T <: Extension](createExtension: ActorSystem[?] => DistributedData): DistributedDataSetup =
     new DistributedDataSetup(createExtension(_))
 
 }
@@ -118,5 +118,5 @@ object DistributedDataSetup {
  * to replace the default implementation of the [[DistributedData]] extension. Intended
  * for tests that need to replace extension with stub/mock implementations.
  */
-final class DistributedDataSetup(createExtension: java.util.function.Function[ActorSystem[_], DistributedData])
+final class DistributedDataSetup(createExtension: java.util.function.Function[ActorSystem[?], DistributedData])
     extends ExtensionSetup[DistributedData](DistributedData, createExtension)

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/javadsl/ReplicatorSettings.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/javadsl/ReplicatorSettings.scala
@@ -26,7 +26,7 @@ object ReplicatorSettings {
    * Create settings from the default configuration
    * `pekko.cluster.distributed-data`.
    */
-  def create(system: ActorSystem[_]): dd.ReplicatorSettings =
+  def create(system: ActorSystem[?]): dd.ReplicatorSettings =
     dd.ReplicatorSettings(system.toClassic)
 
   /**

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/scaladsl/DistributedData.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/scaladsl/DistributedData.scala
@@ -31,9 +31,9 @@ import pekko.cluster.ddata.SelfUniqueAddress
 import pekko.util.JavaDurationConverters._
 
 object DistributedData extends ExtensionId[DistributedData] {
-  def get(system: ActorSystem[_]): DistributedData = apply(system)
+  def get(system: ActorSystem[?]): DistributedData = apply(system)
 
-  override def createExtension(system: ActorSystem[_]): DistributedData =
+  override def createExtension(system: ActorSystem[?]): DistributedData =
     new DistributedData(system)
 
   /**
@@ -76,7 +76,7 @@ object DistributedData extends ExtensionId[DistributedData] {
  * [[pekko.cluster.ddata.DistributedData]] and that means that typed
  * and classic actors can share the same data.
  */
-class DistributedData(system: ActorSystem[_]) extends Extension {
+class DistributedData(system: ActorSystem[?]) extends Extension {
   import pekko.actor.typed.scaladsl.adapter._
 
   private val settings: ReplicatorSettings = ReplicatorSettings(system)

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/scaladsl/ReplicatorSettings.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/ddata/typed/scaladsl/ReplicatorSettings.scala
@@ -30,7 +30,7 @@ object ReplicatorSettings {
    * Create settings from the default configuration
    * `pekko.cluster.distributed-data`.
    */
-  def apply(system: ActorSystem[_]): ReplicatorSettings =
+  def apply(system: ActorSystem[?]): ReplicatorSettings =
     dd.ReplicatorSettings(system.toClassic)
 
   /**
@@ -44,6 +44,6 @@ object ReplicatorSettings {
    * INTERNAL API
    * The name of the actor used in DistributedData extensions.
    */
-  @InternalApi private[pekko] def name(system: ActorSystem[_]): String =
+  @InternalApi private[pekko] def name(system: ActorSystem[?]): String =
     dd.ReplicatorSettings.name(system.toClassic, Some("typed"))
 }

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/Cluster.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/Cluster.scala
@@ -185,12 +185,12 @@ case object PrepareForFullClusterShutdown extends PrepareForFullClusterShutdown 
  */
 object Cluster extends ExtensionId[Cluster] {
 
-  def createExtension(system: ActorSystem[_]): Cluster = new AdapterClusterImpl(system)
+  def createExtension(system: ActorSystem[?]): Cluster = new AdapterClusterImpl(system)
 
   /**
    * Java API
    */
-  def get(system: ActorSystem[_]): Cluster = apply(system)
+  def get(system: ActorSystem[?]): Cluster = apply(system)
 }
 
 /**
@@ -223,7 +223,7 @@ abstract class Cluster extends Extension {
 }
 
 object ClusterSetup {
-  def apply[T <: Extension](createExtension: ActorSystem[_] => Cluster): ClusterSetup =
+  def apply[T <: Extension](createExtension: ActorSystem[?] => Cluster): ClusterSetup =
     new ClusterSetup(createExtension(_))
 
 }
@@ -233,5 +233,5 @@ object ClusterSetup {
  * to replace the default implementation of the [[Cluster]] extension. Intended
  * for tests that need to replace extension with stub/mock implementations.
  */
-final class ClusterSetup(createExtension: java.util.function.Function[ActorSystem[_], Cluster])
+final class ClusterSetup(createExtension: java.util.function.Function[ActorSystem[?], Cluster])
     extends ExtensionSetup[Cluster](Cluster, createExtension)

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/ClusterSingleton.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/ClusterSingleton.scala
@@ -29,13 +29,13 @@ import pekko.util.JavaDurationConverters._
 import com.typesafe.config.Config
 
 object ClusterSingletonSettings {
-  def apply(system: ActorSystem[_]): ClusterSingletonSettings =
+  def apply(system: ActorSystem[?]): ClusterSingletonSettings =
     fromConfig(system.settings.config.getConfig("pekko.cluster"))
 
   /**
    * Java API
    */
-  def create(system: ActorSystem[_]): ClusterSingletonSettings = apply(system)
+  def create(system: ActorSystem[?]): ClusterSingletonSettings = apply(system)
 
   def fromConfig(config: Config): ClusterSingletonSettings = {
     // TODO introduce a config namespace for typed singleton and read that?
@@ -144,12 +144,12 @@ final class ClusterSingletonSettings(
 
 object ClusterSingleton extends ExtensionId[ClusterSingleton] {
 
-  override def createExtension(system: ActorSystem[_]): ClusterSingleton = new AdaptedClusterSingletonImpl(system)
+  override def createExtension(system: ActorSystem[?]): ClusterSingleton = new AdaptedClusterSingletonImpl(system)
 
   /**
    * Java API:
    */
-  def get(system: ActorSystem[_]): ClusterSingleton = apply(system)
+  def get(system: ActorSystem[?]): ClusterSingleton = apply(system)
 }
 
 /**
@@ -236,7 +236,7 @@ object ClusterSingletonManagerSettings {
    * Create settings from the default configuration
    * `pekko.cluster.singleton`.
    */
-  def apply(system: ActorSystem[_]): ClusterSingletonManagerSettings =
+  def apply(system: ActorSystem[?]): ClusterSingletonManagerSettings =
     apply(system.settings.config.getConfig("pekko.cluster.singleton"))
       .withRemovalMargin(pekko.cluster.Cluster(system).downingProvider.downRemovalMargin)
 
@@ -262,7 +262,7 @@ object ClusterSingletonManagerSettings {
    * Java API: Create settings from the default configuration
    * `pekko.cluster.singleton`.
    */
-  def create(system: ActorSystem[_]): ClusterSingletonManagerSettings = apply(system)
+  def create(system: ActorSystem[?]): ClusterSingletonManagerSettings = apply(system)
 
   /**
    * Java API: Create settings from a configuration with the same layout as
@@ -343,7 +343,7 @@ final class ClusterSingletonManagerSettings(
 }
 
 object ClusterSingletonSetup {
-  def apply[T <: Extension](createExtension: ActorSystem[_] => ClusterSingleton): ClusterSingletonSetup =
+  def apply[T <: Extension](createExtension: ActorSystem[?] => ClusterSingleton): ClusterSingletonSetup =
     new ClusterSingletonSetup(createExtension(_))
 
 }
@@ -353,5 +353,5 @@ object ClusterSingletonSetup {
  * to replace the default implementation of the [[ClusterSingleton]] extension. Intended
  * for tests that need to replace extension with stub/mock implementations.
  */
-final class ClusterSingletonSetup(createExtension: java.util.function.Function[ActorSystem[_], ClusterSingleton])
+final class ClusterSingletonSetup(createExtension: java.util.function.Function[ActorSystem[?], ClusterSingleton])
     extends ExtensionSetup[ClusterSingleton](ClusterSingleton, createExtension)

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/AdaptedClusterImpl.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/AdaptedClusterImpl.scala
@@ -155,10 +155,10 @@ private[pekko] object AdapterClusterImpl {
  * INTERNAL API:
  */
 @InternalApi
-private[pekko] final class AdapterClusterImpl(system: ActorSystem[_]) extends Cluster {
+private[pekko] final class AdapterClusterImpl(system: ActorSystem[?]) extends Cluster {
   import AdapterClusterImpl._
 
-  require(system.isInstanceOf[ActorSystemAdapter[_]], "only adapted actor systems can be used for cluster features")
+  require(system.isInstanceOf[ActorSystemAdapter[?]], "only adapted actor systems can be used for cluster features")
   private val classicCluster = pekko.cluster.Cluster(system)
 
   override def selfMember: Member = classicCluster.selfMember

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/AdaptedClusterSingletonImpl.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/AdaptedClusterSingletonImpl.scala
@@ -32,9 +32,9 @@ import pekko.cluster.typed.{ Cluster, ClusterSingleton, ClusterSingletonImpl, Cl
  * INTERNAL API:
  */
 @InternalApi
-private[pekko] final class AdaptedClusterSingletonImpl(system: ActorSystem[_]) extends ClusterSingleton {
+private[pekko] final class AdaptedClusterSingletonImpl(system: ActorSystem[?]) extends ClusterSingleton {
   require(
-    system.isInstanceOf[ActorSystemAdapter[_]],
+    system.isInstanceOf[ActorSystemAdapter[?]],
     "only adapted actor systems can be used for the typed cluster singleton")
 
   import ClusterSingletonImpl._
@@ -44,7 +44,7 @@ private[pekko] final class AdaptedClusterSingletonImpl(system: ActorSystem[_]) e
   private lazy val cluster = Cluster(system)
   private val classicSystem = system.toClassic.asInstanceOf[ExtendedActorSystem]
 
-  private val proxies = new ConcurrentHashMap[(String, Option[DataCenter]), ActorRef[_]]()
+  private val proxies = new ConcurrentHashMap[(String, Option[DataCenter]), ActorRef[?]]()
 
   override def init[M](singleton: typed.SingletonActor[M]): ActorRef[M] = {
     val settings = singleton.settings match {
@@ -79,8 +79,8 @@ private[pekko] final class AdaptedClusterSingletonImpl(system: ActorSystem[_]) e
   }
 
   private def getProxy[T](name: String, settings: ClusterSingletonSettings): ActorRef[T] = {
-    val proxyCreator = new JFunction[(String, Option[DataCenter]), ActorRef[_]] {
-      def apply(singletonNameAndDc: (String, Option[DataCenter])): ActorRef[_] = {
+    val proxyCreator = new JFunction[(String, Option[DataCenter]), ActorRef[?]] {
+      def apply(singletonNameAndDc: (String, Option[DataCenter])): ActorRef[?] = {
         val (singletonName, _) = singletonNameAndDc
         val proxyName = s"singletonProxy$singletonName-${settings.dataCenter.getOrElse("no-dc")}"
         classicSystem.systemActorOf(

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/PekkoClusterTypedSerializer.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/PekkoClusterTypedSerializer.scala
@@ -43,14 +43,14 @@ private[pekko] final class PekkoClusterTypedSerializer(override val system: Exte
 
   override def manifest(o: AnyRef): String = o match {
     case _: Entry                         => ReceptionistEntryManifest
-    case _: TopicImpl.MessagePublished[_] => PubSubPublishManifest
+    case _: TopicImpl.MessagePublished[?] => PubSubPublishManifest
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }
 
   override def toBinary(o: AnyRef): Array[Byte] = o match {
     case e: Entry                         => receptionistEntryToBinary(e)
-    case m: TopicImpl.MessagePublished[_] => pubSubPublishToBinary(m)
+    case m: TopicImpl.MessagePublished[?] => pubSubPublishToBinary(m)
     case _ =>
       throw new IllegalArgumentException(s"Cannot serialize object of type [${o.getClass.getName}]")
   }
@@ -63,7 +63,7 @@ private[pekko] final class PekkoClusterTypedSerializer(override val system: Exte
         s"Unimplemented deserialization of message with manifest [$manifest] in [${getClass.getName}]")
   }
 
-  private def pubSubPublishToBinary(m: TopicImpl.MessagePublished[_]): Array[Byte] = {
+  private def pubSubPublishToBinary(m: TopicImpl.MessagePublished[?]): Array[Byte] = {
     ClusterMessages.PubSubMessagePublished
       .newBuilder()
       .setMessage(payloadSupport.payloadBuilder(m.message))
@@ -83,7 +83,7 @@ private[pekko] final class PekkoClusterTypedSerializer(override val system: Exte
     b.build().toByteArray
   }
 
-  private def pubSubMessageFromBinary(bytes: Array[Byte]): TopicImpl.MessagePublished[_] = {
+  private def pubSubMessageFromBinary(bytes: Array[Byte]): TopicImpl.MessagePublished[?] = {
     val parsed = ClusterMessages.PubSubMessagePublished.parseFrom(bytes)
     val userMessage = payloadSupport.deserializePayload(parsed.getMessage)
     TopicImpl.MessagePublished(userMessage)

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/delivery/ReliableDeliverySerializer.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/delivery/ReliableDeliverySerializer.scala
@@ -58,34 +58,34 @@ import pekko.remote.ByteStringUtils
   private val DurableQueueCleanupManifest = "i"
 
   override def manifest(o: AnyRef): String = o match {
-    case _: ConsumerController.SequencedMessage[_] => SequencedMessageManifest
+    case _: ConsumerController.SequencedMessage[?] => SequencedMessageManifest
     case _: ProducerControllerImpl.Ack             => AckManifest
     case _: ProducerControllerImpl.Request         => RequestManifest
     case _: ProducerControllerImpl.Resend          => ResendManifest
-    case _: ProducerController.RegisterConsumer[_] => RegisterConsumerManifest
-    case _: DurableProducerQueue.MessageSent[_]    => DurableQueueMessageSentManifest
+    case _: ProducerController.RegisterConsumer[?] => RegisterConsumerManifest
+    case _: DurableProducerQueue.MessageSent[?]    => DurableQueueMessageSentManifest
     case _: DurableProducerQueue.Confirmed         => DurableQueueConfirmedManifest
-    case _: DurableProducerQueue.State[_]          => DurableQueueStateManifest
+    case _: DurableProducerQueue.State[?]          => DurableQueueStateManifest
     case _: DurableProducerQueue.Cleanup           => DurableQueueCleanupManifest
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }
 
   override def toBinary(o: AnyRef): Array[Byte] = o match {
-    case m: ConsumerController.SequencedMessage[_] => sequencedMessageToBinary(m)
+    case m: ConsumerController.SequencedMessage[?] => sequencedMessageToBinary(m)
     case m: ProducerControllerImpl.Ack             => ackToBinary(m)
     case m: ProducerControllerImpl.Request         => requestToBinary(m)
     case m: ProducerControllerImpl.Resend          => resendToBinary(m)
-    case m: ProducerController.RegisterConsumer[_] => registerConsumerToBinary(m)
-    case m: DurableProducerQueue.MessageSent[_]    => durableQueueMessageSentToBinary(m)
+    case m: ProducerController.RegisterConsumer[?] => registerConsumerToBinary(m)
+    case m: DurableProducerQueue.MessageSent[?]    => durableQueueMessageSentToBinary(m)
     case m: DurableProducerQueue.Confirmed         => durableQueueConfirmedToBinary(m)
-    case m: DurableProducerQueue.State[_]          => durableQueueStateToBinary(m)
+    case m: DurableProducerQueue.State[?]          => durableQueueStateToBinary(m)
     case m: DurableProducerQueue.Cleanup           => durableQueueCleanupToBinary(m)
     case _ =>
       throw new IllegalArgumentException(s"Cannot serialize object of type [${o.getClass.getName}]")
   }
 
-  private def sequencedMessageToBinary(m: ConsumerController.SequencedMessage[_]): Array[Byte] = {
+  private def sequencedMessageToBinary(m: ConsumerController.SequencedMessage[?]): Array[Byte] = {
     val b = ReliableDelivery.SequencedMessage.newBuilder()
     b.setProducerId(m.producerId)
     b.setSeqNr(m.seqNr)
@@ -134,17 +134,17 @@ import pekko.remote.ByteStringUtils
     b.build().toByteArray()
   }
 
-  private def registerConsumerToBinary(m: ProducerController.RegisterConsumer[_]): Array[Byte] = {
+  private def registerConsumerToBinary(m: ProducerController.RegisterConsumer[?]): Array[Byte] = {
     val b = ReliableDelivery.RegisterConsumer.newBuilder()
     b.setConsumerControllerRef(resolver.toSerializationFormat(m.consumerController))
     b.build().toByteArray()
   }
 
-  private def durableQueueMessageSentToBinary(m: DurableProducerQueue.MessageSent[_]): Array[Byte] = {
+  private def durableQueueMessageSentToBinary(m: DurableProducerQueue.MessageSent[?]): Array[Byte] = {
     durableQueueMessageSentToProto(m).toByteArray()
   }
 
-  private def durableQueueMessageSentToProto(m: DurableProducerQueue.MessageSent[_]): ReliableDelivery.MessageSent = {
+  private def durableQueueMessageSentToProto(m: DurableProducerQueue.MessageSent[?]): ReliableDelivery.MessageSent = {
     val b = ReliableDelivery.MessageSent.newBuilder()
     b.setSeqNr(m.seqNr)
     b.setQualifier(m.confirmationQualifier)
@@ -178,7 +178,7 @@ import pekko.remote.ByteStringUtils
     b.build()
   }
 
-  private def durableQueueStateToBinary(m: DurableProducerQueue.State[_]): Array[Byte] = {
+  private def durableQueueStateToBinary(m: DurableProducerQueue.State[?]): Array[Byte] = {
     val b = ReliableDelivery.State.newBuilder()
     b.setCurrentSeqNr(m.currentSeqNr)
     b.setHighestConfirmedSeqNr(m.highestConfirmedSeqNr)

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/receptionist/ClusterReceptionistSettings.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/receptionist/ClusterReceptionistSettings.scala
@@ -30,7 +30,7 @@ import pekko.util.Helpers.toRootLowerCase
  */
 @InternalApi
 private[pekko] object ClusterReceptionistSettings {
-  def apply(system: ActorSystem[_]): ClusterReceptionistSettings =
+  def apply(system: ActorSystem[?]): ClusterReceptionistSettings =
     apply(system.settings.config.getConfig("pekko.cluster.typed.receptionist"))
 
   def apply(config: Config): ClusterReceptionistSettings = {

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/receptionist/Registry.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/internal/receptionist/Registry.scala
@@ -28,7 +28,7 @@ import pekko.cluster.typed.internal.receptionist.ClusterReceptionist.{ DDataKey,
 @InternalApi private[pekko] object ShardedServiceRegistry {
   def apply(numberOfKeys: Int): ShardedServiceRegistry = {
     val emptyRegistries = (0 until numberOfKeys).map { n =>
-      val key = ORMultiMapKey[ServiceKey[_], Entry](s"ReceptionistKey_$n")
+      val key = ORMultiMapKey[ServiceKey[?], Entry](s"ReceptionistKey_$n")
       key -> new ServiceRegistry(EmptyORMultiMap)
     }.toMap
     new ShardedServiceRegistry(emptyRegistries, Set.empty, Set.empty)
@@ -53,10 +53,10 @@ import pekko.cluster.typed.internal.receptionist.ClusterReceptionist.{ DDataKey,
 
   def allDdataKeys: Iterable[DDataKey] = keys
 
-  def ddataKeyFor(serviceKey: ServiceKey[_]): DDataKey =
+  def ddataKeyFor(serviceKey: ServiceKey[?]): DDataKey =
     keys(math.abs(serviceKey.id.hashCode() % serviceRegistries.size))
 
-  def allServices: Iterator[(ServiceKey[_], Set[Entry])] =
+  def allServices: Iterator[(ServiceKey[?], Set[Entry])] =
     serviceRegistries.valuesIterator.flatMap(_.entries.entries)
 
   def allEntries: Iterator[Entry] = allServices.flatMap(_._2)
@@ -113,7 +113,7 @@ import pekko.cluster.typed.internal.receptionist.ClusterReceptionist.{ DDataKey,
 /**
  * INTERNAL API
  */
-@InternalApi private[pekko] final case class ServiceRegistry(entries: ORMultiMap[ServiceKey[_], Entry]) extends AnyVal {
+@InternalApi private[pekko] final case class ServiceRegistry(entries: ORMultiMap[ServiceKey[?], Entry]) extends AnyVal {
 
   // let's hide all the ugly casts we can in here
   def actorRefsFor[T](key: AbstractServiceKey): Set[ActorRef[key.Protocol]] =
@@ -122,7 +122,7 @@ import pekko.cluster.typed.internal.receptionist.ClusterReceptionist.{ DDataKey,
   def entriesFor(key: AbstractServiceKey): Set[Entry] =
     entries.getOrElse(key.asServiceKey, Set.empty[Entry])
 
-  def keysFor(address: UniqueAddress)(implicit node: SelfUniqueAddress): Set[ServiceKey[_]] =
+  def keysFor(address: UniqueAddress)(implicit node: SelfUniqueAddress): Set[ServiceKey[?]] =
     entries.entries.collect {
       case (key, entries) if entries.exists(_.uniqueAddress(node.uniqueAddress.address) == address) =>
         key
@@ -144,7 +144,7 @@ import pekko.cluster.typed.internal.receptionist.ClusterReceptionist.{ DDataKey,
     }
   }
 
-  def toORMultiMap: ORMultiMap[ServiceKey[_], Entry] = entries
+  def toORMultiMap: ORMultiMap[ServiceKey[?], Entry] = entries
 
 }
 

--- a/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
+++ b/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
@@ -67,7 +67,7 @@ pekko {
      """).withFallback(configSystem1)
 
   def illustrateJoinSeedNodes(): Unit = {
-    val system: ActorSystem[_] = ???
+    val system: ActorSystem[?] = ???
 
     // #join-seed-nodes
     import pekko.actor.Address
@@ -82,15 +82,15 @@ pekko {
   }
 
   object Backend {
-    def apply(): Behavior[_] = Behaviors.empty
+    def apply(): Behavior[?] = Behaviors.empty
   }
 
   object Frontend {
-    def apply(): Behavior[_] = Behaviors.empty
+    def apply(): Behavior[?] = Behaviors.empty
   }
 
   def illustrateRoles(): Unit = {
-    val context: ActorContext[_] = ???
+    val context: ActorContext[?] = ???
 
     // #hasRole
     val selfMember = Cluster(context.system).selfMember
@@ -104,7 +104,7 @@ pekko {
 
   @nowarn("msg=never used")
   def illustrateDcAccess(): Unit = {
-    val system: ActorSystem[_] = ???
+    val system: ActorSystem[?] = ???
 
     // #dcAccess
     val cluster = Cluster(system)

--- a/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/DistributedPubSubExample.scala
+++ b/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/DistributedPubSubExample.scala
@@ -306,13 +306,13 @@ object DistributedPubSubExample {
         pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
     """)
 
-  def createCluster(nodes: List[ActorSystem[_]]): Unit = {
-    val clusterUp = (nodes: List[ActorSystem[_]], expected: Int) =>
+  def createCluster(nodes: List[ActorSystem[?]]): Unit = {
+    val clusterUp = (nodes: List[ActorSystem[?]], expected: Int) =>
       nodes.forall { s =>
         Cluster(s).state.members.count(_.status == MemberStatus.up) == expected
       }
 
-    val awaitClusterUp = (nodes: List[ActorSystem[_]], expected: Int) =>
+    val awaitClusterUp = (nodes: List[ActorSystem[?]], expected: Int) =>
       while (!clusterUp(nodes, expected)) {
         Thread.sleep(1000)
       }

--- a/cluster-typed/src/test/scala/org/apache/pekko/cluster/typed/GroupRouterSpec.scala
+++ b/cluster-typed/src/test/scala/org/apache/pekko/cluster/typed/GroupRouterSpec.scala
@@ -47,7 +47,7 @@ object GroupRouterSpec {
   """)
 
   object PingActor {
-    case class Pong(workerActor: ActorRef[_]) extends CborSerializable
+    case class Pong(workerActor: ActorRef[?]) extends CborSerializable
     case class Ping(replyTo: ActorRef[Pong]) extends CborSerializable
 
     def apply(): Behavior[Ping] = Behaviors.receive {
@@ -59,8 +59,8 @@ object GroupRouterSpec {
 
   object Pinger {
     sealed trait Command
-    private case class SawPong(worker: ActorRef[_]) extends Command
-    case class DonePinging(pongs: Int, uniqueWorkers: Set[ActorRef[_]])
+    private case class SawPong(worker: ActorRef[?]) extends Command
+    case class DonePinging(pongs: Int, uniqueWorkers: Set[ActorRef[?]])
     def apply(
         router: ActorRef[PingActor.Ping],
         requestedPings: Int,
@@ -71,7 +71,7 @@ object GroupRouterSpec {
         }
         (0 to requestedPings).foreach(_ => router ! PingActor.Ping(pongAdapter))
         var pongs = 0
-        var uniqueWorkers = Set.empty[ActorRef[_]]
+        var uniqueWorkers = Set.empty[ActorRef[?]]
 
         Behaviors.receiveMessage {
           case SawPong(worker) =>

--- a/cluster/src/main/scala/org/apache/pekko/cluster/Cluster.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/Cluster.scala
@@ -266,7 +266,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    * A snapshot of [[pekko.cluster.ClusterEvent.CurrentClusterState]]
    * will be sent to the subscriber as the first message.
    */
-  @varargs def subscribe(subscriber: ActorRef, to: Class[_]*): Unit =
+  @varargs def subscribe(subscriber: ActorRef, to: Class[?]*): Unit =
     subscribe(subscriber, initialStateMode = InitialStateAsSnapshot, to: _*)
 
   /**
@@ -284,7 +284,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    *
    * Note that for large clusters it is more efficient to use `InitialStateAsSnapshot`.
    */
-  @varargs def subscribe(subscriber: ActorRef, initialStateMode: SubscriptionInitialStateMode, to: Class[_]*): Unit = {
+  @varargs def subscribe(subscriber: ActorRef, initialStateMode: SubscriptionInitialStateMode, to: Class[?]*): Unit = {
     require(to.length > 0, "at least one `ClusterDomainEvent` class is required")
     require(
       to.forall(classOf[ClusterDomainEvent].isAssignableFrom),
@@ -303,7 +303,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    * Unsubscribe to a specific type of cluster domain events,
    * matching previous `subscribe` registration.
    */
-  def unsubscribe(subscriber: ActorRef, to: Class[_]): Unit =
+  def unsubscribe(subscriber: ActorRef, to: Class[?]): Unit =
     clusterCore ! InternalClusterAction.Unsubscribe(subscriber, Some(to))
 
   /**

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterDaemon.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterDaemon.scala
@@ -179,9 +179,9 @@ private[cluster] object InternalClusterAction {
   final case class AddOnMemberRemovedListener(callback: Runnable) extends NoSerializationVerificationNeeded
 
   sealed trait SubscriptionMessage
-  final case class Subscribe(subscriber: ActorRef, initialStateMode: SubscriptionInitialStateMode, to: Set[Class[_]])
+  final case class Subscribe(subscriber: ActorRef, initialStateMode: SubscriptionInitialStateMode, to: Set[Class[?]])
       extends SubscriptionMessage
-  final case class Unsubscribe(subscriber: ActorRef, to: Option[Class[_]])
+  final case class Unsubscribe(subscriber: ActorRef, to: Option[Class[?]])
       extends SubscriptionMessage
       with DeadLetterSuppression
 

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterEvent.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterEvent.scala
@@ -731,7 +731,7 @@ private[cluster] final class ClusterDomainEventPublisher
     receiver ! state
   }
 
-  def subscribe(subscriber: ActorRef, initMode: SubscriptionInitialStateMode, to: Set[Class[_]]): Unit = {
+  def subscribe(subscriber: ActorRef, initMode: SubscriptionInitialStateMode, to: Set[Class[?]]): Unit = {
     initMode match {
       case InitialStateAsEvents =>
         def pub(event: AnyRef): Unit = {
@@ -746,7 +746,7 @@ private[cluster] final class ClusterDomainEventPublisher
     to.foreach { eventStream.subscribe(subscriber, _) }
   }
 
-  def unsubscribe(subscriber: ActorRef, to: Option[Class[_]]): Unit = to match {
+  def unsubscribe(subscriber: ActorRef, to: Option[Class[?]]): Unit = to match {
     case None    => eventStream.unsubscribe(subscriber)
     case Some(c) => eventStream.unsubscribe(subscriber, c)
   }

--- a/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/SurviveNetworkInstabilitySpec.scala
+++ b/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/SurviveNetworkInstabilitySpec.scala
@@ -103,7 +103,7 @@ abstract class SurviveNetworkInstabilitySpec
   private val remoteSettings = RARP(system).provider.remoteSettings
 
   @nowarn
-  def quarantinedEventClass: Class[_] =
+  def quarantinedEventClass: Class[?] =
     if (remoteSettings.Artery.Enabled)
       classOf[QuarantinedEvent]
     else

--- a/coordination/src/main/scala/org/apache/pekko/coordination/lease/scaladsl/LeaseProvider.scala
+++ b/coordination/src/main/scala/org/apache/pekko/coordination/lease/scaladsl/LeaseProvider.scala
@@ -116,7 +116,7 @@ final class LeaseProvider(system: ExtendedActorSystem) extends Extension {
         s
       case Failure(_: NoSuchMethodException) =>
         dynamicAccess.createInstanceFor[T](fqcn, immutable.Seq((classOf[LeaseSettings], leaseSettings)))
-      case f: Failure[_] =>
+      case f: Failure[?] =>
         f
     }
 

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/Key.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/Key.scala
@@ -18,7 +18,7 @@ object Key {
   /**
    * Extract the [[Key#id]].
    */
-  def unapply(k: Key[_]): Option[String] = Some(k.id)
+  def unapply(k: Key[?]): Option[String] = Some(k.id)
 
   private[pekko] type KeyR = Key[ReplicatedData]
 
@@ -37,7 +37,7 @@ object Key {
 abstract class Key[+T <: ReplicatedData](val id: Key.KeyId) extends Serializable {
 
   override final def equals(o: Any): Boolean = o match {
-    case k: Key[_] => id == k.id
+    case k: Key[?] => id == k.id
     case _         => false
   }
 

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/LWWMap.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/LWWMap.scala
@@ -213,7 +213,7 @@ final class LWWMap[A, B] private[pekko] (private[pekko] val underlying: ORMap[A,
   override def toString: String = s"LWW$entries" // e.g. LWWMap(a -> 1, b -> 2)
 
   override def equals(o: Any): Boolean = o match {
-    case other: LWWMap[_, _] => underlying == other.underlying
+    case other: LWWMap[?, ?] => underlying == other.underlying
     case _                   => false
   }
 

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/LWWRegister.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/LWWRegister.scala
@@ -213,7 +213,7 @@ final class LWWRegister[A] private[pekko] (private[pekko] val node: UniqueAddres
   override def toString: String = s"LWWRegister($value)"
 
   override def equals(o: Any): Boolean = o match {
-    case other: LWWRegister[_] =>
+    case other: LWWRegister[?] =>
       timestamp == other.timestamp && value == other.value && node == other.node
     case _ => false
   }

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/ORMultiMap.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/ORMultiMap.scala
@@ -362,7 +362,7 @@ final class ORMultiMap[A, B] private[pekko] (
   override def toString: String = s"ORMulti$entries"
 
   override def equals(o: Any): Boolean = o match {
-    case other: ORMultiMap[_, _] => underlying == other.underlying
+    case other: ORMultiMap[?, ?] => underlying == other.underlying
     case _                       => false
   }
 

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/PNCounterMap.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/PNCounterMap.scala
@@ -199,7 +199,7 @@ final class PNCounterMap[A] private[pekko] (private[pekko] val underlying: ORMap
   override def toString: String = s"PNCounter$entries"
 
   override def equals(o: Any): Boolean = o match {
-    case other: PNCounterMap[_] => underlying == other.underlying
+    case other: PNCounterMap[?] => underlying == other.underlying
     case _                      => false
   }
 

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/Replicator.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/Replicator.scala
@@ -2675,10 +2675,10 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
       // Try again with the full state
       sender() ! writeMsg
 
-    case _: Replicator.UpdateSuccess[_] =>
+    case _: Replicator.UpdateSuccess[?] =>
       gotLocalStoreReply = true
       if (isDone) reply(isTimeout = false)
-    case _: Replicator.StoreFailure[_] =>
+    case _: Replicator.StoreFailure[?] =>
       gotLocalStoreReply = true
       gotWriteNackFrom += selfUniqueAddress.address
       if (isDone) reply(isTimeout = false)

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
@@ -339,67 +339,67 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     ORMultiMapKeyManifest -> (bytes => ORMultiMapKey(keyIdFromBinary(bytes))))
 
   override def manifest(obj: AnyRef): String = obj match {
-    case _: ORSet[_]                     => ORSetManifest
-    case _: ORSet.AddDeltaOp[_]          => ORSetAddManifest
-    case _: ORSet.RemoveDeltaOp[_]       => ORSetRemoveManifest
-    case _: GSet[_]                      => GSetManifest
+    case _: ORSet[?]                     => ORSetManifest
+    case _: ORSet.AddDeltaOp[?]          => ORSetAddManifest
+    case _: ORSet.RemoveDeltaOp[?]       => ORSetRemoveManifest
+    case _: GSet[?]                      => GSetManifest
     case _: GCounter                     => GCounterManifest
     case _: PNCounter                    => PNCounterManifest
     case _: Flag                         => FlagManifest
-    case _: LWWRegister[_]               => LWWRegisterManifest
-    case _: ORMap[_, _]                  => ORMapManifest
-    case _: ORMap.PutDeltaOp[_, _]       => ORMapPutManifest
-    case _: ORMap.RemoveDeltaOp[_, _]    => ORMapRemoveManifest
-    case _: ORMap.RemoveKeyDeltaOp[_, _] => ORMapRemoveKeyManifest
-    case _: ORMap.UpdateDeltaOp[_, _]    => ORMapUpdateManifest
-    case _: LWWMap[_, _]                 => LWWMapManifest
-    case _: PNCounterMap[_]              => PNCounterMapManifest
-    case _: ORMultiMap[_, _]             => ORMultiMapManifest
+    case _: LWWRegister[?]               => LWWRegisterManifest
+    case _: ORMap[?, ?]                  => ORMapManifest
+    case _: ORMap.PutDeltaOp[?, ?]       => ORMapPutManifest
+    case _: ORMap.RemoveDeltaOp[?, ?]    => ORMapRemoveManifest
+    case _: ORMap.RemoveKeyDeltaOp[?, ?] => ORMapRemoveKeyManifest
+    case _: ORMap.UpdateDeltaOp[?, ?]    => ORMapUpdateManifest
+    case _: LWWMap[?, ?]                 => LWWMapManifest
+    case _: PNCounterMap[?]              => PNCounterMapManifest
+    case _: ORMultiMap[?, ?]             => ORMultiMapManifest
     case DeletedData                     => DeletedDataManifest
     case _: VersionVector                => VersionVectorManifest
 
-    case _: ORSetKey[_]         => ORSetKeyManifest
-    case _: GSetKey[_]          => GSetKeyManifest
+    case _: ORSetKey[?]         => ORSetKeyManifest
+    case _: GSetKey[?]          => GSetKeyManifest
     case _: GCounterKey         => GCounterKeyManifest
     case _: PNCounterKey        => PNCounterKeyManifest
     case _: FlagKey             => FlagKeyManifest
-    case _: LWWRegisterKey[_]   => LWWRegisterKeyManifest
-    case _: ORMapKey[_, _]      => ORMapKeyManifest
-    case _: LWWMapKey[_, _]     => LWWMapKeyManifest
-    case _: PNCounterMapKey[_]  => PNCounterMapKeyManifest
-    case _: ORMultiMapKey[_, _] => ORMultiMapKeyManifest
+    case _: LWWRegisterKey[?]   => LWWRegisterKeyManifest
+    case _: ORMapKey[?, ?]      => ORMapKeyManifest
+    case _: LWWMapKey[?, ?]     => LWWMapKeyManifest
+    case _: PNCounterMapKey[?]  => PNCounterMapKeyManifest
+    case _: ORMultiMapKey[?, ?] => ORMultiMapKeyManifest
 
-    case _: ORSet.DeltaGroup[_]       => ORSetDeltaGroupManifest
-    case _: ORMap.DeltaGroup[_, _]    => ORMapDeltaGroupManifest
-    case _: ORSet.FullStateDeltaOp[_] => ORSetFullManifest
+    case _: ORSet.DeltaGroup[?]       => ORSetDeltaGroupManifest
+    case _: ORMap.DeltaGroup[?, ?]    => ORMapDeltaGroupManifest
+    case _: ORSet.FullStateDeltaOp[?] => ORSetFullManifest
 
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass} in [${getClass.getName}]")
   }
 
   def toBinary(obj: AnyRef): Array[Byte] = obj match {
-    case m: ORSet[_]                     => compress(orsetToProto(m))
-    case m: ORSet.AddDeltaOp[_]          => orsetToProto(m.underlying).toByteArray
-    case m: ORSet.RemoveDeltaOp[_]       => orsetToProto(m.underlying).toByteArray
-    case m: GSet[_]                      => gsetToProto(m).toByteArray
+    case m: ORSet[?]                     => compress(orsetToProto(m))
+    case m: ORSet.AddDeltaOp[?]          => orsetToProto(m.underlying).toByteArray
+    case m: ORSet.RemoveDeltaOp[?]       => orsetToProto(m.underlying).toByteArray
+    case m: GSet[?]                      => gsetToProto(m).toByteArray
     case m: GCounter                     => gcounterToProto(m).toByteArray
     case m: PNCounter                    => pncounterToProto(m).toByteArray
     case m: Flag                         => flagToProto(m).toByteArray
-    case m: LWWRegister[_]               => lwwRegisterToProto(m).toByteArray
-    case m: ORMap[_, _]                  => compress(ormapToProto(m))
-    case m: ORMap.PutDeltaOp[_, _]       => ormapPutToProto(m).toByteArray
-    case m: ORMap.RemoveDeltaOp[_, _]    => ormapRemoveToProto(m).toByteArray
-    case m: ORMap.RemoveKeyDeltaOp[_, _] => ormapRemoveKeyToProto(m).toByteArray
-    case m: ORMap.UpdateDeltaOp[_, _]    => ormapUpdateToProto(m).toByteArray
-    case m: LWWMap[_, _]                 => compress(lwwmapToProto(m))
-    case m: PNCounterMap[_]              => compress(pncountermapToProto(m))
-    case m: ORMultiMap[_, _]             => compress(multimapToProto(m))
+    case m: LWWRegister[?]               => lwwRegisterToProto(m).toByteArray
+    case m: ORMap[?, ?]                  => compress(ormapToProto(m))
+    case m: ORMap.PutDeltaOp[?, ?]       => ormapPutToProto(m).toByteArray
+    case m: ORMap.RemoveDeltaOp[?, ?]    => ormapRemoveToProto(m).toByteArray
+    case m: ORMap.RemoveKeyDeltaOp[?, ?] => ormapRemoveKeyToProto(m).toByteArray
+    case m: ORMap.UpdateDeltaOp[?, ?]    => ormapUpdateToProto(m).toByteArray
+    case m: LWWMap[?, ?]                 => compress(lwwmapToProto(m))
+    case m: PNCounterMap[?]              => compress(pncountermapToProto(m))
+    case m: ORMultiMap[?, ?]             => compress(multimapToProto(m))
     case DeletedData                     => dm.Empty.getDefaultInstance.toByteArray
     case m: VersionVector                => versionVectorToProto(m).toByteArray
     case Key(id)                         => keyIdToBinary(id)
-    case m: ORSet.DeltaGroup[_]          => orsetDeltaGroupToProto(m).toByteArray
-    case m: ORMap.DeltaGroup[_, _]       => ormapDeltaGroupToProto(m).toByteArray
-    case m: ORSet.FullStateDeltaOp[_]    => orsetToProto(m.underlying).toByteArray
+    case m: ORSet.DeltaGroup[?]          => orsetDeltaGroupToProto(m).toByteArray
+    case m: ORMap.DeltaGroup[?, ?]       => ormapDeltaGroupToProto(m).toByteArray
+    case m: ORSet.FullStateDeltaOp[?]    => orsetToProto(m.underlying).toByteArray
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass} in [${getClass.getName}]")
   }
@@ -412,7 +412,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
           s"Unimplemented deserialization of message with manifest [$manifest] in [${getClass.getName}]")
     }
 
-  def gsetToProto(gset: GSet[_]): rd.GSet = {
+  def gsetToProto(gset: GSet[?]): rd.GSet = {
     val b = rd.GSet.newBuilder()
     // using java collections and sorting for performance (avoid conversions)
     val stringElements = new ArrayList[String]
@@ -450,7 +450,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     b.build()
   }
 
-  def gsetFromBinary(bytes: Array[Byte]): GSet[_] =
+  def gsetFromBinary(bytes: Array[Byte]): GSet[?] =
     gsetFromProto(rd.GSet.parseFrom(bytes))
 
   def gsetFromProto(gset: rd.GSet): GSet[Any] = {
@@ -464,7 +464,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     GSet(elements.toSet)
   }
 
-  def orsetToProto(orset: ORSet[_]): rd.ORSet =
+  def orsetToProto(orset: ORSet[?]): rd.ORSet =
     orsetToProtoImpl(orset.asInstanceOf[ORSet[Any]])
 
   private def orsetToProtoImpl(orset: ORSet[Any]): rd.ORSet = {
@@ -488,7 +488,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
         otherElementsMap = otherElementsMap.updated(enclosedMsg, other)
     }
 
-    def addDots(elements: ArrayList[_]): Unit = {
+    def addDots(elements: ArrayList[?]): Unit = {
       // add corresponding dots in same order
       val iter = elements.iterator
       while (iter.hasNext) {
@@ -544,8 +544,8 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
   private def orsetFullFromBinary(bytes: Array[Byte]): ORSet.FullStateDeltaOp[Any] =
     new ORSet.FullStateDeltaOp(orsetFromProto(rd.ORSet.parseFrom(bytes)))
 
-  private def orsetDeltaGroupToProto(deltaGroup: ORSet.DeltaGroup[_]): rd.ORSetDeltaGroup = {
-    def createEntry(opType: rd.ORSetDeltaOp, u: ORSet[_]) = {
+  private def orsetDeltaGroupToProto(deltaGroup: ORSet.DeltaGroup[?]): rd.ORSetDeltaGroup = {
+    def createEntry(opType: rd.ORSetDeltaOp, u: ORSet[?]) = {
       rd.ORSetDeltaGroup.Entry.newBuilder().setOperation(opType).setUnderlying(orsetToProto(u))
     }
 
@@ -605,7 +605,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
   def flagFromProto(flag: rd.Flag): Flag =
     if (flag.getEnabled) Flag.Enabled else Flag.Disabled
 
-  def lwwRegisterToProto(lwwRegister: LWWRegister[_]): rd.LWWRegister =
+  def lwwRegisterToProto(lwwRegister: LWWRegister[?]): rd.LWWRegister =
     rd.LWWRegister
       .newBuilder()
       .setTimestamp(lwwRegister.timestamp)
@@ -684,7 +684,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     protoEntries
   }
 
-  def ormapToProto(ormap: ORMap[_, _]): rd.ORMap = {
+  def ormapToProto(ormap: ORMap[?, ?]): rd.ORMap = {
     val ormapBuilder = rd.ORMap.newBuilder()
     val entries: jl.Iterable[rd.ORMap.Entry] =
       getEntries(ormap.values, rd.ORMap.Entry.newBuilder _, otherMessageToProto)
@@ -741,7 +741,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
   // wire protocol is always DeltaGroup
   private def ormapPutFromBinary(bytes: Array[Byte]): ORMap.PutDeltaOp[Any, ReplicatedData] = {
     val ops = ormapDeltaGroupOpsFromBinary(bytes)
-    if (ops.size == 1 && ops.head.isInstanceOf[ORMap.PutDeltaOp[_, _]])
+    if (ops.size == 1 && ops.head.isInstanceOf[ORMap.PutDeltaOp[?, ?]])
       ops.head.asInstanceOf[ORMap.PutDeltaOp[Any, ReplicatedData]]
     else
       throw new NotSerializableException("Improper ORMap delta put operation size or kind")
@@ -750,7 +750,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
   // wire protocol is always delta group
   private def ormapRemoveFromBinary(bytes: Array[Byte]): ORMap.RemoveDeltaOp[Any, ReplicatedData] = {
     val ops = ormapDeltaGroupOpsFromBinary(bytes)
-    if (ops.size == 1 && ops.head.isInstanceOf[ORMap.RemoveDeltaOp[_, _]])
+    if (ops.size == 1 && ops.head.isInstanceOf[ORMap.RemoveDeltaOp[?, ?]])
       ops.head.asInstanceOf[ORMap.RemoveDeltaOp[Any, ReplicatedData]]
     else
       throw new NotSerializableException("Improper ORMap delta remove operation size or kind")
@@ -759,7 +759,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
   // wire protocol is always delta group
   private def ormapRemoveKeyFromBinary(bytes: Array[Byte]): ORMap.RemoveKeyDeltaOp[Any, ReplicatedData] = {
     val ops = ormapDeltaGroupOpsFromBinary(bytes)
-    if (ops.size == 1 && ops.head.isInstanceOf[ORMap.RemoveKeyDeltaOp[_, _]])
+    if (ops.size == 1 && ops.head.isInstanceOf[ORMap.RemoveKeyDeltaOp[?, ?]])
       ops.head.asInstanceOf[ORMap.RemoveKeyDeltaOp[Any, ReplicatedData]]
     else
       throw new NotSerializableException("Improper ORMap delta remove key operation size or kind")
@@ -768,7 +768,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
   // wire protocol is always delta group
   private def ormapUpdateFromBinary(bytes: Array[Byte]): ORMap.UpdateDeltaOp[Any, ReplicatedDelta] = {
     val ops = ormapDeltaGroupOpsFromBinary(bytes)
-    if (ops.size == 1 && ops.head.isInstanceOf[ORMap.UpdateDeltaOp[_, _]])
+    if (ops.size == 1 && ops.head.isInstanceOf[ORMap.UpdateDeltaOp[?, ?]])
       ops.head.asInstanceOf[ORMap.UpdateDeltaOp[Any, ReplicatedDelta]]
     else
       throw new NotSerializableException("Improper ORMap delta update operation size or kind")
@@ -827,28 +827,28 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     ops
   }
 
-  private def ormapPutToProto(deltaOp: ORMap.PutDeltaOp[_, _]): rd.ORMapDeltaGroup = {
+  private def ormapPutToProto(deltaOp: ORMap.PutDeltaOp[?, ?]): rd.ORMapDeltaGroup = {
     ormapDeltaGroupOpsToProto(immutable.IndexedSeq(deltaOp.asInstanceOf[ORMap.DeltaOp]))
   }
 
-  private def ormapRemoveToProto(deltaOp: ORMap.RemoveDeltaOp[_, _]): rd.ORMapDeltaGroup = {
+  private def ormapRemoveToProto(deltaOp: ORMap.RemoveDeltaOp[?, ?]): rd.ORMapDeltaGroup = {
     ormapDeltaGroupOpsToProto(immutable.IndexedSeq(deltaOp.asInstanceOf[ORMap.DeltaOp]))
   }
 
-  private def ormapRemoveKeyToProto(deltaOp: ORMap.RemoveKeyDeltaOp[_, _]): rd.ORMapDeltaGroup = {
+  private def ormapRemoveKeyToProto(deltaOp: ORMap.RemoveKeyDeltaOp[?, ?]): rd.ORMapDeltaGroup = {
     ormapDeltaGroupOpsToProto(immutable.IndexedSeq(deltaOp.asInstanceOf[ORMap.DeltaOp]))
   }
 
-  private def ormapUpdateToProto(deltaOp: ORMap.UpdateDeltaOp[_, _]): rd.ORMapDeltaGroup = {
+  private def ormapUpdateToProto(deltaOp: ORMap.UpdateDeltaOp[?, ?]): rd.ORMapDeltaGroup = {
     ormapDeltaGroupOpsToProto(immutable.IndexedSeq(deltaOp.asInstanceOf[ORMap.DeltaOp]))
   }
 
-  private def ormapDeltaGroupToProto(deltaGroup: ORMap.DeltaGroup[_, _]): rd.ORMapDeltaGroup = {
+  private def ormapDeltaGroupToProto(deltaGroup: ORMap.DeltaGroup[?, ?]): rd.ORMapDeltaGroup = {
     ormapDeltaGroupOpsToProto(deltaGroup.ops)
   }
 
   private def ormapDeltaGroupOpsToProto(deltaGroupOps: immutable.IndexedSeq[ORMap.DeltaOp]): rd.ORMapDeltaGroup = {
-    def createEntry(opType: rd.ORMapDeltaOp, u: ORSet[_], m: Map[_, _], zt: Int) = {
+    def createEntry(opType: rd.ORMapDeltaOp, u: ORSet[?], m: Map[?, ?], zt: Int) = {
       if (m.size > 1 && opType != rd.ORMapDeltaOp.ORMapUpdate)
         throw new IllegalArgumentException("Invalid size of ORMap delta map")
       else {
@@ -876,7 +876,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
       }
     }
 
-    def createEntryWithKey(opType: rd.ORMapDeltaOp, u: ORSet[_], k: Any, zt: Int) = {
+    def createEntryWithKey(opType: rd.ORMapDeltaOp, u: ORSet[?], k: Any, zt: Int) = {
       val entryDataBuilder = rd.ORMapDeltaGroup.MapEntry.newBuilder()
       k match {
         case key: String => entryDataBuilder.setStringKey(key)
@@ -894,31 +894,31 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     deltaGroupOps.foreach {
       case ORMap.PutDeltaOp(op, pair, zt) =>
         b.addEntries(
-          createEntry(rd.ORMapDeltaOp.ORMapPut, op.asInstanceOf[ORSet.AddDeltaOp[_]].underlying, Map(pair), zt.value))
+          createEntry(rd.ORMapDeltaOp.ORMapPut, op.asInstanceOf[ORSet.AddDeltaOp[?]].underlying, Map(pair), zt.value))
       case ORMap.RemoveDeltaOp(op, zt) =>
         b.addEntries(
           createEntry(
             rd.ORMapDeltaOp.ORMapRemove,
-            op.asInstanceOf[ORSet.RemoveDeltaOp[_]].underlying,
+            op.asInstanceOf[ORSet.RemoveDeltaOp[?]].underlying,
             Map.empty,
             zt.value))
       case ORMap.RemoveKeyDeltaOp(op, k, zt) =>
         b.addEntries(
           createEntryWithKey(
             rd.ORMapDeltaOp.ORMapRemoveKey,
-            op.asInstanceOf[ORSet.RemoveDeltaOp[_]].underlying,
+            op.asInstanceOf[ORSet.RemoveDeltaOp[?]].underlying,
             k,
             zt.value))
       case ORMap.UpdateDeltaOp(op, m, zt) =>
         b.addEntries(
-          createEntry(rd.ORMapDeltaOp.ORMapUpdate, op.asInstanceOf[ORSet.AddDeltaOp[_]].underlying, m, zt.value))
+          createEntry(rd.ORMapDeltaOp.ORMapUpdate, op.asInstanceOf[ORSet.AddDeltaOp[?]].underlying, m, zt.value))
       case ORMap.DeltaGroup(_) =>
         throw new IllegalArgumentException("ORMap.DeltaGroup should not be nested")
     }
     b.build()
   }
 
-  def lwwmapToProto(lwwmap: LWWMap[_, _]): rd.LWWMap = {
+  def lwwmapToProto(lwwmap: LWWMap[?, ?]): rd.LWWMap = {
     val lwwmapBuilder = rd.LWWMap.newBuilder()
     val entries: jl.Iterable[rd.LWWMap.Entry] =
       getEntries(lwwmap.underlying.entries, rd.LWWMap.Entry.newBuilder _, lwwRegisterToProto)
@@ -933,22 +933,22 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     new LWWMap(new ORMap(keys = orsetFromProto(lwwmap.getKeys), entries, LWWMap.LWWMapTag))
   }
 
-  def pncountermapToProto(pncountermap: PNCounterMap[_]): rd.PNCounterMap = {
+  def pncountermapToProto(pncountermap: PNCounterMap[?]): rd.PNCounterMap = {
     val pncountermapBuilder = rd.PNCounterMap.newBuilder()
     val entries: jl.Iterable[rd.PNCounterMap.Entry] =
       getEntries(pncountermap.underlying.entries, rd.PNCounterMap.Entry.newBuilder _, pncounterToProto)
     pncountermapBuilder.setKeys(orsetToProto(pncountermap.underlying.keys)).addAllEntries(entries).build()
   }
 
-  def pncountermapFromBinary(bytes: Array[Byte]): PNCounterMap[_] =
+  def pncountermapFromBinary(bytes: Array[Byte]): PNCounterMap[?] =
     pncountermapFromProto(rd.PNCounterMap.parseFrom(decompress(bytes)))
 
-  def pncountermapFromProto(pncountermap: rd.PNCounterMap): PNCounterMap[_] = {
+  def pncountermapFromProto(pncountermap: rd.PNCounterMap): PNCounterMap[?] = {
     val entries = mapTypeFromProto(pncountermap.getEntriesList, pncounterFromProto)
     new PNCounterMap(new ORMap(keys = orsetFromProto(pncountermap.getKeys), entries, PNCounterMap.PNCounterMapTag))
   }
 
-  def multimapToProto(multimap: ORMultiMap[_, _]): rd.ORMultiMap = {
+  def multimapToProto(multimap: ORMultiMap[?, ?]): rd.ORMultiMap = {
     val ormultimapBuilder = rd.ORMultiMap.newBuilder()
     val entries: jl.Iterable[rd.ORMultiMap.Entry] =
       getEntries(multimap.underlying.entries, rd.ORMultiMap.Entry.newBuilder _, orsetToProto)

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/JepsenInspiredInsertSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/JepsenInspiredInsertSpec.scala
@@ -135,8 +135,8 @@ class JepsenInspiredInsertSpec
         replicator.tell(Update(key, ORSet(), WriteLocal, Some(i))(_ :+ i), writeProbe.ref)
         writeProbe.receiveOne(3.seconds)
       }
-      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess[_] => success }
-      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure[_] => fail }
+      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess[?] => success }
+      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure[?] => fail }
       successWriteAcks.map(_.request.get).toSet should be(myData.toSet)
       successWriteAcks.size should be(myData.size)
       failureWriteAcks should be(Nil)
@@ -168,8 +168,8 @@ class JepsenInspiredInsertSpec
         replicator.tell(Update(key, ORSet(), writeMajority, Some(i))(_ :+ i), writeProbe.ref)
         writeProbe.receiveOne(timeout + 1.second)
       }
-      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess[_] => success }
-      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure[_] => fail }
+      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess[?] => success }
+      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure[?] => fail }
       successWriteAcks.map(_.request.get).toSet should be(myData.toSet)
       successWriteAcks.size should be(myData.size)
       failureWriteAcks should be(Nil)
@@ -212,8 +212,8 @@ class JepsenInspiredInsertSpec
         replicator.tell(Update(key, ORSet(), WriteLocal, Some(i))(_ :+ i), writeProbe.ref)
         writeProbe.receiveOne(3.seconds)
       }
-      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess[_] => success }
-      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure[_] => fail }
+      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess[?] => success }
+      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure[?] => fail }
       successWriteAcks.map(_.request.get).toSet should be(myData.toSet)
       successWriteAcks.size should be(myData.size)
       failureWriteAcks should be(Nil)
@@ -257,8 +257,8 @@ class JepsenInspiredInsertSpec
         replicator.tell(Update(key, ORSet(), writeMajority, Some(i))(_ :+ i), writeProbe.ref)
         writeProbe.receiveOne(timeout + 1.second)
       }
-      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess[_] => success }
-      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure[_] => fail }
+      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess[?] => success }
+      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure[?] => fail }
       runOn(n1, n4, n5) {
         successWriteAcks.map(_.request.get).toSet should be(myData.toSet)
         successWriteAcks.size should be(myData.size)

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorChaosSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorChaosSpec.scala
@@ -85,8 +85,8 @@ class ReplicatorChaosSpec extends MultiNodeSpec(ReplicatorChaosSpec) with STMult
             g.dataValue match {
               case c: GCounter  => c.value
               case c: PNCounter => c.value
-              case c: GSet[_]   => c.elements
-              case c: ORSet[_]  => c.elements
+              case c: GSet[?]   => c.elements
+              case c: ORSet[?]  => c.elements
               case _            => fail()
             }
         }
@@ -125,7 +125,7 @@ class ReplicatorChaosSpec extends MultiNodeSpec(ReplicatorChaosSpec) with STMult
           replicator ! Update(KeyB, PNCounter(), WriteLocal)(_.decrement(1))
           replicator ! Update(KeyC, GCounter(), WriteAll(timeout))(_ :+ 1)
         }
-        receiveN(15).map(_.getClass).toSet should be(Set(classOf[UpdateSuccess[_]]))
+        receiveN(15).map(_.getClass).toSet should be(Set(classOf[UpdateSuccess[?]]))
       }
 
       runOn(second) {

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorDeltaSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorDeltaSpec.scala
@@ -251,8 +251,8 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
         val p1 = TestProbe()
         fullStateReplicator.tell(Update(KeyD, ORSet.empty[String], writeAll)(_ :+ "A"), p1.ref)
         deltaReplicator.tell(Update(KeyD, ORSet.empty[String], writeAll)(_ :+ "A"), p1.ref)
-        p1.expectMsgType[UpdateSuccess[_]]
-        p1.expectMsgType[UpdateSuccess[_]]
+        p1.expectMsgType[UpdateSuccess[?]]
+        p1.expectMsgType[UpdateSuccess[?]]
       }
       enterBarrier("write-1")
 
@@ -268,9 +268,9 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
         deltaReplicator.tell(Update(KeyD, ORSet.empty[String], writeAll)(_ :+ "B"), p1.ref)
         deltaReplicator.tell(Update(KeyD, ORSet.empty[String], writeAll)(_ :+ "C"), p1.ref)
         deltaReplicator.tell(Update(KeyD, ORSet.empty[String], writeAll)(_ :+ "D"), p1.ref)
-        p1.expectMsgType[UpdateSuccess[_]]
-        p1.expectMsgType[UpdateSuccess[_]]
-        p1.expectMsgType[UpdateSuccess[_]]
+        p1.expectMsgType[UpdateSuccess[?]]
+        p1.expectMsgType[UpdateSuccess[?]]
+        p1.expectMsgType[UpdateSuccess[?]]
       }
       enterBarrier("write-2")
       deltaReplicator.tell(Get(KeyD, ReadLocal), p.ref)
@@ -280,7 +280,7 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
       runOn(first) {
         val p1 = TestProbe()
         fullStateReplicator.tell(Update(KeyD, ORSet.empty[String], writeAll)(_ :+ "A" :+ "B" :+ "C" :+ "D"), p1.ref)
-        p1.expectMsgType[UpdateSuccess[_]]
+        p1.expectMsgType[UpdateSuccess[?]]
       }
       enterBarrier("write-3")
       fullStateReplicator.tell(Get(KeyD, ReadLocal), p.ref)
@@ -293,7 +293,7 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
       runOn(first) {
         val p1 = TestProbe()
         deltaReplicator.tell(Update(KeyHigh, Highest(0), WriteLocal)(_.incr(1)), p1.ref)
-        p1.expectMsgType[UpdateSuccess[_]]
+        p1.expectMsgType[UpdateSuccess[?]]
       }
       enterBarrier("write-1")
 
@@ -316,11 +316,11 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
       runOn(first) {
         val p1 = TestProbe()
         deltaReplicator.tell(Update(KeyHigh, Highest(0), writeAll)(_.incr(2)), p1.ref)
-        p1.expectMsgType[UpdateSuccess[_]]
+        p1.expectMsgType[UpdateSuccess[?]]
         deltaReplicator.tell(Update(KeyHigh, Highest(0), WriteLocal)(_.incrNoDelta(5)), p1.ref)
         deltaReplicator.tell(Update(KeyHigh, Highest(0), WriteLocal)(_.incr(10)), p1.ref)
-        p1.expectMsgType[UpdateSuccess[_]]
-        p1.expectMsgType[UpdateSuccess[_]]
+        p1.expectMsgType[UpdateSuccess[?]]
+        p1.expectMsgType[UpdateSuccess[?]]
       }
       enterBarrier("write-2")
 
@@ -347,7 +347,7 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
         // delta versions again. Same would happen via full state gossip.
         // Thereafter delta can be propagated and applied again.
         deltaReplicator.tell(Update(KeyHigh, Highest(0), writeAll)(_.incr(100)), p1.ref)
-        p1.expectMsgType[UpdateSuccess[_]]
+        p1.expectMsgType[UpdateSuccess[?]]
         // Flush the deltaPropagation buffer, otherwise it will contain
         // NoDeltaPlaceholder from previous updates and the incr(4) delta will also
         // be folded into NoDeltaPlaceholder and not propagated as delta. A few DeltaPropagationTick
@@ -356,7 +356,7 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
           deltaReplicator ! Replicator.Internal.DeltaPropagationTick
         }
         deltaReplicator.tell(Update(KeyHigh, Highest(0), WriteLocal)(_.incr(4)), p1.ref)
-        p1.expectMsgType[UpdateSuccess[_]]
+        p1.expectMsgType[UpdateSuccess[?]]
       }
       enterBarrier("write-3")
 

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorGossipSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorGossipSpec.scala
@@ -93,11 +93,11 @@ class ReplicatorGossipSpec extends MultiNodeSpec(ReplicatorGossipSpec) with STMu
       runOn(first) {
         (0 until numberOfSmall).foreach { i =>
           replicator ! Update(smallORSetKeys(i), ORSet.empty[String], WriteLocal)(_ :+ smallPayload())
-          expectMsgType[UpdateSuccess[_]]
+          expectMsgType[UpdateSuccess[?]]
         }
         (0 until numberOfLarge).foreach { i =>
           replicator ! Update(largeORSetKeys(i), ORSet.empty[String], WriteLocal)(_ :+ largePayload())
-          expectMsgType[UpdateSuccess[_]]
+          expectMsgType[UpdateSuccess[?]]
         }
       }
       enterBarrier("updated-first")

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorORSetDeltaSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorORSetDeltaSpec.scala
@@ -76,7 +76,7 @@ class ReplicatorORSetDeltaSpec
         val value = expectMsgPF() {
           case g @ GetSuccess(`key`, _) =>
             g.dataValue match {
-              case c: ORSet[_] => c.elements
+              case c: ORSet[?] => c.elements
               case _           => fail()
             }
         }

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/ReplicatorSpec.scala
@@ -205,7 +205,7 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
   "reply with ModifyFailure if exception is thrown by modify function" in {
     val e = new RuntimeException("errr")
     replicator ! Update(KeyA, GCounter(), WriteLocal)(_ => throw e)
-    expectMsgType[ModifyFailure[_]].cause should be(e)
+    expectMsgType[ModifyFailure[?]].cause should be(e)
   }
 
   "replicate values to new node" in {
@@ -459,7 +459,7 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
       val probe1 = TestProbe()
       val probe2 = TestProbe()
       replicator.tell(Get(KeyE, readMajority), probe2.ref)
-      probe2.expectMsgType[GetSuccess[_]]
+      probe2.expectMsgType[GetSuccess[?]]
       replicator.tell(Update(KeyE, GCounter(), writeMajority, None) { data =>
           probe1.ref ! data.value
           data :+ 1
@@ -478,7 +478,7 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
     runOn(second) {
       val probe1 = TestProbe()
       replicator.tell(Get(KeyE, readMajority), probe1.ref)
-      probe1.expectMsgType[GetSuccess[_]]
+      probe1.expectMsgType[GetSuccess[?]]
       replicator.tell(Update(KeyE, GCounter(), writeMajority, Some(153))(_ :+ 1), probe1.ref)
       // verify read your own writes, without waiting for the UpdateSuccess reply
       // note that the order of the replies are not defined, and therefore we use separate probes
@@ -527,7 +527,7 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
         replicator ! Update(KeyF, GCounter(), writeTwo)(_ :+ 1)
       }
       val results = receiveN(100)
-      results.map(_.getClass).toSet should be(Set(classOf[UpdateSuccess[_]]))
+      results.map(_.getClass).toSet should be(Set(classOf[UpdateSuccess[?]]))
     }
     enterBarrier("100-updates-done")
     runOn(first, second, third) {
@@ -541,7 +541,7 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
   "read-repair happens before GetSuccess" in {
     runOn(first) {
       replicator ! Update(KeyG, ORSet(), writeTwo)(_ :+ "a" :+ "b")
-      expectMsgType[UpdateSuccess[_]]
+      expectMsgType[UpdateSuccess[?]]
     }
     enterBarrier("a-b-added-to-G")
     runOn(second) {

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LocalConcurrencySpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LocalConcurrencySpec.scala
@@ -87,7 +87,7 @@ class LocalConcurrencySpec(_system: ActorSystem)
       val expected = ((1 to numMessages).map("a" + _) ++ (1 to numMessages).map("b" + _)).toSet
       awaitAssert {
         replicator ! Replicator.Get(Updater.key, Replicator.ReadLocal)
-        val elements = expectMsgType[Replicator.GetSuccess[_]].get(Updater.key) match {
+        val elements = expectMsgType[Replicator.GetSuccess[?]].get(Updater.key) match {
           case ORSet(e) => e
           case _        => fail()
         }

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LotsOfDataBot.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/LotsOfDataBot.scala
@@ -122,7 +122,7 @@ class LotsOfDataBot extends Actor with ActorLogging {
         }
       }
 
-    case _: UpdateResponse[_] => // ignore
+    case _: UpdateResponse[?] => // ignore
     case c @ Changed(ORSetKey(id)) =>
       val elements = c.dataValue match {
         case ORSet(e) => e

--- a/docs/src/test/scala/docs/actor/SharedMutableStateDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/SharedMutableStateDocSpec.scala
@@ -34,7 +34,7 @@ class SharedMutableStateDocSpec {
 
   class CleanUpActor extends Actor {
     def receive = {
-      case set: mutable.Set[_] => set.clear()
+      case set: mutable.Set[?] => set.clear()
     }
   }
 

--- a/docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
+++ b/docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
@@ -95,7 +95,7 @@ object DistributedDataDocSpec {
           replicator ! Update(DataKey, ORSet.empty[String], WriteLocal)(_.remove(s))
         }
 
-      case _: UpdateResponse[_] => // ignore
+      case _: UpdateResponse[?] => // ignore
       case c @ Changed(DataKey) =>
         val data = c.get(DataKey)
         log.info("Current elements: {}", data.elements)
@@ -136,14 +136,14 @@ class DistributedDataDocSpec extends PekkoSpec(DistributedDataDocSpec.config) {
     replicator ! Update(ActiveFlagKey, Flag.Disabled, writeAll)(_.switchOn)
     // #update
 
-    probe.expectMsgType[UpdateResponse[_]] match {
+    probe.expectMsgType[UpdateResponse[?]] match {
       // #update-response1
       case UpdateSuccess(Counter1Key, req) => // ok
       // #update-response1
       case unexpected => fail("Unexpected response: " + unexpected)
     }
 
-    probe.expectMsgType[UpdateResponse[_]] match {
+    probe.expectMsgType[UpdateResponse[?]] match {
       // #update-response2
       case UpdateSuccess(Set1Key, req) => // ok
       case UpdateTimeout(Set1Key, req) =>
@@ -203,7 +203,7 @@ class DistributedDataDocSpec extends PekkoSpec(DistributedDataDocSpec.config) {
     replicator ! Get(ActiveFlagKey, readAll)
     // #get
 
-    probe.expectMsgType[GetResponse[_]] match {
+    probe.expectMsgType[GetResponse[?]] match {
       // #get-response1
       case g @ GetSuccess(Counter1Key, req) =>
         val value = g.get(Counter1Key).value
@@ -212,7 +212,7 @@ class DistributedDataDocSpec extends PekkoSpec(DistributedDataDocSpec.config) {
       case unexpected => fail("Unexpected response: " + unexpected)
     }
 
-    probe.expectMsgType[GetResponse[_]] match {
+    probe.expectMsgType[GetResponse[?]] match {
       // #get-response2
       case g @ GetSuccess(Set1Key, req) =>
         val elements = g.get(Set1Key).elements

--- a/docs/src/test/scala/docs/ddata/ShoppingCart.scala
+++ b/docs/src/test/scala/docs/ddata/ShoppingCart.scala
@@ -118,9 +118,9 @@ class ShoppingCart(userId: String) extends Actor {
   // #remove-item
 
   def receiveOther: Receive = {
-    case _: UpdateSuccess[_] | _: UpdateTimeout[_] =>
+    case _: UpdateSuccess[?] | _: UpdateTimeout[?] =>
     // UpdateTimeout, will eventually be replicated
-    case e: UpdateFailure[_] => throw new IllegalStateException("Unexpected failure: " + e)
+    case e: UpdateFailure[?] => throw new IllegalStateException("Unexpected failure: " + e)
   }
 
 }

--- a/docs/src/test/scala/docs/ddata/protobuf/TwoPhaseSetSerializer.scala
+++ b/docs/src/test/scala/docs/ddata/protobuf/TwoPhaseSetSerializer.scala
@@ -36,7 +36,7 @@ class TwoPhaseSetSerializer(val system: ExtendedActorSystem) extends Serializer 
     case _              => throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass}")
   }
 
-  override def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = {
     twoPhaseSetFromBinary(bytes)
   }
 
@@ -78,7 +78,7 @@ class TwoPhaseSetSerializerWithCompression(system: ExtendedActorSystem) extends 
     case _              => throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass}")
   }
 
-  override def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = {
     twoPhaseSetFromBinary(decompress(bytes))
   }
   // #compression

--- a/docs/src/test/scala/docs/ddata/protobuf/TwoPhaseSetSerializer2.scala
+++ b/docs/src/test/scala/docs/ddata/protobuf/TwoPhaseSetSerializer2.scala
@@ -33,7 +33,7 @@ class TwoPhaseSetSerializer2(val system: ExtendedActorSystem) extends Serializer
     case _              => throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass}")
   }
 
-  override def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = {
     twoPhaseSetFromBinary(bytes)
   }
 

--- a/docs/src/test/scala/docs/event/LoggingDocSpec.scala
+++ b/docs/src/test/scala/docs/event/LoggingDocSpec.scala
@@ -112,7 +112,7 @@ object LoggingDocSpec {
   object MyType {
     implicit val logSource: LogSource[AnyRef] = new LogSource[AnyRef] {
       def genString(o: AnyRef): String = o.getClass.getName
-      override def getClazz(o: AnyRef): Class[_] = o.getClass
+      override def getClazz(o: AnyRef): Class[?] = o.getClass
     }
   }
 

--- a/docs/src/test/scala/docs/io/EchoServer.scala
+++ b/docs/src/test/scala/docs/io/EchoServer.scala
@@ -35,7 +35,7 @@ object EchoServer extends App {
   system.terminate()
 }
 
-class EchoManager(handlerClass: Class[_]) extends Actor with ActorLogging {
+class EchoManager(handlerClass: Class[?]) extends Actor with ActorLogging {
 
   import Tcp._
   import context.system

--- a/docs/src/test/scala/docs/persistence/PersistenceSerializerDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceSerializerDocSpec.scala
@@ -54,12 +54,12 @@ class MyPayloadSerializer extends Serializer {
   def identifier: Int = 77124
   def includeManifest: Boolean = false
   def toBinary(o: AnyRef): Array[Byte] = ???
-  def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = ???
+  def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = ???
 }
 
 class MySnapshotSerializer extends Serializer {
   def identifier: Int = 77125
   def includeManifest: Boolean = false
   def toBinary(o: AnyRef): Array[Byte] = ???
-  def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = ???
+  def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = ???
 }

--- a/docs/src/test/scala/docs/serialization/SerializationDocSpec.scala
+++ b/docs/src/test/scala/docs/serialization/SerializationDocSpec.scala
@@ -53,7 +53,7 @@ package docs.serialization {
 
     // "fromBinary" deserializes the given array,
     // using the type hint (if any, see "includeManifest" above)
-    def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+    def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = {
       // Put your code that deserializes here
       // #...
       null

--- a/docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
@@ -110,9 +110,9 @@ class GraphDSLDocSpec extends PekkoSpec {
 
       // It is important to provide the list of all input and output
       // ports with a stable order. Duplicates are not allowed.
-      override val inlets: immutable.Seq[Inlet[_]] =
+      override val inlets: immutable.Seq[Inlet[?]] =
         jobsIn :: priorityJobsIn :: Nil
-      override val outlets: immutable.Seq[Outlet[_]] =
+      override val outlets: immutable.Seq[Outlet[?]] =
         resultsOut :: Nil
 
       // A Shape must be able to create a copy of itself. Basically

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeAdhocSource.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeAdhocSource.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 class RecipeAdhocSource extends RecipeSpec {
 
   // #adhoc-source
-  def adhocSource[T](source: Source[T, _], timeout: FiniteDuration, maxRetries: Int): Source[T, _] =
+  def adhocSource[T](source: Source[T, ?], timeout: FiniteDuration, maxRetries: Int): Source[T, ?] =
     Source.lazySource(() =>
       source
         .backpressureTimeout(timeout)

--- a/docs/src/test/scala/docs/stream/operators/source/Zip.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/Zip.scala
@@ -18,7 +18,7 @@ import org.apache.pekko.stream.scaladsl.Source
 
 object Zip {
 
-  implicit val system: ActorSystem[_] = ???
+  implicit val system: ActorSystem[?] = ???
 
   def zipN(): Unit = {
     // #zipN-simple

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Limit.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Limit.scala
@@ -22,7 +22,7 @@ import scala.concurrent.Future
 
 object Limit {
 
-  implicit val system: ActorSystem[_] = ???
+  implicit val system: ActorSystem[?] = ???
 
   def simple(): Unit = {
     // #simple

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/LimitWeighted.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/LimitWeighted.scala
@@ -22,7 +22,7 @@ import scala.concurrent.Future
 
 object LimitWeighted {
 
-  implicit val system: ActorSystem[_] = ???
+  implicit val system: ActorSystem[?] = ???
 
   def simple(): Unit = {
     // #simple

--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
@@ -56,11 +56,11 @@ object Player {
       case Transition(_, f: ClientFSM.State, t: ClientFSM.State)
           if f == AwaitDone && t == Connected => // SI-5900 workaround
         waiting ! Done; context.stop(self)
-      case t: Transition[_] =>
+      case t: Transition[?] =>
         waiting ! Status.Failure(new RuntimeException("unexpected transition: " + t)); context.stop(self)
       case CurrentState(_, s: ClientFSM.State) if s == Connected => // SI-5900 workaround
         waiting ! Done; context.stop(self)
-      case _: CurrentState[_] =>
+      case _: CurrentState[?] =>
     }
 
   }

--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testkit/MultiNodeSpec.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testkit/MultiNodeSpec.scala
@@ -464,9 +464,9 @@ abstract class MultiNodeSpec(
    */
   def node(role: RoleName): ActorPath = RootActorPath(testConductor.getAddressFor(role).await)
 
-  def muteDeadLetters(messageClasses: Class[_]*)(sys: ActorSystem = system): Unit =
+  def muteDeadLetters(messageClasses: Class[?]*)(sys: ActorSystem = system): Unit =
     if (!sys.log.isDebugEnabled) {
-      def mute(clazz: Class[_]): Unit =
+      def mute(clazz: Class[?]): Unit =
         sys.eventStream.publish(Mute(DeadLettersFilter(clazz)(occurrences = Int.MaxValue)))
       if (messageClasses.isEmpty) mute(classOf[AnyRef])
       else messageClasses.foreach(mute)

--- a/osgi/src/main/scala/org/apache/pekko/osgi/ActorSystemActivator.scala
+++ b/osgi/src/main/scala/org/apache/pekko/osgi/ActorSystemActivator.scala
@@ -35,7 +35,7 @@ import pekko.util.unused
 abstract class ActorSystemActivator extends BundleActivator {
 
   private var system: Option[ActorSystem] = None
-  private var registration: Option[ServiceRegistration[_]] = None
+  private var registration: Option[ServiceRegistration[?]] = None
 
   /**
    * Implement this method to add your own actors to the ActorSystem.  If you want to share the actor
@@ -88,7 +88,7 @@ abstract class ActorSystemActivator extends BundleActivator {
   /**
    * Convenience method to find a service by its reference.
    */
-  def serviceForReference[T](context: BundleContext, reference: ServiceReference[_]): T =
+  def serviceForReference[T](context: BundleContext, reference: ServiceReference[?]): T =
     context.getService(reference).asInstanceOf[T]
 
   /**

--- a/osgi/src/main/scala/org/apache/pekko/osgi/BundleDelegatingClassLoader.scala
+++ b/osgi/src/main/scala/org/apache/pekko/osgi/BundleDelegatingClassLoader.scala
@@ -50,8 +50,8 @@ class BundleDelegatingClassLoader(bundle: Bundle, fallBackClassLoader: ClassLoad
 
   private val bundles = findTransitiveBundles(bundle).toList
 
-  override def findClass(name: String): Class[_] = {
-    @tailrec def find(remaining: List[Bundle]): Class[_] = {
+  override def findClass(name: String): Class[?] = {
+    @tailrec def find(remaining: List[Bundle]): Class[?] = {
       if (remaining.isEmpty) throw new ClassNotFoundException(name)
       else
         Try { remaining.head.loadClass(name) } match {

--- a/osgi/src/test/scala/org/apache/pekko/osgi/PojoSRTestSupport.scala
+++ b/osgi/src/test/scala/org/apache/pekko/osgi/PojoSRTestSupport.scala
@@ -150,7 +150,7 @@ class BundleDescriptorBuilder(name: String) {
   /**
    * Add a Bundle activator to our test bundle
    */
-  def withActivator(activator: Class[_ <: BundleActivator]): BundleDescriptorBuilder = {
+  def withActivator(activator: Class[? <: BundleActivator]): BundleDescriptorBuilder = {
     tinybundle.set(Constants.BUNDLE_ACTIVATOR, activator.getName)
     this
   }

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/internal/QuerySerializer.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/internal/QuerySerializer.scala
@@ -60,14 +60,14 @@ import pekko.serialization.Serializers
   private val timestampOffsetSeparator = ';'
 
   override def manifest(o: AnyRef): String = o match {
-    case _: EventEnvelope[_] => EventEnvelopeManifest
+    case _: EventEnvelope[?] => EventEnvelopeManifest
     case offset: Offset      => toStorageRepresentation(offset)._2
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }
 
   override def toBinary(o: AnyRef): Array[Byte] = o match {
-    case env: EventEnvelope[_] =>
+    case env: EventEnvelope[?] =>
       val builder = QueryMessages.EventEnvelope.newBuilder()
 
       val (offset, offsetManifest) = toStorageRepresentation(env.offset)

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/AllPersistenceIdsStage.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/AllPersistenceIdsStage.scala
@@ -46,7 +46,7 @@ final private[pekko] class AllPersistenceIdsStage(liveQuery: Boolean, writeJourn
       val journal: ActorRef = Persistence(mat.system).journalFor(writeJournalPluginId)
       var initialResponseReceived = false
 
-      override protected def logSource: Class[_] = classOf[AllPersistenceIdsStage]
+      override protected def logSource: Class[?] = classOf[AllPersistenceIdsStage]
 
       override def preStart(): Unit = {
         journal.tell(LeveldbJournal.SubscribeAllPersistenceIds, getStageActor(journalInteraction).ref)

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/EventsByPersistenceIdStage.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/EventsByPersistenceIdStage.scala
@@ -72,7 +72,7 @@ final private[pekko] class EventsByPersistenceIdStage(
       var nextSequenceNr = fromSequenceNr
       var toSequenceNr = initialToSequenceNr
 
-      override protected def logSource: Class[_] = classOf[EventsByPersistenceIdStage]
+      override protected def logSource: Class[?] = classOf[EventsByPersistenceIdStage]
 
       override def preStart(): Unit = {
         stageActorRef = getStageActor(journalInteraction).ref

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/EventsByTagStage.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/EventsByTagStage.scala
@@ -72,7 +72,7 @@ final private[leveldb] class EventsByTagStage(
       var replayInProgress = false
       var outstandingReplay = false
 
-      override protected def logSource: Class[_] = classOf[EventsByTagStage]
+      override protected def logSource: Class[?] = classOf[EventsByTagStage]
 
       override def preStart(): Unit = {
         stageActorRef = getStageActor(journalInteraction).ref

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/EventEnvelope.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/EventEnvelope.scala
@@ -114,7 +114,7 @@ final class EventEnvelope[Event](
   }
 
   override def equals(obj: Any): Boolean = obj match {
-    case other: EventEnvelope[_] =>
+    case other: EventEnvelope[?] =>
       offset == other.offset && persistenceId == other.persistenceId && sequenceNr == other.sequenceNr &&
       eventOption == other.eventOption && timestamp == other.timestamp && eventMetadata == other.eventMetadata &&
       entityType == other.entityType && slice == other.slice

--- a/persistence-shared/src/test/scala/org/apache/pekko/persistence/serialization/SerializerSpec.scala
+++ b/persistence-shared/src/test/scala/org/apache/pekko/persistence/serialization/SerializerSpec.scala
@@ -397,7 +397,7 @@ class MyPayloadSerializer extends Serializer {
     case x               => throw new NotSerializableException(s"Unexpected object: $x")
   }
 
-  def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = manifest match {
+  def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = manifest match {
     case Some(MyPayloadClass) => MyPayload(s"${new String(bytes, UTF_8)}.")
     case Some(c)              => throw new Exception(s"unexpected manifest $c")
     case None                 => throw new Exception("no manifest")
@@ -441,7 +441,7 @@ class MySnapshotSerializer extends Serializer {
     case x                => throw new NotSerializableException(s"Unexpected object: $x")
   }
 
-  def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = manifest match {
+  def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = manifest match {
     case Some(MySnapshotClass) => MySnapshot(s"${new String(bytes, UTF_8)}.")
     case Some(c)               => throw new Exception(s"unexpected manifest $c")
     case None                  => throw new Exception("no manifest")

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -97,7 +97,7 @@ import pekko.stream.scaladsl.Sink
 
   import EventSourcedBehaviorTestKitImpl._
 
-  private def system: ActorSystem[_] = actorTestKit.system
+  private def system: ActorSystem[?] = actorTestKit.system
   if (system.settings.config.getBoolean("pekko.persistence.testkit.events.serialize") ||
     system.settings.config.getBoolean("pekko.persistence.testkit.snapshots.serialize")) {
     system.log.warn(
@@ -176,7 +176,7 @@ import pekko.stream.scaladsl.Sink
   }
 
   private def getHighestSeqNr(): Long = {
-    implicit val sys: ActorSystem[_] = system
+    implicit val sys: ActorSystem[?] = system
     val result =
       queries.currentEventsByPersistenceId(persistenceId.id, 0L, toSequenceNr = Long.MaxValue).runWith(Sink.lastOption)
 
@@ -187,7 +187,7 @@ import pekko.stream.scaladsl.Sink
   }
 
   private def getEvents(fromSeqNr: Long): immutable.Seq[Event] = {
-    implicit val sys: ActorSystem[_] = system
+    implicit val sys: ActorSystem[?] = system
     val result =
       queries.currentEventsByPersistenceId(persistenceId.id, fromSeqNr, toSequenceNr = Long.MaxValue).runWith(Sink.seq)
 

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/SnapshotStorageEmulatorExtension.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/SnapshotStorageEmulatorExtension.scala
@@ -35,6 +35,6 @@ private[testkit] object SnapshotStorageEmulatorExtension extends ExtensionId[Sna
       new SimpleSnapshotStorageImpl
     }
 
-  override def lookup: ExtensionId[_ <: Extension] =
+  override def lookup: ExtensionId[? <: Extension] =
     SnapshotStorageEmulatorExtension
 }

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
@@ -102,7 +102,7 @@ object EventSourcedBehaviorTestKit {
    * Factory method to create a new EventSourcedBehaviorTestKit.
    */
   def create[Command, Event, State](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       behavior: Behavior[Command]): EventSourcedBehaviorTestKit[Command, Event, State] =
     create(system, behavior, enabledSerializationSettings)
 
@@ -112,7 +112,7 @@ object EventSourcedBehaviorTestKit {
    * Note that `equals` must be implemented in the commands, events and state if `verifyEquality` is enabled.
    */
   def create[Command, Event, State](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       behavior: Behavior[Command],
       serializationSettings: SerializationSettings): EventSourcedBehaviorTestKit[Command, Event, State] = {
     val scaladslSettings = new scaladsl.EventSourcedBehaviorTestKit.SerializationSettings(

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/PersistenceTestKit.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/PersistenceTestKit.scala
@@ -451,6 +451,6 @@ object PersistenceTestKit {
 
   def create(system: ActorSystem): PersistenceTestKit = new PersistenceTestKit(system)
 
-  def create(system: TypedActorSystem[_]): PersistenceTestKit = create(system.classicSystem)
+  def create(system: TypedActorSystem[?]): PersistenceTestKit = create(system.classicSystem)
 
 }

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/SnapshotTestKit.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/SnapshotTestKit.scala
@@ -278,6 +278,6 @@ object SnapshotTestKit {
 
   def create(system: ActorSystem): SnapshotTestKit = new SnapshotTestKit(system)
 
-  def create(system: TypedActorSystem[_]): SnapshotTestKit = create(system.classicSystem)
+  def create(system: TypedActorSystem[?]): SnapshotTestKit = create(system.classicSystem)
 
 }

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
@@ -105,7 +105,7 @@ object EventSourcedBehaviorTestKit {
    * Factory method to create a new EventSourcedBehaviorTestKit.
    */
   def apply[Command, Event, State](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       behavior: Behavior[Command]): EventSourcedBehaviorTestKit[Command, Event, State] =
     apply(system, behavior, SerializationSettings.enabled)
 
@@ -116,7 +116,7 @@ object EventSourcedBehaviorTestKit {
    * `verifyEquality` is enabled.
    */
   def apply[Command, Event, State](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       behavior: Behavior[Command],
       serializationSettings: SerializationSettings): EventSourcedBehaviorTestKit[Command, Event, State] =
     new EventSourcedBehaviorTestKitImpl(ActorTestKit(system), behavior, serializationSettings)

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/PersistenceTestKit.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/PersistenceTestKit.scala
@@ -410,7 +410,7 @@ object SnapshotTestKit {
 
   def apply(implicit system: ActorSystem): SnapshotTestKit = new SnapshotTestKit(system)
 
-  def apply(implicit system: TypedActorSystem[_]): SnapshotTestKit = apply(system.classicSystem)
+  def apply(implicit system: TypedActorSystem[?]): SnapshotTestKit = apply(system.classicSystem)
 
   object Settings extends ExtensionId[Settings] {
 

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/TestOps.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/TestOps.scala
@@ -26,7 +26,7 @@ import pekko.util
 import pekko.util.BoxedType
 
 private[testkit] trait RejectSupport[U] {
-  this: PolicyOpsTestKit[U] with HasStorage[U, _] =>
+  this: PolicyOpsTestKit[U] with HasStorage[U, ?] =>
 
   /**
    * Reject `n` following journal operations depending on the condition `cond`.
@@ -67,7 +67,7 @@ private[testkit] trait RejectSupport[U] {
 }
 
 private[testkit] trait PolicyOpsTestKit[P] {
-  this: HasStorage[P, _] =>
+  this: HasStorage[P, ?] =>
 
   private[testkit] val Policies: DefaultPolicies[P]
 
@@ -124,7 +124,7 @@ private[testkit] trait PolicyOpsTestKit[P] {
 }
 
 private[testkit] trait ExpectOps[U] {
-  this: HasStorage[_, U] =>
+  this: HasStorage[?, U] =>
 
   private[testkit] val probe: TestKitBase
 
@@ -265,7 +265,7 @@ private[testkit] trait ExpectOps[U] {
 }
 
 private[testkit] trait ClearOps {
-  this: HasStorage[_, _] =>
+  this: HasStorage[?, ?] =>
 
   /**
    * Clear all data from the storage.
@@ -294,7 +294,7 @@ private[testkit] trait ClearOps {
 }
 
 private[testkit] trait ClearPreservingSeqNums {
-  this: HasStorage[_, _] =>
+  this: HasStorage[?, ?] =>
 
   /**
    * Clear all data in the storage preserving sequence numbers.

--- a/persistence-typed-tests/src/test/scala/docs/org/apache/pekko/persistence/typed/ReplicatedEventSourcingCompileOnlySpec.scala
+++ b/persistence-typed-tests/src/test/scala/docs/org/apache/pekko/persistence/typed/ReplicatedEventSourcingCompileOnlySpec.scala
@@ -40,7 +40,7 @@ object ReplicatedEventSourcingCompileOnlySpec {
   object Shared {
     // #factory-shared
     def apply(
-        system: ActorSystem[_],
+        system: ActorSystem[?],
         entityId: String,
         replicaId: ReplicaId): EventSourcedBehavior[Command, State, Event] = {
       ReplicatedEventSourcing.commonJournalConfig(
@@ -56,7 +56,7 @@ object ReplicatedEventSourcingCompileOnlySpec {
   object PerReplica {
     // #factory
     def apply(
-        system: ActorSystem[_],
+        system: ActorSystem[?],
         entityId: String,
         replicaId: ReplicaId): EventSourcedBehavior[Command, State, Event] = {
       ReplicatedEventSourcing.perReplicaJournalConfig(

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorReplySpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorReplySpec.scala
@@ -40,13 +40,13 @@ object EventSourcedBehaviorReplySpec {
 
   final case class State(value: Int, history: Vector[Int]) extends CborSerializable
 
-  def counter(persistenceId: PersistenceId): Behavior[Command[_]] =
+  def counter(persistenceId: PersistenceId): Behavior[Command[?]] =
     Behaviors.setup(ctx => counter(ctx, persistenceId))
 
   def counter(
-      ctx: ActorContext[Command[_]],
-      persistenceId: PersistenceId): EventSourcedBehavior[Command[_], Event, State] = {
-    EventSourcedBehavior.withEnforcedReplies[Command[_], Event, State](
+      ctx: ActorContext[Command[?]],
+      persistenceId: PersistenceId): EventSourcedBehavior[Command[?], Event, State] = {
+    EventSourcedBehavior.withEnforcedReplies[Command[?], Event, State](
       persistenceId,
       emptyState = State(0, Vector.empty),
       commandHandler = (state, command) =>

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -128,15 +128,15 @@ object EventSourcedBehaviorSpec {
   val firstLogging = "first logging"
   val secondLogging = "second logging"
 
-  def counter(persistenceId: PersistenceId)(implicit system: ActorSystem[_]): Behavior[Command] =
+  def counter(persistenceId: PersistenceId)(implicit system: ActorSystem[?]): Behavior[Command] =
     Behaviors.setup(ctx => counter(ctx, persistenceId))
 
   def counter(persistenceId: PersistenceId, logging: ActorRef[String])(
-      implicit system: ActorSystem[_]): Behavior[Command] =
+      implicit system: ActorSystem[?]): Behavior[Command] =
     Behaviors.setup(ctx => counter(ctx, persistenceId, logging))
 
   def counter(ctx: ActorContext[Command], persistenceId: PersistenceId)(
-      implicit system: ActorSystem[_]): EventSourcedBehavior[Command, Event, State] =
+      implicit system: ActorSystem[?]): EventSourcedBehavior[Command, Event, State] =
     counter(
       ctx,
       persistenceId,
@@ -145,7 +145,7 @@ object EventSourcedBehaviorSpec {
       snapshotProbe = TestProbe[Try[SnapshotMetadata]]().ref)
 
   def counter(ctx: ActorContext[Command], persistenceId: PersistenceId, logging: ActorRef[String])(
-      implicit system: ActorSystem[_]): EventSourcedBehavior[Command, Event, State] =
+      implicit system: ActorSystem[?]): EventSourcedBehavior[Command, Event, State] =
     counter(
       ctx,
       persistenceId,
@@ -158,18 +158,18 @@ object EventSourcedBehaviorSpec {
       persistenceId: PersistenceId,
       probe: ActorRef[(State, Event)],
       snapshotProbe: ActorRef[Try[SnapshotMetadata]])(
-      implicit system: ActorSystem[_]): EventSourcedBehavior[Command, Event, State] =
+      implicit system: ActorSystem[?]): EventSourcedBehavior[Command, Event, State] =
     counter(ctx, persistenceId, TestProbe[String]().ref, probe, snapshotProbe)
 
   def counterWithProbe(ctx: ActorContext[Command], persistenceId: PersistenceId, probe: ActorRef[(State, Event)])(
-      implicit system: ActorSystem[_]): EventSourcedBehavior[Command, Event, State] =
+      implicit system: ActorSystem[?]): EventSourcedBehavior[Command, Event, State] =
     counter(ctx, persistenceId, TestProbe[String]().ref, probe, TestProbe[Try[SnapshotMetadata]]().ref)
 
   def counterWithSnapshotProbe(
       ctx: ActorContext[Command],
       persistenceId: PersistenceId,
       probe: ActorRef[Try[SnapshotMetadata]])(
-      implicit system: ActorSystem[_]): EventSourcedBehavior[Command, Event, State] =
+      implicit system: ActorSystem[?]): EventSourcedBehavior[Command, Event, State] =
     counter(ctx, persistenceId, TestProbe[String]().ref, TestProbe[(State, Event)]().ref, snapshotProbe = probe)
 
   def counter(
@@ -728,7 +728,7 @@ class EventSourcedBehaviorSpec
       firstThree ++ others should contain theSameElementsInOrderAs all
     }
 
-    def watcher(toWatch: ActorRef[_]): TestProbe[String] = {
+    def watcher(toWatch: ActorRef[?]): TestProbe[String] = {
       val probe = TestProbe[String]()
       val w = Behaviors.setup[Any] { ctx =>
         ctx.watch(toWatch)

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -79,18 +79,18 @@ object EventSourcedBehaviorStashSpec {
 
   final case class State(value: Int, active: Boolean)
 
-  def counter(persistenceId: PersistenceId, signalProbe: Option[ActorRef[String]] = None): Behavior[Command[_]] =
+  def counter(persistenceId: PersistenceId, signalProbe: Option[ActorRef[String]] = None): Behavior[Command[?]] =
     Behaviors
-      .supervise[Command[_]] {
+      .supervise[Command[?]] {
         Behaviors.setup(_ => eventSourcedCounter(persistenceId, signalProbe))
       }
       .onFailure(SupervisorStrategy.restart.withLoggingEnabled(enabled = false))
 
   def eventSourcedCounter(
       persistenceId: PersistenceId,
-      signalProbe: Option[ActorRef[String]]): EventSourcedBehavior[Command[_], Event, State] = {
+      signalProbe: Option[ActorRef[String]]): EventSourcedBehavior[Command[?], Event, State] = {
     EventSourcedBehavior
-      .withEnforcedReplies[Command[_], Event, State](
+      .withEnforcedReplies[Command[?], Event, State](
         persistenceId,
         emptyState = State(0, active = true),
         commandHandler = (state, command) => {
@@ -120,7 +120,7 @@ object EventSourcedBehaviorStashSpec {
       }
   }
 
-  private def active(state: State, command: Command[_]): ReplyEffect[Event, State] = {
+  private def active(state: State, command: Command[?]): ReplyEffect[Event, State] = {
     command match {
       case Increment(id, replyTo) =>
         Effect.persist(Incremented(1)).thenReply(replyTo)(_ => Ack(id))
@@ -146,7 +146,7 @@ object EventSourcedBehaviorStashSpec {
     }
   }
 
-  private def inactive(state: State, command: Command[_]): ReplyEffect[Event, State] = {
+  private def inactive(state: State, command: Command[?]): ReplyEffect[Event, State] = {
     command match {
       case _: Increment =>
         Effect.stash()

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorWatchSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorWatchSpec.scala
@@ -44,7 +44,7 @@ object EventSourcedBehaviorWatchSpec {
   case object Fail extends Command
   case object Stop extends Command
   final case class ChildHasFailed(t: pekko.actor.typed.ChildFailed)
-  final case class HasTerminated(ref: ActorRef[_])
+  final case class HasTerminated(ref: ActorRef[?])
 }
 
 class EventSourcedBehaviorWatchSpec
@@ -65,7 +65,7 @@ class EventSourcedBehaviorWatchSpec
   private def setup(
       pf: PartialFunction[(String, Signal), Unit],
       settings: EventSourcedSettings,
-      context: ActorContext[_]): BehaviorSetup[Command, String, String] =
+      context: ActorContext[?]): BehaviorSetup[Command, String, String] =
     new BehaviorSetup[Command, String, String](
       context.asInstanceOf[ActorContext[InternalProtocol]],
       nextPid,

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
@@ -47,11 +47,11 @@ object DurableStateBehaviorReplySpec {
 
   final case class State(value: Int) extends CborSerializable
 
-  def counter(persistenceId: PersistenceId): Behavior[Command[_]] =
+  def counter(persistenceId: PersistenceId): Behavior[Command[?]] =
     Behaviors.setup(ctx => counter(ctx, persistenceId))
 
-  def counter(ctx: ActorContext[Command[_]], persistenceId: PersistenceId): DurableStateBehavior[Command[_], State] = {
-    DurableStateBehavior.withEnforcedReplies[Command[_], State](
+  def counter(ctx: ActorContext[Command[?]], persistenceId: PersistenceId): DurableStateBehavior[Command[?], State] = {
+    DurableStateBehavior.withEnforcedReplies[Command[?], State](
       persistenceId,
       emptyState = State(0),
       commandHandler = (state, command) =>

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/crdt/ORSet.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/crdt/ORSet.scala
@@ -495,7 +495,7 @@ final class ORSet[A] private[pekko] (
   override def toString: String = s"OR$elements"
 
   override def equals(o: Any): Boolean = o match {
-    case other: ORSet[_] =>
+    case other: ORSet[?] =>
       originReplica == other.originReplica && vvector == other.vvector && elementsMap == other.elementsMap
     case _ => false
   }

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/delivery/EventSourcedProducerQueue.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/delivery/EventSourcedProducerQueue.scala
@@ -52,7 +52,7 @@ object EventSourcedProducerQueue {
      * Scala API: Factory method from config `pekko.reliable-delivery.producer-controller.event-sourced-durable-queue`
      * of the `ActorSystem`.
      */
-    def apply(system: ActorSystem[_]): Settings =
+    def apply(system: ActorSystem[?]): Settings =
       apply(system.settings.config.getConfig("pekko.reliable-delivery.producer-controller.event-sourced-durable-queue"))
 
     /**
@@ -74,7 +74,7 @@ object EventSourcedProducerQueue {
      * Java API: Factory method from config `pekko.reliable-delivery.producer-controller.event-sourced-durable-queue`
      * of the `ActorSystem`.
      */
-    def create(system: ActorSystem[_]): Settings =
+    def create(system: ActorSystem[?]): Settings =
       apply(system)
 
     /**
@@ -274,7 +274,7 @@ private class EventSourcedProducerQueue[A](
         case LoadState(replyTo) =>
           Effect.reply(replyTo)(state)
 
-        case _: CleanupTick[_] =>
+        case _: CleanupTick[?] =>
           onCleanupTick(state)
 
         case cmd =>
@@ -307,7 +307,7 @@ private class EventSourcedProducerQueue[A](
 
   def onCommandBeforeInitialCleanup(state: State[A], command: Command[A]): Effect[Event, State[A]] = {
     command match {
-      case _: CleanupTick[_] =>
+      case _: CleanupTick[?] =>
         val old = oldUnconfirmedToCleanup(state)
         val stateWithoutPartialChunkedMessages = state.cleanupPartialChunkedMessages()
         initialCleanupDone = true

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -102,7 +102,7 @@ private[pekko] final case class EventSourcedBehaviorImpl[Command, Event, State](
     emptyState: State,
     commandHandler: EventSourcedBehavior.CommandHandler[Command, Event, State],
     eventHandler: EventSourcedBehavior.EventHandler[State, Event],
-    loggerClass: Class[_],
+    loggerClass: Class[?],
     journalPluginId: Option[String] = None,
     snapshotPluginId: Option[String] = None,
     tagger: Event => Set[String] = (_: Event) => Set.empty[String],
@@ -128,7 +128,7 @@ private[pekko] final case class EventSourcedBehaviorImpl[Command, Event, State](
   override def apply(context: typed.TypedActorContext[Command]): Behavior[Command] = {
     val ctx = context.asScala
     val hasCustomLoggerName = ctx match {
-      case internalCtx: ActorContextImpl[_] => internalCtx.hasCustomLoggerName
+      case internalCtx: ActorContextImpl[?] => internalCtx.hasCustomLoggerName
       case _                                => false
     }
     if (!hasCustomLoggerName) ctx.setLoggerName(loggerClass)
@@ -245,7 +245,7 @@ private[pekko] final case class EventSourcedBehaviorImpl[Command, Event, State](
   }
 
   @InternalStableApi
-  private[pekko] def initialize(@unused context: ActorContext[_]): Unit = ()
+  private[pekko] def initialize(@unused context: ActorContext[?]): Unit = ()
 
   override def receiveSignal(
       handler: PartialFunction[(State, Signal), Unit]): EventSourcedBehavior[Command, Event, State] =
@@ -275,7 +275,7 @@ private[pekko] final case class EventSourcedBehaviorImpl[Command, Event, State](
   override def withTagger(tagger: Event => Set[String]): EventSourcedBehavior[Command, Event, State] =
     copy(tagger = tagger)
 
-  override def eventAdapter(adapter: EventAdapter[Event, _]): EventSourcedBehavior[Command, Event, State] =
+  override def eventAdapter(adapter: EventAdapter[Event, ?]): EventSourcedBehavior[Command, Event, State] =
     copy(eventAdapter = adapter.asInstanceOf[EventAdapter[Event, Any]])
 
   override def snapshotAdapter(adapter: SnapshotAdapter[State]): EventSourcedBehavior[Command, Event, State] =

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventSourcedSettings.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventSourcedSettings.scala
@@ -29,7 +29,7 @@ import pekko.persistence.Persistence
  */
 @InternalApi private[pekko] object EventSourcedSettings {
 
-  def apply(system: ActorSystem[_], journalPluginId: String, snapshotPluginId: String): EventSourcedSettings =
+  def apply(system: ActorSystem[?], journalPluginId: String, snapshotPluginId: String): EventSourcedSettings =
     apply(system.settings.config, journalPluginId, snapshotPluginId)
 
   def apply(config: Config, journalPluginId: String, snapshotPluginId: String): EventSourcedSettings = {

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ExternalInteractions.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ExternalInteractions.scala
@@ -52,7 +52,7 @@ private[pekko] trait JournalInteractions[C, E, S] {
   def setup: BehaviorSetup[C, E, S]
 
   protected def internalPersist(
-      ctx: ActorContext[_],
+      ctx: ActorContext[?],
       cmd: Any,
       state: Running.RunningState[S],
       event: EventOrTaggedOrReplicated,
@@ -86,12 +86,12 @@ private[pekko] trait JournalInteractions[C, E, S] {
 
   @InternalStableApi
   private[pekko] def onWriteInitiated(
-      @unused ctx: ActorContext[_],
+      @unused ctx: ActorContext[?],
       @unused cmd: Any,
       @unused repr: PersistentRepr): Unit = ()
 
   protected def internalPersistAll(
-      ctx: ActorContext[_],
+      ctx: ActorContext[?],
       cmd: Any,
       state: Running.RunningState[S],
       events: immutable.Seq[EventToPersist]): Running.RunningState[S] = {
@@ -127,7 +127,7 @@ private[pekko] trait JournalInteractions[C, E, S] {
 
   @InternalStableApi
   private[pekko] def onWritesInitiated(
-      @unused ctx: ActorContext[_],
+      @unused ctx: ActorContext[?],
       @unused cmd: Any,
       @unused repr: immutable.Seq[PersistentRepr]): Unit = ()
 

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ReplayingEvents.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ReplayingEvents.scala
@@ -97,11 +97,11 @@ private[pekko] final class ReplayingEvents[C, E, S](
   onRecoveryStart(setup.context)
 
   @InternalStableApi
-  def onRecoveryStart(@unused context: ActorContext[_]): Unit = ()
+  def onRecoveryStart(@unused context: ActorContext[?]): Unit = ()
   @InternalStableApi
-  def onRecoveryComplete(@unused context: ActorContext[_]): Unit = ()
+  def onRecoveryComplete(@unused context: ActorContext[?]): Unit = ()
   @InternalStableApi
-  def onRecoveryFailed(@unused context: ActorContext[_], @unused reason: Throwable, @unused event: Option[Any]): Unit =
+  def onRecoveryFailed(@unused context: ActorContext[?], @unused reason: Throwable, @unused event: Option[Any]): Unit =
     ()
 
   override def onMessage(msg: InternalProtocol): Behavior[InternalProtocol] = {
@@ -204,7 +204,7 @@ private[pekko] final class ReplayingEvents[C, E, S](
           Behaviors.unhandled
       }
     } catch {
-      case ex: UnstashException[_] =>
+      case ex: UnstashException[?] =>
         // let supervisor handle it, don't treat it as recovery failure
         throw ex
       case NonFatal(cause) =>

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ReplayingSnapshot.scala
@@ -119,9 +119,9 @@ private[pekko] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetu
   }
 
   @InternalStableApi
-  def onRecoveryStart(@unused context: ActorContext[_]): Unit = ()
+  def onRecoveryStart(@unused context: ActorContext[?]): Unit = ()
   @InternalStableApi
-  def onRecoveryFailed(@unused context: ActorContext[_], @unused reason: Throwable): Unit = ()
+  def onRecoveryFailed(@unused context: ActorContext[?], @unused reason: Throwable): Unit = ()
 
   private def onRecoveryTick(snapshot: Boolean): Behavior[InternalProtocol] =
     if (snapshot) {

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/RequestingRecoveryPermit.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/RequestingRecoveryPermit.scala
@@ -78,7 +78,7 @@ private[pekko] class RequestingRecoveryPermit[C, E, S](override val setup: Behav
   }
 
   @InternalStableApi
-  def onRequestingRecoveryPermit(@unused context: ActorContext[_]): Unit = ()
+  def onRequestingRecoveryPermit(@unused context: ActorContext[?]): Unit = ()
 
   private def becomeReplaying(receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {
     setup.internalLogger.debug(s"Initializing snapshot recovery: {}", setup.recovery)

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/Running.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/Running.scala
@@ -244,7 +244,7 @@ private[pekko] object Running {
 
     _currentSequenceNumber = state.seqNr
 
-    private def alreadySeen(e: ReplicatedEvent[_]): Boolean = {
+    private def alreadySeen(e: ReplicatedEvent[?]): Boolean = {
       e.originSequenceNr <= state.seenPerReplica.getOrElse(e.originReplica, 0L)
     }
 
@@ -577,7 +577,7 @@ private[pekko] object Running {
         state: RunningState[S],
         effect: Effect[E, S],
         sideEffects: immutable.Seq[SideEffect[S]] = Nil): (Behavior[InternalProtocol], Boolean) = {
-      if (setup.internalLogger.isDebugEnabled && !effect.isInstanceOf[CompositeEffect[_, _]])
+      if (setup.internalLogger.isDebugEnabled && !effect.isInstanceOf[CompositeEffect[?, ?]])
         setup.internalLogger.debugN(
           s"Handled command [{}], resulting effect: [{}], side effects: [{}]",
           msg.getClass.getName,
@@ -915,7 +915,7 @@ private[pekko] object Running {
         unstashAll()
         behavior
 
-      case callback: Callback[_] =>
+      case callback: Callback[?] =>
         callback.sideEffect(state.state)
         behavior
     }
@@ -982,16 +982,16 @@ private[pekko] object Running {
 
   @InternalStableApi
   private[pekko] def onWriteFailed(
-      @unused ctx: ActorContext[_],
+      @unused ctx: ActorContext[?],
       @unused reason: Throwable,
       @unused event: PersistentRepr): Unit = ()
   @InternalStableApi
   private[pekko] def onWriteRejected(
-      @unused ctx: ActorContext[_],
+      @unused ctx: ActorContext[?],
       @unused reason: Throwable,
       @unused event: PersistentRepr): Unit = ()
   @InternalStableApi
-  private[pekko] def onWriteSuccess(@unused ctx: ActorContext[_], @unused event: PersistentRepr): Unit = ()
+  private[pekko] def onWriteSuccess(@unused ctx: ActorContext[?], @unused event: PersistentRepr): Unit = ()
   @InternalStableApi
-  private[pekko] def onWriteDone(@unused ctx: ActorContext[_], @unused event: PersistentRepr): Unit = ()
+  private[pekko] def onWriteDone(@unused ctx: ActorContext[?], @unused event: PersistentRepr): Unit = ()
 }

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -181,7 +181,7 @@ abstract class EventSourcedBehavior[Command, Event, State] private[pekko] (
    * Transform the event in another type before giving to the journal. Can be used to wrap events
    * in types Journals understand but is of a different type than `Event`.
    */
-  def eventAdapter(): EventAdapter[Event, _] = NoOpEventAdapter.instance[Event]
+  def eventAdapter(): EventAdapter[Event, ?] = NoOpEventAdapter.instance[Event]
 
   /**
    * Transform the state into another type before giving it to and from the journal. Can be used
@@ -240,7 +240,7 @@ abstract class EventSourcedBehavior[Command, Event, State] private[pekko] (
   /**
    * The last sequence number that was persisted, can only be called from inside the handlers of an `EventSourcedBehavior`
    */
-  final def lastSequenceNumber(ctx: ActorContext[_]): Long = {
+  final def lastSequenceNumber(ctx: ActorContext[?]): Long = {
     scaladsl.EventSourcedBehavior.lastSequenceNumber(ctx.asScala)
   }
 

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala
@@ -52,7 +52,7 @@ object EventSourcedBehavior {
    */
   type EventHandler[State, Event] = (State, Event) => State
 
-  private val logPrefixSkipList = classOf[EventSourcedBehavior[_, _, _]].getName :: Nil
+  private val logPrefixSkipList = classOf[EventSourcedBehavior[?, ?, ?]].getName :: Nil
 
   /**
    * Create a `Behavior` for a persistent actor.
@@ -67,7 +67,7 @@ object EventSourcedBehavior {
       emptyState: State,
       commandHandler: (State, Command) => Effect[Event, State],
       eventHandler: (State, Event) => State): EventSourcedBehavior[Command, Event, State] = {
-    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[EventSourcedBehavior[_, _, _]], logPrefixSkipList)
+    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[EventSourcedBehavior[?, ?, ?]], logPrefixSkipList)
     EventSourcedBehaviorImpl(persistenceId, emptyState, commandHandler, eventHandler, loggerClass)
   }
 
@@ -81,7 +81,7 @@ object EventSourcedBehavior {
       emptyState: State,
       commandHandler: (State, Command) => ReplyEffect[Event, State],
       eventHandler: (State, Event) => State): EventSourcedBehavior[Command, Event, State] = {
-    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[EventSourcedBehavior[_, _, _]], logPrefixSkipList)
+    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[EventSourcedBehavior[?, ?, ?]], logPrefixSkipList)
     EventSourcedBehaviorImpl(persistenceId, emptyState, commandHandler, eventHandler, loggerClass)
   }
 
@@ -112,11 +112,11 @@ object EventSourcedBehavior {
   /**
    * The last sequence number that was persisted, can only be called from inside the handlers of an `EventSourcedBehavior`
    */
-  def lastSequenceNumber(context: ActorContext[_]): Long = {
+  def lastSequenceNumber(context: ActorContext[?]): Long = {
     @tailrec
-    def extractConcreteBehavior(beh: Behavior[_]): Behavior[_] =
+    def extractConcreteBehavior(beh: Behavior[?]): Behavior[?] =
       beh match {
-        case interceptor: InterceptorImpl[_, _] => extractConcreteBehavior(interceptor.nestedBehavior)
+        case interceptor: InterceptorImpl[?, ?] => extractConcreteBehavior(interceptor.nestedBehavior)
         case concrete                           => concrete
       }
 
@@ -204,7 +204,7 @@ object EventSourcedBehavior {
    * Transform the event to another type before giving to the journal. Can be used to wrap events
    * in types Journals understand but is of a different type than `Event`.
    */
-  def eventAdapter(adapter: EventAdapter[Event, _]): EventSourcedBehavior[Command, Event, State]
+  def eventAdapter(adapter: EventAdapter[Event, ?]): EventSourcedBehavior[Command, Event, State]
 
   /**
    * Transform the state to another type before giving to the journal. Can be used to transform older

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/serialization/ReplicatedEventSourcingSerializer.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/serialization/ReplicatedEventSourcingSerializer.scala
@@ -92,11 +92,11 @@ import scala.collection.immutable.TreeMap
   private val PublishedEventManifest = "PA"
 
   def manifest(o: AnyRef) = o match {
-    case _: ORSet[_]                  => ORSetManifest
-    case _: ORSet.AddDeltaOp[_]       => ORSetAddManifest
-    case _: ORSet.RemoveDeltaOp[_]    => ORSetRemoveManifest
-    case _: ORSet.DeltaGroup[_]       => ORSetDeltaGroupManifest
-    case _: ORSet.FullStateDeltaOp[_] => ORSetFullManifest
+    case _: ORSet[?]                  => ORSetManifest
+    case _: ORSet.AddDeltaOp[?]       => ORSetAddManifest
+    case _: ORSet.RemoveDeltaOp[?]    => ORSetRemoveManifest
+    case _: ORSet.DeltaGroup[?]       => ORSetDeltaGroupManifest
+    case _: ORSet.FullStateDeltaOp[?] => ORSetFullManifest
 
     case _: Counter         => CrdtCounterManifest
     case _: Counter.Updated => CrdtCounterUpdatedManifest
@@ -117,11 +117,11 @@ import scala.collection.immutable.TreeMap
 
     case m: VersionVector => versionVectorToProto(m).toByteArray
 
-    case m: ORSet[_]                  => orsetToProto(m).toByteArray
-    case m: ORSet.AddDeltaOp[_]       => orsetToProto(m.underlying).toByteArray
-    case m: ORSet.RemoveDeltaOp[_]    => orsetToProto(m.underlying).toByteArray
-    case m: ORSet.DeltaGroup[_]       => orsetDeltaGroupToProto(m).toByteArray
-    case m: ORSet.FullStateDeltaOp[_] => orsetToProto(m.underlying).toByteArray
+    case m: ORSet[?]                  => orsetToProto(m).toByteArray
+    case m: ORSet.AddDeltaOp[?]       => orsetToProto(m.underlying).toByteArray
+    case m: ORSet.RemoveDeltaOp[?]    => orsetToProto(m.underlying).toByteArray
+    case m: ORSet.DeltaGroup[?]       => orsetDeltaGroupToProto(m).toByteArray
+    case m: ORSet.FullStateDeltaOp[?] => orsetToProto(m.underlying).toByteArray
 
     case m: Counter         => counterToProtoByteArray(m)
     case m: Counter.Updated => counterUpdatedToProtoBufByteArray(m)
@@ -212,7 +212,7 @@ import scala.collection.immutable.TreeMap
       .build()
       .toByteArray
 
-  def orsetToProto(orset: ORSet[_]): ReplicatedEventSourcing.ORSet =
+  def orsetToProto(orset: ORSet[?]): ReplicatedEventSourcing.ORSet =
     orsetToProtoImpl(orset.asInstanceOf[ORSet[Any]])
 
   private def orsetToProtoImpl(orset: ORSet[Any]): ReplicatedEventSourcing.ORSet = {
@@ -238,7 +238,7 @@ import scala.collection.immutable.TreeMap
         otherElementsMap = otherElementsMap.updated(enclosedMsg, other)
     }
 
-    def addDots(elements: ArrayList[_]): Unit = {
+    def addDots(elements: ArrayList[?]): Unit = {
       // add corresponding dots in same order
       val iter = elements.iterator
       while (iter.hasNext) {
@@ -313,8 +313,8 @@ import scala.collection.immutable.TreeMap
   private def orsetFullFromBinary(bytes: Array[Byte]): ORSet.FullStateDeltaOp[Any] =
     new ORSet.FullStateDeltaOp(orsetFromProto(ReplicatedEventSourcing.ORSet.parseFrom(bytes)))
 
-  private def orsetDeltaGroupToProto(deltaGroup: ORSet.DeltaGroup[_]): ReplicatedEventSourcing.ORSetDeltaGroup = {
-    def createEntry(opType: ReplicatedEventSourcing.ORSetDeltaOp, u: ORSet[_]) = {
+  private def orsetDeltaGroupToProto(deltaGroup: ORSet.DeltaGroup[?]): ReplicatedEventSourcing.ORSetDeltaGroup = {
+    def createEntry(opType: ReplicatedEventSourcing.ORSetDeltaOp, u: ORSet[?]) = {
       ReplicatedEventSourcing.ORSetDeltaGroup.Entry.newBuilder().setOperation(opType).setUnderlying(orsetToProto(u))
     }
 

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
@@ -56,7 +56,7 @@ private[pekko] final case class DurableStateBehaviorImpl[Command, State](
     persistenceId: PersistenceId,
     emptyState: State,
     commandHandler: DurableStateBehavior.CommandHandler[Command, State],
-    loggerClass: Class[_],
+    loggerClass: Class[?],
     durableStateStorePluginId: Option[String] = None,
     tag: String = "",
     snapshotAdapter: SnapshotAdapter[State] = NoOpSnapshotAdapter.instance[State],
@@ -73,7 +73,7 @@ private[pekko] final case class DurableStateBehaviorImpl[Command, State](
   override def apply(context: typed.TypedActorContext[Command]): Behavior[Command] = {
     val ctx = context.asScala
     val hasCustomLoggerName = ctx match {
-      case internalCtx: ActorContextImpl[_] => internalCtx.hasCustomLoggerName
+      case internalCtx: ActorContextImpl[?] => internalCtx.hasCustomLoggerName
       case _                                => false
     }
     if (!hasCustomLoggerName) ctx.setLoggerName(loggerClass)
@@ -157,7 +157,7 @@ private[pekko] final case class DurableStateBehaviorImpl[Command, State](
   }
 
   @InternalStableApi
-  private[pekko] def initialize(@unused context: ActorContext[_]): Unit = ()
+  private[pekko] def initialize(@unused context: ActorContext[?]): Unit = ()
 
   override def receiveSignal(handler: PartialFunction[(State, Signal), Unit]): DurableStateBehavior[Command, State] =
     copy(signalHandler = handler)

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/DurableStateSettings.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/DurableStateSettings.scala
@@ -30,7 +30,7 @@ import pekko.persistence.Persistence
  */
 @InternalApi private[pekko] object DurableStateSettings {
 
-  def apply(system: ActorSystem[_], durableStateStorePluginId: String): DurableStateSettings =
+  def apply(system: ActorSystem[?], durableStateStorePluginId: String): DurableStateSettings =
     apply(system.settings.config, durableStateStorePluginId)
 
   def apply(config: Config, durableStateStorePluginId: String): DurableStateSettings = {

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/DurableStateStoreInteractions.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/DurableStateStoreInteractions.scala
@@ -86,9 +86,9 @@ private[pekko] trait DurableStateStoreInteractions[C, S] {
 
   // FIXME These hook methods are for Telemetry. What more parameters are needed? persistenceId?
   @InternalStableApi
-  private[pekko] def onWriteInitiated(@unused ctx: ActorContext[_], @unused cmd: Any): Unit = ()
+  private[pekko] def onWriteInitiated(@unused ctx: ActorContext[?], @unused cmd: Any): Unit = ()
 
-  private[pekko] def onDeleteInitiated(@unused ctx: ActorContext[_], @unused cmd: Any): Unit = ()
+  private[pekko] def onDeleteInitiated(@unused ctx: ActorContext[?], @unused cmd: Any): Unit = ()
 
   protected def requestRecoveryPermit(): Unit = {
     setup.persistence.recoveryPermitter.tell(RecoveryPermitter.RequestRecoveryPermit, setup.selfClassic)

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/Recovering.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/Recovering.scala
@@ -136,11 +136,11 @@ private[pekko] class Recovering[C, S](
   }
 
   @InternalStableApi
-  def onRecoveryStart(@unused context: ActorContext[_]): Unit = ()
+  def onRecoveryStart(@unused context: ActorContext[?]): Unit = ()
   @InternalStableApi
-  def onRecoveryComplete(@unused context: ActorContext[_]): Unit = ()
+  def onRecoveryComplete(@unused context: ActorContext[?]): Unit = ()
   @InternalStableApi
-  def onRecoveryFailed(@unused context: ActorContext[_], @unused reason: Throwable): Unit = ()
+  def onRecoveryFailed(@unused context: ActorContext[?], @unused reason: Throwable): Unit = ()
 
   private def onRecoveryTimeout(): Behavior[InternalProtocol] = {
     val ex = new RecoveryTimedOut(s"Recovery timed out, didn't get state within ${setup.settings.recoveryTimeout}")

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/RequestingRecoveryPermit.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/RequestingRecoveryPermit.scala
@@ -77,7 +77,7 @@ private[pekko] class RequestingRecoveryPermit[C, S](override val setup: Behavior
   }
 
   @InternalStableApi
-  def onRequestingRecoveryPermit(@unused context: ActorContext[_]): Unit = ()
+  def onRequestingRecoveryPermit(@unused context: ActorContext[?]): Unit = ()
 
   private def becomeRecovering(receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {
     setup.internalLogger.debug(s"Initializing recovery")

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/Running.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/Running.scala
@@ -133,7 +133,7 @@ private[pekko] object Running {
         state: RunningState[S],
         effect: Effect[S],
         sideEffects: immutable.Seq[SideEffect[S]] = Nil): (Behavior[InternalProtocol], Boolean) = {
-      if (setup.internalLogger.isDebugEnabled && !effect.isInstanceOf[CompositeEffect[_]])
+      if (setup.internalLogger.isDebugEnabled && !effect.isInstanceOf[CompositeEffect[?]])
         setup.internalLogger.debugN(
           s"Handled command [{}], resulting effect: [{}], side effects: [{}]",
           msg.getClass.getName,
@@ -151,7 +151,7 @@ private[pekko] object Running {
         case _: PersistNothing.type =>
           (applySideEffects(sideEffects, state), true)
 
-        case _: Delete[_] =>
+        case _: Delete[?] =>
           val nextState = internalDelete(setup.context, msg, state)
           (applySideEffects(sideEffects, nextState), true)
 
@@ -206,7 +206,7 @@ private[pekko] object Running {
         case get: GetState[S @unchecked]       => stashInternal(get)
         case RecoveryTimeout                   => Behaviors.unhandled
         case RecoveryPermitGranted             => Behaviors.unhandled
-        case _: GetSuccess[_]                  => Behaviors.unhandled
+        case _: GetSuccess[?]                  => Behaviors.unhandled
         case _: GetFailure                     => Behaviors.unhandled
         case DeleteSuccess                     => Behaviors.unhandled
         case DeleteFailure(_)                  => Behaviors.unhandled
@@ -287,15 +287,15 @@ private[pekko] object Running {
         unstashAll()
         behavior
 
-      case callback: Callback[_] =>
+      case callback: Callback[?] =>
         callback.sideEffect(state.state)
         behavior
     }
   }
 
   @InternalStableApi
-  private[pekko] def onWriteFailed(@unused ctx: ActorContext[_], @unused reason: Throwable): Unit = ()
+  private[pekko] def onWriteFailed(@unused ctx: ActorContext[?], @unused reason: Throwable): Unit = ()
   @InternalStableApi
-  private[pekko] def onWriteSuccess(@unused ctx: ActorContext[_]): Unit = ()
+  private[pekko] def onWriteSuccess(@unused ctx: ActorContext[?]): Unit = ()
 
 }

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/DurableStateBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/DurableStateBehavior.scala
@@ -155,7 +155,7 @@ abstract class DurableStateBehavior[Command, State] private[pekko] (
   /**
    * The last sequence number that was persisted, can only be called from inside the handlers of a `DurableStateBehavior`
    */
-  final def lastSequenceNumber(ctx: ActorContext[_]): Long = {
+  final def lastSequenceNumber(ctx: ActorContext[?]): Long = {
     scaladsl.DurableStateBehavior.lastSequenceNumber(ctx.asScala)
   }
 

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehavior.scala
@@ -44,7 +44,7 @@ object DurableStateBehavior {
    */
   type CommandHandler[Command, State] = (State, Command) => Effect[State]
 
-  private val logPrefixSkipList = classOf[DurableStateBehavior[_, _]].getName :: Nil
+  private val logPrefixSkipList = classOf[DurableStateBehavior[?, ?]].getName :: Nil
 
   /**
    * Create a `Behavior` for a persistent actor with durable storage of its state.
@@ -57,7 +57,7 @@ object DurableStateBehavior {
       persistenceId: PersistenceId,
       emptyState: State,
       commandHandler: (State, Command) => Effect[State]): DurableStateBehavior[Command, State] = {
-    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[DurableStateBehavior[_, _]], logPrefixSkipList)
+    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[DurableStateBehavior[?, ?]], logPrefixSkipList)
     DurableStateBehaviorImpl(persistenceId, emptyState, commandHandler, loggerClass)
   }
 
@@ -70,7 +70,7 @@ object DurableStateBehavior {
       persistenceId: PersistenceId,
       emptyState: State,
       commandHandler: (State, Command) => ReplyEffect[State]): DurableStateBehavior[Command, State] = {
-    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[DurableStateBehavior[_, _]], logPrefixSkipList)
+    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[DurableStateBehavior[?, ?]], logPrefixSkipList)
     DurableStateBehaviorImpl(persistenceId, emptyState, commandHandler, loggerClass)
   }
 
@@ -100,11 +100,11 @@ object DurableStateBehavior {
   /**
    * The last sequence number that was persisted, can only be called from inside the handlers of a `DurableStateBehavior`
    */
-  def lastSequenceNumber(context: ActorContext[_]): Long = {
+  def lastSequenceNumber(context: ActorContext[?]): Long = {
     @tailrec
-    def extractConcreteBehavior(beh: Behavior[_]): Behavior[_] =
+    def extractConcreteBehavior(beh: Behavior[?]): Behavior[?] =
       beh match {
-        case interceptor: InterceptorImpl[_, _] => extractConcreteBehavior(interceptor.nestedBehavior)
+        case interceptor: InterceptorImpl[?, ?] => extractConcreteBehavior(interceptor.nestedBehavior)
         case concrete                           => concrete
       }
 

--- a/persistence-typed/src/test/scala/docs/org/apache/pekko/persistence/typed/DurableStatePersistentBehaviorCompileOnly.scala
+++ b/persistence-typed/src/test/scala/docs/org/apache/pekko/persistence/typed/DurableStatePersistentBehaviorCompileOnly.scala
@@ -51,7 +51,7 @@ object DurableStatePersistentBehaviorCompileOnly {
     // #command-handler
     import pekko.persistence.typed.state.scaladsl.Effect
 
-    val commandHandler: (State, Command[_]) => Effect[State] = (state, command) =>
+    val commandHandler: (State, Command[?]) => Effect[State] = (state, command) =>
       command match {
         case Increment         => Effect.persist(state.copy(value = state.value + 1))
         case IncrementBy(by)   => Effect.persist(state.copy(value = state.value + by))
@@ -61,8 +61,8 @@ object DurableStatePersistentBehaviorCompileOnly {
     // #command-handler
 
     // #behavior
-    def counter(id: String): DurableStateBehavior[Command[_], State] = {
-      DurableStateBehavior.apply[Command[_], State](
+    def counter(id: String): DurableStateBehavior[Command[?], State] = {
+      DurableStateBehavior.apply[Command[?], State](
         persistenceId = PersistenceId.ofUniqueId(id),
         emptyState = State(0),
         commandHandler = commandHandler)
@@ -76,8 +76,8 @@ object DurableStatePersistentBehaviorCompileOnly {
 
     final case class State(value: Int) extends CborSerializable
 
-    def counter(persistenceId: PersistenceId): DurableStateBehavior[Command[_], State] = {
-      DurableStateBehavior.apply[Command[_], State](
+    def counter(persistenceId: PersistenceId): DurableStateBehavior[Command[?], State] = {
+      DurableStateBehavior.apply[Command[?], State](
         persistenceId,
         emptyState = State(0),
         commandHandler =
@@ -97,8 +97,8 @@ object DurableStatePersistentBehaviorCompileOnly {
 
     final case class State(value: Int) extends CborSerializable
 
-    def counter(persistenceId: PersistenceId): DurableStateBehavior[Command[_], State] = {
-      DurableStateBehavior.withEnforcedReplies[Command[_], State](
+    def counter(persistenceId: PersistenceId): DurableStateBehavior[Command[?], State] = {
+      DurableStateBehavior.withEnforcedReplies[Command[?], State](
         persistenceId,
         emptyState = State(0),
         commandHandler = (state, command) =>
@@ -134,9 +134,9 @@ object DurableStatePersistentBehaviorCompileOnly {
   }
 
   object TaggingBehavior {
-    def apply(): Behavior[Command[_]] =
+    def apply(): Behavior[Command[?]] =
       // #tagging
-      DurableStateBehavior[Command[_], State](
+      DurableStateBehavior[Command[?], State](
         persistenceId = PersistenceId.ofUniqueId("abc"),
         emptyState = State(0),
         commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"))
@@ -148,10 +148,10 @@ object DurableStatePersistentBehaviorCompileOnly {
     import pekko.persistence.typed.state.scaladsl.Effect
     import pekko.persistence.typed.state.scaladsl.DurableStateBehavior.CommandHandler
 
-    def apply(): Behavior[Command[_]] =
+    def apply(): Behavior[Command[?]] =
       // #wrapPersistentBehavior
-      Behaviors.setup[Command[_]] { context =>
-        DurableStateBehavior[Command[_], State](
+      Behaviors.setup[Command[?]] { context =>
+        DurableStateBehavior[Command[?], State](
           persistenceId = PersistenceId.ofUniqueId("abc"),
           emptyState = State(0),
           commandHandler = CommandHandler.command { cmd =>

--- a/persistence-typed/src/test/scala/org/apache/pekko/persistence/typed/StashingWhenSnapshottingSpec.scala
+++ b/persistence-typed/src/test/scala/org/apache/pekko/persistence/typed/StashingWhenSnapshottingSpec.scala
@@ -40,7 +40,7 @@ import pekko.persistence.typed.scaladsl.EventSourcedBehavior
 object StashingWhenSnapshottingSpec {
   object ControllableSnapshotStoreExt extends ExtensionId[ControllableSnapshotStoreExt] {
 
-    override def createExtension(system: ActorSystem[_]): ControllableSnapshotStoreExt =
+    override def createExtension(system: ActorSystem[?]): ControllableSnapshotStoreExt =
       new ControllableSnapshotStoreExt()
   }
 

--- a/persistence-typed/src/test/scala/org/apache/pekko/persistence/typed/internal/StashStateSpec.scala
+++ b/persistence-typed/src/test/scala/org/apache/pekko/persistence/typed/internal/StashStateSpec.scala
@@ -58,7 +58,7 @@ class StashStateSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with
               stashState.internalStashBuffer.stash(RecoveryPermitGranted)
               probe.ref ! stashState.internalStashBuffer.size
               Behaviors.same[InternalProtocol]
-            case _: IncomingCommand[_] => Behaviors.stopped
+            case _: IncomingCommand[?] => Behaviors.stopped
           }
           .receiveSignal {
             case (_, _) =>

--- a/persistence-typed/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/persistence-typed/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -76,7 +76,7 @@ object PersistentActorCompileOnlyTest {
     def performSideEffect(sender: ActorRef[AcknowledgeSideEffect], correlationId: Int, data: String): Unit = {
       import pekko.actor.typed.scaladsl.AskPattern._
       implicit val timeout: pekko.util.Timeout = 1.second
-      implicit val system: ActorSystem[_] = ???
+      implicit val system: ActorSystem[?] = ???
       implicit val ec: ExecutionContext = ???
 
       val response: Future[RecoveryComplete.Response] =

--- a/persistence/src/main/scala-2/org/apache/pekko/persistence/TraitOrder.scala
+++ b/persistence/src/main/scala-2/org/apache/pekko/persistence/TraitOrder.scala
@@ -22,7 +22,7 @@ import org.apache.pekko.annotation.InternalApi
 private[persistence] object TraitOrder {
   val canBeChecked = true
 
-  def checkBefore(clazz: Class[_], one: Class[_], other: Class[_]): Unit = {
+  def checkBefore(clazz: Class[?], one: Class[?], other: Class[?]): Unit = {
     val interfaces = clazz.getInterfaces
     val i = interfaces.indexOf(other)
     val j = interfaces.indexOf(one)

--- a/persistence/src/main/scala/org/apache/pekko/persistence/PersistencePlugin.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/PersistencePlugin.scala
@@ -55,7 +55,7 @@ private[pekko] abstract class PersistencePlugin[ScalaDsl, JavaDsl, T: ClassTag](
     implicit ev: PluginProvider[T, ScalaDsl, JavaDsl]) {
 
   private val plugins = new AtomicReference[Map[String, ExtensionId[PluginHolder[ScalaDsl, JavaDsl]]]](Map.empty)
-  private val log = Logging(system, classOf[PersistencePlugin[_, _, _]])
+  private val log = Logging(system, classOf[PersistencePlugin[?, ?, ?]])
 
   @tailrec
   final protected def pluginFor(pluginId: String, readJournalPluginConfig: Config): PluginHolder[ScalaDsl, JavaDsl] = {
@@ -86,7 +86,7 @@ private[pekko] abstract class PersistencePlugin[ScalaDsl, JavaDsl, T: ClassTag](
     log.debug(s"Create plugin: $configPath $pluginClassName")
     val pluginClass = system.dynamicAccess.getClassFor[AnyRef](pluginClassName).get
 
-    def instantiate(args: collection.immutable.Seq[(Class[_], AnyRef)]) =
+    def instantiate(args: collection.immutable.Seq[(Class[?], AnyRef)]) =
       system.dynamicAccess.createInstanceFor[T](pluginClass, args)
 
     instantiate(

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/PersistencePluginProxy.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/PersistencePluginProxy.scala
@@ -77,7 +77,7 @@ object PersistencePluginProxyExtension
     with ExtensionIdProvider {
   override def createExtension(system: ExtendedActorSystem): PersistencePluginProxyExtensionImpl =
     new PersistencePluginProxyExtensionImpl(system)
-  override def lookup: ExtensionId[_ <: Extension] = PersistencePluginProxyExtension
+  override def lookup: ExtensionId[? <: Extension] = PersistencePluginProxyExtension
   override def get(system: ActorSystem): PersistencePluginProxyExtensionImpl = super.get(system)
   override def get(system: ClassicActorSystemProvider): PersistencePluginProxyExtensionImpl = super.get(system)
 }

--- a/persistence/src/main/scala/org/apache/pekko/persistence/serialization/MessageSerializer.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/serialization/MessageSerializer.scala
@@ -71,7 +71,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
    * Deserializes persistent messages. Delegates deserialization of a persistent
    * message's payload to a matching `org.apache.pekko.serialization.Serializer`.
    */
-  def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): Message = manifest match {
+  def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): Message = manifest match {
     case None => persistent(mf.PersistentMessage.parseFrom(bytes))
     case Some(c) =>
       c match {

--- a/persistence/src/main/scala/org/apache/pekko/persistence/serialization/SnapshotSerializer.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/serialization/SnapshotSerializer.scala
@@ -51,7 +51,7 @@ class SnapshotSerializer(val system: ExtendedActorSystem) extends BaseSerializer
    * Deserializes a [[Snapshot]]. Delegates deserialization of snapshot `data` to a matching
    * `org.apache.pekko.serialization.Serializer`.
    */
-  def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef =
+  def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef =
     Snapshot(snapshotFromBinary(bytes))
 
   private def headerToBinary(snapshot: AnyRef, snapshotSerializer: Serializer): Array[Byte] = {

--- a/persistence/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreRegistry.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreRegistry.scala
@@ -45,16 +45,16 @@ object DurableStateStoreRegistry extends ExtensionId[DurableStateStoreRegistry] 
 
   @InternalApi
   private[pekko] val pluginProvider
-      : PluginProvider[DurableStateStoreProvider, DurableStateStore[_], javadsl.DurableStateStore[_]] =
-    new PluginProvider[DurableStateStoreProvider, scaladsl.DurableStateStore[_], javadsl.DurableStateStore[_]] {
-      override def scalaDsl(t: DurableStateStoreProvider): DurableStateStore[_] = t.scaladslDurableStateStore()
-      override def javaDsl(t: DurableStateStoreProvider): javadsl.DurableStateStore[_] = t.javadslDurableStateStore()
+      : PluginProvider[DurableStateStoreProvider, DurableStateStore[?], javadsl.DurableStateStore[?]] =
+    new PluginProvider[DurableStateStoreProvider, scaladsl.DurableStateStore[?], javadsl.DurableStateStore[?]] {
+      override def scalaDsl(t: DurableStateStoreProvider): DurableStateStore[?] = t.scaladslDurableStateStore()
+      override def javaDsl(t: DurableStateStoreProvider): javadsl.DurableStateStore[?] = t.javadslDurableStateStore()
     }
 
 }
 
 class DurableStateStoreRegistry(system: ExtendedActorSystem)
-    extends PersistencePlugin[scaladsl.DurableStateStore[_], javadsl.DurableStateStore[_], DurableStateStoreProvider](
+    extends PersistencePlugin[scaladsl.DurableStateStore[?], javadsl.DurableStateStore[?], DurableStateStoreProvider](
       system)(ClassTag(classOf[DurableStateStoreProvider]), DurableStateStoreRegistry.pluginProvider)
     with Extension {
 
@@ -87,7 +87,7 @@ class DurableStateStoreRegistry(system: ExtendedActorSystem)
    * Scala API: Returns the [[pekko.persistence.state.scaladsl.DurableStateStore]] specified by the given
    * configuration entry.
    */
-  final def durableStateStoreFor[T <: scaladsl.DurableStateStore[_]](pluginId: String): T = {
+  final def durableStateStoreFor[T <: scaladsl.DurableStateStore[?]](pluginId: String): T = {
     pluginFor(pluginIdOrDefault(pluginId), pluginConfig(pluginId)).scaladslPlugin.asInstanceOf[T]
   }
 
@@ -95,7 +95,7 @@ class DurableStateStoreRegistry(system: ExtendedActorSystem)
    * Java API: Returns the [[pekko.persistence.state.javadsl.DurableStateStore]] specified by the given
    * configuration entry.
    */
-  final def getDurableStateStoreFor[T <: javadsl.DurableStateStore[_]](
+  final def getDurableStateStoreFor[T <: javadsl.DurableStateStore[?]](
       @unused clazz: Class[T], // FIXME generic Class could be problematic in Java
       pluginId: String): T = {
     pluginFor(pluginIdOrDefault(pluginId), pluginConfig(pluginId)).javadslPlugin.asInstanceOf[T]

--- a/persistence/src/test/scala/org/apache/pekko/persistence/AtLeastOnceDeliverySpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/AtLeastOnceDeliverySpec.scala
@@ -256,7 +256,7 @@ class AtLeastOnceDeliverySpec
 
     "not allow using actorSelection with wildcards" in {
       system.actorOf(Props(classOf[DeliverToStarSelection], name)) ! "anything, really."
-      expectMsgType[Failure[_]].toString should include("not supported")
+      expectMsgType[Failure[?]].toString should include("not supported")
     }
 
     "re-deliver lost messages after restart" taggedAs TimingTest in {

--- a/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorSpec.scala
@@ -215,7 +215,7 @@ object PersistentActorSpec {
 
   class SnapshottingPersistentActor(name: String, probe: ActorRef) extends ExamplePersistentActor(name) {
     override def receiveRecover = super.receiveRecover.orElse {
-      case SnapshotOffer(_, events: List[_]) =>
+      case SnapshotOffer(_, events: List[?]) =>
         probe ! "offered"
         this.events = events
     }

--- a/persistence/src/test/scala/org/apache/pekko/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
@@ -33,7 +33,7 @@ object SnapshotRecoveryWithEmptyJournalSpec {
 
     override def receiveRecover: Receive = {
       case payload: String                     => state = s"$payload-$lastSequenceNr" :: state
-      case SnapshotOffer(_, snapshot: List[_]) => state = snapshot.asInstanceOf[List[String]]
+      case SnapshotOffer(_, snapshot: List[?]) => state = snapshot.asInstanceOf[List[String]]
     }
 
     override def receiveCommand: PartialFunction[Any, Unit] = {

--- a/persistence/src/test/scala/org/apache/pekko/persistence/SnapshotSerializationSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/SnapshotSerializationSpec.scala
@@ -51,7 +51,7 @@ object SnapshotSerializationSpec {
       bStream.toByteArray
     }
 
-    def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+    def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = {
       val bStream = new ByteArrayInputStream(bytes)
       val reader = new BufferedReader(new InputStreamReader(bStream))
       new MySnapshot(reader.readLine())

--- a/persistence/src/test/scala/org/apache/pekko/persistence/SnapshotSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/SnapshotSpec.scala
@@ -25,7 +25,7 @@ object SnapshotSpec {
 
     override def receiveRecover: Receive = {
       case payload: String                     => state = s"$payload-$lastSequenceNr" :: state
-      case SnapshotOffer(_, snapshot: List[_]) => state = snapshot.asInstanceOf[List[String]]
+      case SnapshotOffer(_, snapshot: List[?]) => state = snapshot.asInstanceOf[List[String]]
     }
 
     override def receiveCommand = {

--- a/persistence/src/test/scala/org/apache/pekko/persistence/serialization/SnapshotSerializerSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/serialization/SnapshotSerializerSpec.scala
@@ -37,8 +37,8 @@ class SnapshotSerializerSpec extends PekkoSpec {
       val bytes = Base64.getDecoder.decode(data)
       val result = serialization.deserialize(bytes, classOf[Snapshot]).get
       val deserialized = result.data
-      deserialized shouldBe a[PersistentFSMSnapshot[_]]
-      val persistentFSMSnapshot = deserialized.asInstanceOf[PersistentFSMSnapshot[_]]
+      deserialized shouldBe a[PersistentFSMSnapshot[?]]
+      val persistentFSMSnapshot = deserialized.asInstanceOf[PersistentFSMSnapshot[?]]
       persistentFSMSnapshot shouldEqual PersistentFSMSnapshot[String]("test-identifier", "test-data", None)
     }
   }

--- a/remote/src/main/scala/org/apache/pekko/remote/Endpoint.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/Endpoint.scala
@@ -82,7 +82,7 @@ private[remote] class DefaultMessageDispatcher(
     import provider.remoteSettings._
 
     lazy val payload: AnyRef = MessageSerializer.deserialize(system, serializedMessage)
-    def payloadClass: Class[_] = if (payload eq null) null else payload.getClass
+    def payloadClass: Class[?] = if (payload eq null) null else payload.getClass
     val sender: ActorRef = senderOption.getOrElse(system.deadLetters)
     val originalReceiver = recipient.path
 

--- a/remote/src/main/scala/org/apache/pekko/remote/RemoteDaemon.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemoteDaemon.scala
@@ -285,7 +285,7 @@ private[pekko] class RemoteSystemDaemon(
 }
 
 /** INTERNAL API */
-final class NotAllowedClassRemoteDeploymentAttemptException(illegal: Class[_], allowedClassNames: immutable.Set[String])
+final class NotAllowedClassRemoteDeploymentAttemptException(illegal: Class[?], allowedClassNames: immutable.Set[String])
     extends RuntimeException(
       s"Attempted to deploy Actor class: " +
       s"[$illegal], " +

--- a/remote/src/main/scala/org/apache/pekko/remote/RemoteMetricsExtension.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemoteMetricsExtension.scala
@@ -78,7 +78,7 @@ private[pekko] class RemoteMetricsOn(system: ExtendedActorSystem) extends Remote
   private val logFrameSizeExceeding: Int =
     RARP(system).provider.remoteSettings.LogFrameSizeExceeding.getOrElse(Int.MaxValue)
   private val log = Logging(system, classOf[RemoteMetrics])
-  private val maxPayloadBytes: ConcurrentHashMap[Class[_], Integer] = new ConcurrentHashMap
+  private val maxPayloadBytes: ConcurrentHashMap[Class[?], Integer] = new ConcurrentHashMap
 
   override def logPayloadBytes(msg: Any, payloadBytes: Int): Unit =
     if (payloadBytes >= logFrameSizeExceeding) {

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/Handshake.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/Handshake.scala
@@ -93,7 +93,7 @@ private[remote] class OutboundHandshake(
       private val uniqueRemoteAddressListener: UniqueAddress => Unit =
         peer => uniqueRemoteAddressAsyncCallback.invoke(peer)
 
-      override protected def logSource: Class[_] = classOf[OutboundHandshake]
+      override protected def logSource: Class[?] = classOf[OutboundHandshake]
 
       override def preStart(): Unit = {
         scheduleOnce(HandshakeTimeout, timeout)

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/ImmutableLongMap.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/ImmutableLongMap.scala
@@ -128,7 +128,7 @@ private[pekko] class ImmutableLongMap[A >: Null] private (private val keys: Arra
   }
 
   override def equals(obj: Any): Boolean = obj match {
-    case other: ImmutableLongMap[_] =>
+    case other: ImmutableLongMap[?] =>
       if (other eq this) true
       else if (size != other.size) false
       else if (size == 0 && other.size == 0) true

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/RemoteInstrument.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/RemoteInstrument.scala
@@ -111,7 +111,7 @@ abstract class RemoteInstrument {
 
   private val log = Logging(system, classOf[LoggingRemoteInstrument])
 
-  private val maxPayloadBytes: ConcurrentHashMap[Class[_], Integer] = new ConcurrentHashMap
+  private val maxPayloadBytes: ConcurrentHashMap[Class[?], Integer] = new ConcurrentHashMap
 
   override def identifier: Byte = 1 // Cinnamon is using 0
 

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/RemotingFlightRecorder.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/RemotingFlightRecorder.scala
@@ -37,7 +37,7 @@ object RemotingFlightRecorder extends ExtensionId[RemotingFlightRecorder] with E
       "org.apache.pekko.remote.artery.jfr.JFRRemotingFlightRecorder",
       NoOpRemotingFlightRecorder)
 
-  override def lookup: ExtensionId[_ <: Extension] = this
+  override def lookup: ExtensionId[? <: Extension] = this
 }
 
 /**

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/SystemMessageDelivery.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/SystemMessageDelivery.scala
@@ -111,7 +111,7 @@ import pekko.util.PrettyDuration.PrettyPrintableDuration
       private def remoteAddressLogParam: String =
         outboundContext.associationState.uniqueRemoteAddress().getOrElse(remoteAddress).toString
 
-      override protected def logSource: Class[_] = classOf[SystemMessageDelivery]
+      override protected def logSource: Class[?] = classOf[SystemMessageDelivery]
 
       override def preStart(): Unit = {
         val callback = getAsyncCallback[Done] { _ =>
@@ -351,7 +351,7 @@ import pekko.util.PrettyDuration.PrettyPrintableDuration
 
       def localAddress = inboundContext.localAddress
 
-      override protected def logSource: Class[_] = classOf[SystemMessageAcker]
+      override protected def logSource: Class[?] = classOf[SystemMessageAcker]
 
       // InHandler
       override def onPush(): Unit = {

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/compress/CompressionTable.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/compress/CompressionTable.scala
@@ -90,7 +90,7 @@ private[remote] final class CompressionTable[T](
   }
 
   override def equals(obj: Any): Boolean = obj match {
-    case other: CompressionTable[_] =>
+    case other: CompressionTable[?] =>
       originUid == other.originUid && version == other.version && _dictionary == other._dictionary
     case _ => false
   }

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/X509Readers.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/X509Readers.scala
@@ -34,7 +34,7 @@ private[pekko] object X509Readers {
           attr.getValue.toString
       }
 
-    val iterable: Iterable[util.List[_]] = Option(cert.getSubjectAlternativeNames).map(_.asScala).getOrElse(Nil)
+    val iterable: Iterable[util.List[?]] = Option(cert.getSubjectAlternativeNames).map(_.asScala).getOrElse(Nil)
     val alternates = iterable.collect {
       // See the javadocs of cert.getSubjectAlternativeNames for what this list contains,
       // first element should be an integer, if that integer is 2, then the second element

--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/DaemonMsgCreateSerializer.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/DaemonMsgCreateSerializer.scala
@@ -106,7 +106,7 @@ private[pekko] final class DaemonMsgCreateSerializer(val system: ExtendedActorSy
         "Can't serialize a non-DaemonMsgCreate message using DaemonMsgCreateSerializer [%s]".format(obj))
   }
 
-  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = {
     val proto = DaemonMsgCreateData.parseFrom(bytes)
 
     def deploy(protoDeploy: DeployData): Deploy = {

--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/MessageContainerSerializer.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/MessageContainerSerializer.scala
@@ -73,7 +73,7 @@ class MessageContainerSerializer(val system: ExtendedActorSystem) extends BaseSe
     builder
   }
 
-  def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
+  def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = {
     val selectionEnvelope = ContainerFormats.SelectionEnvelope.parseFrom(bytes)
     val manifest = if (selectionEnvelope.hasMessageManifest) selectionEnvelope.getMessageManifest.toStringUtf8 else ""
     val msg = serialization

--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/PrimitiveSerializers.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/PrimitiveSerializers.scala
@@ -30,7 +30,7 @@ class LongSerializer(val system: ExtendedActorSystem) extends BaseSerializer wit
   override def toBinary(o: AnyRef, buf: ByteBuffer): Unit = delegate.toBinary(o, buf)
   override def fromBinary(buf: ByteBuffer, manifest: String): AnyRef = delegate.fromBinary(buf, manifest)
   override def toBinary(o: AnyRef): Array[Byte] = delegate.toBinary(o)
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = delegate.fromBinary(bytes, manifest)
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = delegate.fromBinary(bytes, manifest)
 }
 
 @deprecated("Moved to org.apache.pekko.serialization.IntSerializer in pekko-actor", "Akka 2.6.0")
@@ -43,7 +43,7 @@ class IntSerializer(val system: ExtendedActorSystem) extends BaseSerializer with
   override def toBinary(o: AnyRef, buf: ByteBuffer): Unit = delegate.toBinary(o, buf)
   override def fromBinary(buf: ByteBuffer, manifest: String): AnyRef = delegate.fromBinary(buf, manifest)
   override def toBinary(o: AnyRef): Array[Byte] = delegate.toBinary(o)
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = delegate.fromBinary(bytes, manifest)
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = delegate.fromBinary(bytes, manifest)
 }
 
 @deprecated("Moved to org.apache.pekko.serialization.StringSerializer in pekko-actor", "Akka 2.6.0")
@@ -56,7 +56,7 @@ class StringSerializer(val system: ExtendedActorSystem) extends BaseSerializer w
   override def toBinary(o: AnyRef, buf: ByteBuffer): Unit = delegate.toBinary(o, buf)
   override def fromBinary(buf: ByteBuffer, manifest: String): AnyRef = delegate.fromBinary(buf, manifest)
   override def toBinary(o: AnyRef): Array[Byte] = delegate.toBinary(o)
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = delegate.fromBinary(bytes, manifest)
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = delegate.fromBinary(bytes, manifest)
 }
 
 @deprecated("Moved to org.apache.pekko.serialization.ByteStringSerializer in pekko-actor", "Akka 2.6.0")
@@ -69,5 +69,5 @@ class ByteStringSerializer(val system: ExtendedActorSystem) extends BaseSerializ
   override def toBinary(o: AnyRef, buf: ByteBuffer): Unit = delegate.toBinary(o, buf)
   override def fromBinary(buf: ByteBuffer, manifest: String): AnyRef = delegate.fromBinary(buf, manifest)
   override def toBinary(o: AnyRef): Array[Byte] = delegate.toBinary(o)
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = delegate.fromBinary(bytes, manifest)
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = delegate.fromBinary(bytes, manifest)
 }

--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/ProtobufSerializer.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/ProtobufSerializer.scala
@@ -28,7 +28,7 @@ import pekko.serialization.{ BaseSerializer, Serialization }
 import pekko.serialization.SerializationExtension
 
 object ProtobufSerializer {
-  private val ARRAY_OF_BYTE_ARRAY = Array[Class[_]](classOf[Array[Byte]])
+  private val ARRAY_OF_BYTE_ARRAY = Array[Class[?]](classOf[Array[Byte]])
 
   /**
    * Helper to serialize an [[pekko.actor.ActorRef]] to Pekko's
@@ -56,8 +56,8 @@ object ProtobufSerializer {
  */
 class ProtobufSerializer(val system: ExtendedActorSystem) extends BaseSerializer {
 
-  private val parsingMethodBindingRef = new AtomicReference[Map[Class[_], Method]](Map.empty)
-  private val toByteArrayMethodBindingRef = new AtomicReference[Map[Class[_], Method]](Map.empty)
+  private val parsingMethodBindingRef = new AtomicReference[Map[Class[?], Method]](Map.empty)
+  private val toByteArrayMethodBindingRef = new AtomicReference[Map[Class[?], Method]](Map.empty)
 
   private val allowedClassNames: Set[String] = {
     import pekko.util.ccompat.JavaConverters._
@@ -71,7 +71,7 @@ class ProtobufSerializer(val system: ExtendedActorSystem) extends BaseSerializer
 
   override def includeManifest: Boolean = true
 
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = {
     manifest match {
       case Some(clazz) =>
         @tailrec
@@ -121,7 +121,7 @@ class ProtobufSerializer(val system: ExtendedActorSystem) extends BaseSerializer
     toByteArrayMethod().invoke(obj).asInstanceOf[Array[Byte]]
   }
 
-  private def checkAllowedClass(clazz: Class[_]): Unit = {
+  private def checkAllowedClass(clazz: Class[?]): Unit = {
     if (!isInAllowList(clazz)) {
       val warnMsg = s"Can't deserialize object of type [${clazz.getName}] in [${getClass.getName}]. " +
         "Only classes that are on the allow list are allowed for security reasons. " +
@@ -147,11 +147,11 @@ class ProtobufSerializer(val system: ExtendedActorSystem) extends BaseSerializer
    * That is also possible when changing a binding from a ProtobufSerializer to another serializer (e.g. Jackson)
    * and still bind with the same class (interface).
    */
-  private def isInAllowList(clazz: Class[_]): Boolean = {
+  private def isInAllowList(clazz: Class[?]): Boolean = {
     isBoundToProtobufSerializer(clazz) || isInAllowListClassName(clazz)
   }
 
-  private def isBoundToProtobufSerializer(clazz: Class[_]): Boolean = {
+  private def isBoundToProtobufSerializer(clazz: Class[?]): Boolean = {
     try {
       val boundSerializer = serialization.serializerFor(clazz)
       boundSerializer.isInstanceOf[ProtobufSerializer]
@@ -160,7 +160,7 @@ class ProtobufSerializer(val system: ExtendedActorSystem) extends BaseSerializer
     }
   }
 
-  private def isInAllowListClassName(clazz: Class[_]): Boolean = {
+  private def isInAllowListClassName(clazz: Class[?]): Boolean = {
     allowedClassNames(clazz.getName) ||
     allowedClassNames(clazz.getSuperclass.getName) ||
     clazz.getInterfaces.exists(c => allowedClassNames(c.getName))

--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/SystemMessageSerializer.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/SystemMessageSerializer.scala
@@ -97,7 +97,7 @@ class SystemMessageSerializer(val system: ExtendedActorSystem) extends BaseSeria
     builder.build().toByteArray
   }
 
-  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = {
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = {
     deserializeSystemMessage(SystemMessageFormats.SystemMessage.parseFrom(bytes))
   }
 

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteInstrumentsSerializationSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteInstrumentsSerializationSpec.scala
@@ -138,13 +138,13 @@ object RemoteInstrumentsSerializationSpec {
   class Filter(@unused settings: ActorSystem.Settings, stream: EventStream) extends LoggingFilter {
     stream.publish(Mute(EventFilter.debug()))
 
-    override def isErrorEnabled(logClass: Class[_], logSource: String): Boolean = true
+    override def isErrorEnabled(logClass: Class[?], logSource: String): Boolean = true
 
-    override def isWarningEnabled(logClass: Class[_], logSource: String): Boolean = true
+    override def isWarningEnabled(logClass: Class[?], logSource: String): Boolean = true
 
-    override def isInfoEnabled(logClass: Class[_], logSource: String): Boolean = true
+    override def isInfoEnabled(logClass: Class[?], logSource: String): Boolean = true
 
-    override def isDebugEnabled(logClass: Class[_], logSource: String): Boolean = logSource == "DebugSource"
+    override def isDebugEnabled(logClass: Class[?], logSource: String): Boolean = logSource == "DebugSource"
   }
 
   def testInstrument(

--- a/remote/src/test/scala/org/apache/pekko/remote/serialization/DaemonMsgCreateSerializerAllowJavaSerializationSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/serialization/DaemonMsgCreateSerializerAllowJavaSerializationSpec.scala
@@ -64,8 +64,8 @@ private[pekko] trait SerializationVerification { self: PekkoSpec =>
     got.props.args.length should ===(expected.props.args.length)
     got.props.args.zip(expected.props.args).foreach {
       case (g, e) =>
-        if (e.isInstanceOf[Function0[_]]) ()
-        else if (e.isInstanceOf[Function1[_, _]]) ()
+        if (e.isInstanceOf[Function0[?]]) ()
+        else if (e.isInstanceOf[Function1[?, ?]]) ()
         else g should ===(e)
     }
     got.props.deploy should ===(expected.props.deploy)

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonModule.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonModule.scala
@@ -43,12 +43,12 @@ import pekko.annotation.InternalApi
     VersionUtil.parseVersion(version, groupId, artifactId)
   }
 
-  class SerializerResolverByClass(clazz: Class[_], deserializer: () => JsonSerializer[_]) extends Serializers.Base {
+  class SerializerResolverByClass(clazz: Class[?], deserializer: () => JsonSerializer[?]) extends Serializers.Base {
 
     override def findSerializer(
         config: SerializationConfig,
         javaType: JavaType,
-        beanDesc: BeanDescription): JsonSerializer[_] = {
+        beanDesc: BeanDescription): JsonSerializer[?] = {
       if (clazz.isAssignableFrom(javaType.getRawClass))
         deserializer()
       else
@@ -57,12 +57,12 @@ import pekko.annotation.InternalApi
 
   }
 
-  class DeserializerResolverByClass(clazz: Class[_], serializer: () => JsonDeserializer[_]) extends Deserializers.Base {
+  class DeserializerResolverByClass(clazz: Class[?], serializer: () => JsonDeserializer[?]) extends Deserializers.Base {
 
     override def findBeanDeserializer(
         javaType: JavaType,
         config: DeserializationConfig,
-        beanDesc: BeanDescription): JsonDeserializer[_] = {
+        beanDesc: BeanDescription): JsonDeserializer[?] = {
       if (clazz.isAssignableFrom(javaType.getRawClass))
         serializer()
       else
@@ -94,9 +94,9 @@ import pekko.annotation.InternalApi
   }
 
   def addSerializer(
-      clazz: Class[_],
-      serializer: () => JsonSerializer[_],
-      deserializer: () => JsonDeserializer[_]): this.type = {
+      clazz: Class[?],
+      serializer: () => JsonSerializer[?],
+      deserializer: () => JsonDeserializer[?]): this.type = {
     this += { ctx =>
       ctx.addSerializers(new SerializerResolverByClass(clazz, serializer))
       ctx.addDeserializers(new DeserializerResolverByClass(clazz, deserializer))

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
@@ -61,14 +61,14 @@ import pekko.util.OptionVal
         true
     }
 
-    def isAllowedClass(clazz: Class[_]): Boolean = {
+    def isAllowedClass(clazz: Class[?]): Boolean = {
       if (clazz.getName.startsWith(prefixSpring)) {
         isAllowedSpringClass(clazz)
       } else
         true
     }
 
-    @tailrec private def isAllowedSpringClass(clazz: Class[_]): Boolean = {
+    @tailrec private def isAllowedSpringClass(clazz: Class[?]): Boolean = {
       if (clazz == null || clazz.equals(classOf[java.lang.Object]))
         true
       else {
@@ -84,8 +84,8 @@ import pekko.util.OptionVal
     }
   }
 
-  val disallowedSerializationBindings: Set[Class[_]] =
-    Set(classOf[java.io.Serializable], classOf[java.io.Serializable], classOf[java.lang.Comparable[_]])
+  val disallowedSerializationBindings: Set[Class[?]] =
+    Set(classOf[java.io.Serializable], classOf[java.io.Serializable], classOf[java.lang.Comparable[?]])
 
   def isGZipped(bytes: Array[Byte]): Boolean = {
     (bytes != null) && (bytes.length >= 2) &&
@@ -221,7 +221,7 @@ import pekko.util.OptionVal
   }
   private val typeInManifest: Boolean = conf.getBoolean("type-in-manifest")
   // Calculated eagerly so as to fail fast
-  private val configuredDeserializationType: Option[Class[_ <: AnyRef]] = conf.getString("deserialization-type") match {
+  private val configuredDeserializationType: Option[Class[? <: AnyRef]] = conf.getString("deserialization-type") match {
     case "" => None
     case className =>
       system.dynamicAccess.getClassFor[AnyRef](className) match {
@@ -236,7 +236,7 @@ import pekko.util.OptionVal
   private lazy val serialization = SerializationExtension(system)
 
   // This must be lazy since it depends on serialization above
-  private lazy val deserializationType: Option[Class[_ <: AnyRef]] = if (typeInManifest) {
+  private lazy val deserializationType: Option[Class[? <: AnyRef]] = if (typeInManifest) {
     None
   } else {
     configuredDeserializationType.orElse {
@@ -395,7 +395,7 @@ import pekko.util.OptionVal
       bytes: Array[Byte],
       decompressBytes: Array[Byte],
       startTime: Long,
-      clazz: Class[_ <: AnyRef]) = {
+      clazz: Class[? <: AnyRef]) = {
     if (isDebugEnabled) {
       val durationMicros = (System.nanoTime - startTime) / 1000
       if (bytes.length == decompressBytes.length)
@@ -426,7 +426,7 @@ import pekko.util.OptionVal
     }
   }
 
-  private def checkAllowedClass(clazz: Class[_]): Unit = {
+  private def checkAllowedClass(clazz: Class[?]): Unit = {
     if (!denyList.isAllowedClass(clazz)) {
       val warnMsg = s"Can't serialize/deserialize object of type [${clazz.getName}] in [${getClass.getName}]. " +
         s"Not allowed for security reasons."
@@ -457,11 +457,11 @@ import pekko.util.OptionVal
    * That is also possible when changing a binding from a JacksonSerializer to another serializer (e.g. protobuf)
    * and still bind with the same class (interface).
    */
-  private def isInAllowList(clazz: Class[_]): Boolean = {
+  private def isInAllowList(clazz: Class[?]): Boolean = {
     isBoundToJacksonSerializer(clazz) || hasAllowedClassPrefix(clazz.getName)
   }
 
-  private def isBoundToJacksonSerializer(clazz: Class[_]): Boolean = {
+  private def isBoundToJacksonSerializer(clazz: Class[?]): Boolean = {
     try {
       // The reason for using isInstanceOf rather than `eq this` is to allow change of
       // serializer within the Jackson family, but we don't trust other serializers
@@ -485,7 +485,7 @@ import pekko.util.OptionVal
    */
   private def checkAllowedSerializationBindings(): Unit = {
     if (!serializationBindingsCheckedOk) {
-      def isBindingOk(clazz: Class[_]): Boolean =
+      def isBindingOk(clazz: Class[?]): Boolean =
         try {
           serialization.serializerFor(clazz) ne this
         } catch {

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/StreamRefModule.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/StreamRefModule.scala
@@ -33,8 +33,8 @@ import pekko.stream.StreamRefResolver
  * INTERNAL API: Adds support for serializing and deserializing [[pekko.stream.SourceRef]] and [[pekko.stream.SinkRef]].
  */
 @InternalApi private[pekko] trait StreamRefModule extends JacksonModule {
-  addSerializer(classOf[SourceRef[_]], () => SourceRefSerializer.instance, () => SourceRefDeserializer.instance)
-  addSerializer(classOf[SinkRef[_]], () => SinkRefSerializer.instance, () => SinkRefDeserializer.instance)
+  addSerializer(classOf[SourceRef[?]], () => SourceRefSerializer.instance, () => SourceRefDeserializer.instance)
+  addSerializer(classOf[SinkRef[?]], () => SinkRefSerializer.instance, () => SinkRefDeserializer.instance)
 }
 
 /**
@@ -48,10 +48,10 @@ import pekko.stream.StreamRefResolver
  * INTERNAL API
  */
 @InternalApi private[pekko] class SourceRefSerializer
-    extends StdScalarSerializer[SourceRef[_]](classOf[SourceRef[_]])
+    extends StdScalarSerializer[SourceRef[?]](classOf[SourceRef[?]])
     with ActorSystemAccess {
 
-  override def serialize(value: SourceRef[_], jgen: JsonGenerator, provider: SerializerProvider): Unit = {
+  override def serialize(value: SourceRef[?], jgen: JsonGenerator, provider: SerializerProvider): Unit = {
     val resolver = StreamRefResolver(currentSystem())
     val serializedSourceRef = resolver.toSerializationFormat(value)
     jgen.writeString(serializedSourceRef)
@@ -69,15 +69,15 @@ import pekko.stream.StreamRefResolver
  * INTERNAL API
  */
 @InternalApi private[pekko] class SourceRefDeserializer
-    extends StdScalarDeserializer[SourceRef[_]](classOf[SourceRef[_]])
+    extends StdScalarDeserializer[SourceRef[?]](classOf[SourceRef[?]])
     with ActorSystemAccess {
 
-  def deserialize(jp: JsonParser, ctxt: DeserializationContext): SourceRef[_] = {
+  def deserialize(jp: JsonParser, ctxt: DeserializationContext): SourceRef[?] = {
     if (jp.currentTokenId() == JsonTokenId.ID_STRING) {
       val serializedSourceRef = jp.getText()
       StreamRefResolver(currentSystem()).resolveSourceRef(serializedSourceRef)
     } else
-      ctxt.handleUnexpectedToken(handledType(), jp).asInstanceOf[SourceRef[_]]
+      ctxt.handleUnexpectedToken(handledType(), jp).asInstanceOf[SourceRef[?]]
   }
 }
 
@@ -92,10 +92,10 @@ import pekko.stream.StreamRefResolver
  * INTERNAL API
  */
 @InternalApi private[pekko] class SinkRefSerializer
-    extends StdScalarSerializer[SinkRef[_]](classOf[SinkRef[_]])
+    extends StdScalarSerializer[SinkRef[?]](classOf[SinkRef[?]])
     with ActorSystemAccess {
 
-  override def serialize(value: SinkRef[_], jgen: JsonGenerator, provider: SerializerProvider): Unit = {
+  override def serialize(value: SinkRef[?], jgen: JsonGenerator, provider: SerializerProvider): Unit = {
     val resolver = StreamRefResolver(currentSystem())
     val serializedSinkRef = resolver.toSerializationFormat(value)
     jgen.writeString(serializedSinkRef)
@@ -113,14 +113,14 @@ import pekko.stream.StreamRefResolver
  * INTERNAL API
  */
 @InternalApi private[pekko] class SinkRefDeserializer
-    extends StdScalarDeserializer[SinkRef[_]](classOf[SinkRef[_]])
+    extends StdScalarDeserializer[SinkRef[?]](classOf[SinkRef[?]])
     with ActorSystemAccess {
 
-  def deserialize(jp: JsonParser, ctxt: DeserializationContext): SinkRef[_] = {
+  def deserialize(jp: JsonParser, ctxt: DeserializationContext): SinkRef[?] = {
     if (jp.currentTokenId() == JsonTokenId.ID_STRING) {
       val serializedSinkref = jp.getText()
       StreamRefResolver(currentSystem()).resolveSinkRef(serializedSinkref)
     } else
-      ctxt.handleUnexpectedToken(handledType(), jp).asInstanceOf[SinkRef[_]]
+      ctxt.handleUnexpectedToken(handledType(), jp).asInstanceOf[SinkRef[?]]
   }
 }

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/TypedActorRefModule.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/TypedActorRefModule.scala
@@ -31,7 +31,7 @@ import pekko.annotation.InternalApi
  * INTERNAL API: Adds support for serializing and deserializing [[pekko.actor.typed.ActorRef]].
  */
 @InternalApi private[pekko] trait TypedActorRefModule extends JacksonModule {
-  addSerializer(classOf[ActorRef[_]], () => TypedActorRefSerializer.instance, () => TypedActorRefDeserializer.instance)
+  addSerializer(classOf[ActorRef[?]], () => TypedActorRefSerializer.instance, () => TypedActorRefDeserializer.instance)
 }
 
 /**
@@ -45,9 +45,9 @@ import pekko.annotation.InternalApi
  * INTERNAL API
  */
 @InternalApi private[pekko] class TypedActorRefSerializer
-    extends StdScalarSerializer[ActorRef[_]](classOf[ActorRef[_]])
+    extends StdScalarSerializer[ActorRef[?]](classOf[ActorRef[?]])
     with ActorSystemAccess {
-  override def serialize(value: ActorRef[_], jgen: JsonGenerator, provider: SerializerProvider): Unit = {
+  override def serialize(value: ActorRef[?], jgen: JsonGenerator, provider: SerializerProvider): Unit = {
     val serializedActorRef = ActorRefResolver(currentSystem().toTyped).toSerializationFormat(value)
     jgen.writeString(serializedActorRef)
   }
@@ -64,14 +64,14 @@ import pekko.annotation.InternalApi
  * INTERNAL API
  */
 @InternalApi private[pekko] class TypedActorRefDeserializer
-    extends StdScalarDeserializer[ActorRef[_]](classOf[ActorRef[_]])
+    extends StdScalarDeserializer[ActorRef[?]](classOf[ActorRef[?]])
     with ActorSystemAccess {
 
-  def deserialize(jp: JsonParser, ctxt: DeserializationContext): ActorRef[_] = {
+  def deserialize(jp: JsonParser, ctxt: DeserializationContext): ActorRef[?] = {
     if (jp.currentTokenId() == JsonTokenId.ID_STRING) {
       val serializedActorRef = jp.getText()
       ActorRefResolver(currentSystem().toTyped).resolveActorRef(serializedActorRef)
     } else
-      ctxt.handleUnexpectedToken(handledType(), jp).asInstanceOf[ActorRef[_]]
+      ctxt.handleUnexpectedToken(handledType(), jp).asInstanceOf[ActorRef[?]]
   }
 }

--- a/slf4j/src/main/scala/org/apache/pekko/event/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/org/apache/pekko/event/slf4j/Slf4jLogger.scala
@@ -46,7 +46,7 @@ object Logger {
    * @param logSource - the textual representation of the source of this log stream
    * @return a Logger for the specified parameters
    */
-  def apply(logClass: Class[_], logSource: String): SLFLogger = logClass match {
+  def apply(logClass: Class[?], logSource: String): SLFLogger = logClass match {
     case c if c == classOf[DummyClassForStringSources] => apply(logSource)
     case _                                             => SLFLoggerFactory.getLogger(logClass)
   }
@@ -170,13 +170,13 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
  */
 class Slf4jLoggingFilter(@unused settings: ActorSystem.Settings, eventStream: EventStream)
     extends LoggingFilterWithMarker {
-  def isErrorEnabled(logClass: Class[_], logSource: String) =
+  def isErrorEnabled(logClass: Class[?], logSource: String) =
     (eventStream.logLevel >= ErrorLevel) && Logger(logClass, logSource).isErrorEnabled
-  def isWarningEnabled(logClass: Class[_], logSource: String) =
+  def isWarningEnabled(logClass: Class[?], logSource: String) =
     (eventStream.logLevel >= WarningLevel) && Logger(logClass, logSource).isWarnEnabled
-  def isInfoEnabled(logClass: Class[_], logSource: String) =
+  def isInfoEnabled(logClass: Class[?], logSource: String) =
     (eventStream.logLevel >= InfoLevel) && Logger(logClass, logSource).isInfoEnabled
-  def isDebugEnabled(logClass: Class[_], logSource: String) =
+  def isDebugEnabled(logClass: Class[?], logSource: String) =
     (eventStream.logLevel >= DebugLevel) && Logger(logClass, logSource).isDebugEnabled
 
   private def slf4jMarker(marker: LogMarker) = marker match {
@@ -185,13 +185,13 @@ class Slf4jLoggingFilter(@unused settings: ActorSystem.Settings, eventStream: Ev
     case marker                      => MarkerFactory.getMarker(marker.name)
   }
 
-  override def isErrorEnabled(logClass: Class[_], logSource: String, marker: LogMarker): Boolean =
+  override def isErrorEnabled(logClass: Class[?], logSource: String, marker: LogMarker): Boolean =
     (eventStream.logLevel >= ErrorLevel) && Logger(logClass, logSource).isErrorEnabled(slf4jMarker(marker))
-  override def isWarningEnabled(logClass: Class[_], logSource: String, marker: LogMarker): Boolean =
+  override def isWarningEnabled(logClass: Class[?], logSource: String, marker: LogMarker): Boolean =
     (eventStream.logLevel >= WarningLevel) && Logger(logClass, logSource).isWarnEnabled(slf4jMarker(marker))
-  override def isInfoEnabled(logClass: Class[_], logSource: String, marker: LogMarker): Boolean =
+  override def isInfoEnabled(logClass: Class[?], logSource: String, marker: LogMarker): Boolean =
     (eventStream.logLevel >= InfoLevel) && Logger(logClass, logSource).isInfoEnabled(slf4jMarker(marker))
-  override def isDebugEnabled(logClass: Class[_], logSource: String, marker: LogMarker): Boolean =
+  override def isDebugEnabled(logClass: Class[?], logSource: String, marker: LogMarker): Boolean =
     (eventStream.logLevel >= DebugLevel) && Logger(logClass, logSource).isDebugEnabled(slf4jMarker(marker))
 
 }

--- a/stream-testkit/src/main/scala/org/apache/pekko/stream/testkit/StreamTestKit.scala
+++ b/stream-testkit/src/main/scala/org/apache/pekko/stream/testkit/StreamTestKit.scala
@@ -57,7 +57,7 @@ object TestPublisher {
    * Publisher that subscribes the subscriber and completes after the first request.
    */
   def lazyEmpty[T]: Publisher[T] = new Publisher[T] {
-    override def subscribe(subscriber: Subscriber[_ >: T]): Unit =
+    override def subscribe(subscriber: Subscriber[? >: T]): Unit =
       subscriber.onSubscribe(CompletedSubscription(subscriber))
   }
 
@@ -70,7 +70,7 @@ object TestPublisher {
    * Publisher that subscribes the subscriber and signals error after the first request.
    */
   def lazyError[T](cause: Throwable): Publisher[T] = new Publisher[T] {
-    override def subscribe(subscriber: Subscriber[_ >: T]): Unit =
+    override def subscribe(subscriber: Subscriber[? >: T]): Unit =
       subscriber.onSubscribe(FailedSubscription(subscriber, cause))
   }
 
@@ -122,7 +122,7 @@ object TestPublisher {
     /**
      * Subscribes a given [[org.reactivestreams.Subscriber]] to this probe publisher.
      */
-    def subscribe(subscriber: Subscriber[_ >: I]): Unit = {
+    def subscribe(subscriber: Subscriber[? >: I]): Unit = {
       val subscription: PublisherProbeSubscription[I] = new PublisherProbeSubscription[I](subscriber, probe)
       probe.ref ! Subscribe(subscription)
       if (autoOnSubscribe) subscriber.onSubscribe(subscription)
@@ -910,7 +910,7 @@ private[stream] object StreamTestKit {
     override def cancel(): Unit = ()
   }
 
-  final case class PublisherProbeSubscription[I](subscriber: Subscriber[_ >: I], publisherProbe: TestProbe)
+  final case class PublisherProbeSubscription[I](subscriber: Subscriber[? >: I], publisherProbe: TestProbe)
       extends Subscription
       with SubscriptionWithCancelException {
     def request(elements: Long): Unit = publisherProbe.ref ! RequestMore(this, elements)

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/impl/fusing/GraphInterpreterSpecKit.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/impl/fusing/GraphInterpreterSpecKit.scala
@@ -102,19 +102,19 @@ object GraphInterpreterSpecKit {
    * @return Created logics and the maps of all inlets respective outlets to those logics
    */
   private[stream] def createLogics(
-      stages: Array[GraphStageWithMaterializedValue[_ <: Shape, _]],
-      upstreams: Array[UpstreamBoundaryStageLogic[_]],
-      downstreams: Array[DownstreamBoundaryStageLogic[_]],
+      stages: Array[GraphStageWithMaterializedValue[? <: Shape, ?]],
+      upstreams: Array[UpstreamBoundaryStageLogic[?]],
+      downstreams: Array[DownstreamBoundaryStageLogic[?]],
       attributes: Array[Attributes] = Array.empty)(implicit system: ActorSystem)
-      : (Array[GraphStageLogic], SMap[Inlet[_], GraphStageLogic], SMap[Outlet[_], GraphStageLogic]) = {
+      : (Array[GraphStageLogic], SMap[Inlet[?], GraphStageLogic], SMap[Outlet[?], GraphStageLogic]) = {
     if (attributes.nonEmpty && attributes.length != stages.length)
       throw new IllegalArgumentException("Attributes must be either empty or one per stage")
 
     @nowarn("msg=deprecated")
     val defaultAttributes = ActorMaterializerSettings(system).toAttributes
 
-    var inOwners = SMap.empty[Inlet[_], GraphStageLogic]
-    var outOwners = SMap.empty[Outlet[_], GraphStageLogic]
+    var inOwners = SMap.empty[Inlet[?], GraphStageLogic]
+    var outOwners = SMap.empty[Outlet[?], GraphStageLogic]
 
     val logics = new Array[GraphStageLogic](upstreams.length + stages.length + downstreams.length)
     var idx = 0
@@ -212,9 +212,9 @@ object GraphInterpreterSpecKit {
    * Create interpreter connections for all the given `connectedPorts`.
    */
   private[stream] def createConnections(
-      connectedPorts: Seq[(Outlet[_], Inlet[_])],
-      inOwners: SMap[Inlet[_], GraphStageLogic],
-      outOwners: SMap[Outlet[_], GraphStageLogic]): Array[Connection] = {
+      connectedPorts: Seq[(Outlet[?], Inlet[?])],
+      inOwners: SMap[Inlet[?], GraphStageLogic],
+      outOwners: SMap[Outlet[?], GraphStageLogic]): Array[Connection] = {
 
     val connections = new Array[Connection](connectedPorts.size)
     connectedPorts.zipWithIndex.foreach {
@@ -245,7 +245,7 @@ object GraphInterpreterSpecKit {
     }
   }
 
-  private def setPortIds(stage: GraphStageWithMaterializedValue[_ <: Shape, _]): Unit = {
+  private def setPortIds(stage: GraphStageWithMaterializedValue[? <: Shape, ?]): Unit = {
     stage.shape.inlets.zipWithIndex.foreach { case (inlet, idx) => inlet.id = idx }
     stage.shape.outlets.zipWithIndex.foreach { case (inlet, idx) => inlet.id = idx }
   }
@@ -302,10 +302,10 @@ trait GraphInterpreterSpecKit extends StreamSpec {
       override def toString = "Downstream"
     }
 
-    class AssemblyBuilder(operators: Seq[GraphStageWithMaterializedValue[_ <: Shape, _]]) {
-      private var upstreams = Vector.empty[UpstreamBoundaryStageLogic[_]]
-      private var downstreams = Vector.empty[DownstreamBoundaryStageLogic[_]]
-      private var connectedPorts = Vector.empty[(Outlet[_], Inlet[_])]
+    class AssemblyBuilder(operators: Seq[GraphStageWithMaterializedValue[? <: Shape, ?]]) {
+      private var upstreams = Vector.empty[UpstreamBoundaryStageLogic[?]]
+      private var downstreams = Vector.empty[DownstreamBoundaryStageLogic[?]]
+      private var connectedPorts = Vector.empty[(Outlet[?], Inlet[?])]
 
       def connect[T](upstream: UpstreamBoundaryStageLogic[T], in: Inlet[T]): AssemblyBuilder = {
         upstreams :+= upstream
@@ -349,7 +349,7 @@ trait GraphInterpreterSpecKit extends StreamSpec {
       _interpreter.init(null)
     }
 
-    def builder(operators: GraphStageWithMaterializedValue[_ <: Shape, _]*): AssemblyBuilder =
+    def builder(operators: GraphStageWithMaterializedValue[? <: Shape, ?]*): AssemblyBuilder =
       new AssemblyBuilder(operators.toVector)
 
   }

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/ChainSetup.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/ChainSetup.scala
@@ -30,13 +30,13 @@ class ChainSetup[In, Out, M](
     stream: Flow[In, In, NotUsed] => Flow[In, Out, M],
     val settings: ActorMaterializerSettings,
     materializer: Materializer,
-    toPublisher: (Source[Out, _], Materializer) => Publisher[Out])(implicit val system: ActorSystem) {
+    toPublisher: (Source[Out, ?], Materializer) => Publisher[Out])(implicit val system: ActorSystem) {
 
   @nowarn("msg=deprecated")
   def this(
       stream: Flow[In, In, NotUsed] => Flow[In, Out, M],
       settings: ActorMaterializerSettings,
-      toPublisher: (Source[Out, _], Materializer) => Publisher[Out])(implicit system: ActorSystem) =
+      toPublisher: (Source[Out, ?], Materializer) => Publisher[Out])(implicit system: ActorSystem) =
     this(stream, settings, ActorMaterializer(settings)(system), toPublisher)(system)
 
   @nowarn("msg=deprecated")
@@ -44,7 +44,7 @@ class ChainSetup[In, Out, M](
       stream: Flow[In, In, NotUsed] => Flow[In, Out, M],
       settings: ActorMaterializerSettings,
       materializerCreator: (ActorMaterializerSettings, ActorRefFactory) => Materializer,
-      toPublisher: (Source[Out, _], Materializer) => Publisher[Out])(implicit system: ActorSystem) =
+      toPublisher: (Source[Out, ?], Materializer) => Publisher[Out])(implicit system: ActorSystem) =
     this(stream, settings, materializerCreator(settings, system), toPublisher)(system)
 
   val upstream = TestPublisher.manualProbe[In]()

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/ScriptedTest.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/ScriptedTest.scala
@@ -39,7 +39,7 @@ trait ScriptedTest extends Matchers {
 
   class ScriptException(msg: String) extends RuntimeException(msg)
 
-  def toPublisher[In, Out]: (Source[Out, _], Materializer) => Publisher[Out] =
+  def toPublisher[In, Out]: (Source[Out, ?], Materializer) => Publisher[Out] =
     (f, m) => f.runWith(Sink.asPublisher(false))(m)
 
   object Script {

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamSpec.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamSpec.scala
@@ -39,7 +39,7 @@ abstract class StreamSpec(_system: ActorSystem) extends PekkoSpec(_system) {
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 
-  def this(configMap: Map[String, _]) = this(PekkoSpec.mapToConfig(configMap))
+  def this(configMap: Map[String, ?]) = this(PekkoSpec.mapToConfig(configMap))
 
   def this() = this(ActorSystem(TestKitUtils.testNameFromCallStack(classOf[StreamSpec], "".r), PekkoSpec.testConf))
 

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/TwoStreamsSetup.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/TwoStreamsSetup.scala
@@ -27,7 +27,7 @@ abstract class TwoStreamsSetup extends BaseTwoStreamsSetup {
     def out: Outlet[Outputs]
   }
 
-  def fixture(b: GraphDSL.Builder[_]): Fixture
+  def fixture(b: GraphDSL.Builder[?]): Fixture
 
   override def setup(p1: Publisher[Int], p2: Publisher[Int]) = {
     val subscriber = TestSubscriber.probe[Outputs]()

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/FlatMapConcatDoubleSubscriberTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/FlatMapConcatDoubleSubscriberTest.scala
@@ -26,7 +26,7 @@ class FlatMapConcatDoubleSubscriberTest extends PekkoSubscriberBlackboxVerificat
     val subscriber = Promise[Subscriber[Int]]()
     Source
       .single(Source.fromPublisher(new Publisher[Int] {
-        def subscribe(s: Subscriber[_ >: Int]): Unit =
+        def subscribe(s: Subscriber[? >: Int]): Unit =
           subscriber.success(s.asInstanceOf[Subscriber[Int]])
       }))
       .flatten

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PekkoIdentityProcessorVerification.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PekkoIdentityProcessorVerification.scala
@@ -46,7 +46,7 @@ abstract class PekkoIdentityProcessorVerification[T](env: TestEnvironment, publi
       override def onError(t: Throwable): Unit = sub.onError(t)
       override def onComplete(): Unit = sub.onComplete()
       override def onNext(t: T): Unit = sub.onNext(t)
-      override def subscribe(s: Subscriber[_ >: T]): Unit = pub.subscribe(s)
+      override def subscribe(s: Subscriber[? >: T]): Unit = pub.subscribe(s)
     }
   }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/DslConsistencySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/DslConsistencySpec.scala
@@ -38,23 +38,23 @@ object DslConsistencySpec {
 
 class DslConsistencySpec extends AnyWordSpec with Matchers {
 
-  val sFlowClass: Class[_] = classOf[pekko.stream.scaladsl.Flow[_, _, _]]
-  val jFlowClass: Class[_] = classOf[pekko.stream.javadsl.Flow[_, _, _]]
+  val sFlowClass: Class[?] = classOf[pekko.stream.scaladsl.Flow[?, ?, ?]]
+  val jFlowClass: Class[?] = classOf[pekko.stream.javadsl.Flow[?, ?, ?]]
 
-  val sSubFlowClass: Class[_] = classOf[DslConsistencySpec.ScalaSubFlow[_, _, _]]
-  val jSubFlowClass: Class[_] = classOf[pekko.stream.javadsl.SubFlow[_, _, _]]
+  val sSubFlowClass: Class[?] = classOf[DslConsistencySpec.ScalaSubFlow[?, ?, ?]]
+  val jSubFlowClass: Class[?] = classOf[pekko.stream.javadsl.SubFlow[?, ?, ?]]
 
-  val sSourceClass: Class[_] = classOf[pekko.stream.scaladsl.Source[_, _]]
-  val jSourceClass: Class[_] = classOf[pekko.stream.javadsl.Source[_, _]]
+  val sSourceClass: Class[?] = classOf[pekko.stream.scaladsl.Source[?, ?]]
+  val jSourceClass: Class[?] = classOf[pekko.stream.javadsl.Source[?, ?]]
 
-  val sSubSourceClass: Class[_] = classOf[DslConsistencySpec.ScalaSubSource[_, _]]
-  val jSubSourceClass: Class[_] = classOf[pekko.stream.javadsl.SubSource[_, _]]
+  val sSubSourceClass: Class[?] = classOf[DslConsistencySpec.ScalaSubSource[?, ?]]
+  val jSubSourceClass: Class[?] = classOf[pekko.stream.javadsl.SubSource[?, ?]]
 
-  val sSinkClass: Class[_] = classOf[pekko.stream.scaladsl.Sink[_, _]]
-  val jSinkClass: Class[_] = classOf[pekko.stream.javadsl.Sink[_, _]]
+  val sSinkClass: Class[?] = classOf[pekko.stream.scaladsl.Sink[?, ?]]
+  val jSinkClass: Class[?] = classOf[pekko.stream.javadsl.Sink[?, ?]]
 
-  val jRunnableGraphClass: Class[_] = classOf[pekko.stream.javadsl.RunnableGraph[_]]
-  val sRunnableGraphClass: Class[_] = classOf[pekko.stream.scaladsl.RunnableGraph[_]]
+  val jRunnableGraphClass: Class[?] = classOf[pekko.stream.javadsl.RunnableGraph[?]]
+  val sRunnableGraphClass: Class[?] = classOf[pekko.stream.scaladsl.RunnableGraph[?]]
 
   val ignore: Set[String] =
     Set("equals", "hashCode", "notify", "notifyAll", "wait", "toString", "getClass") ++
@@ -95,7 +95,7 @@ class DslConsistencySpec extends AnyWordSpec with Matchers {
 
   val forComprehensions = Set("withFilter", "flatMap", "foreach")
 
-  val allowMissing: Map[Class[_], Set[String]] = Map(
+  val allowMissing: Map[Class[?], Set[String]] = Map(
     jFlowClass -> (graphHelpers ++ forComprehensions),
     jSourceClass -> (graphHelpers ++ forComprehensions ++ Set("watch", "ask")),
     // Java subflows can only be nested using .via and .to (due to type system restrictions)
@@ -113,7 +113,7 @@ class DslConsistencySpec extends AnyWordSpec with Matchers {
   @nowarn
   def materializing(m: Method): Boolean = m.getParameterTypes.contains(classOf[ActorMaterializer])
 
-  def assertHasMethod(c: Class[_], name: String): Unit = {
+  def assertHasMethod(c: Class[?], name: String): Unit = {
     // include class name to get better error message
     if (!allowMissing.getOrElse(c, Set.empty).contains(name))
       c.getMethods.collect { case m if !ignore(m.getName) => c.getName + "." + m.getName } should contain(
@@ -122,12 +122,12 @@ class DslConsistencySpec extends AnyWordSpec with Matchers {
 
   "Java and Scala DSLs" must {
 
-    (("Source" -> List[Class[_]](sSourceClass, jSourceClass)) ::
-    ("SubSource" -> List[Class[_]](sSubSourceClass, jSubSourceClass)) ::
-    ("Flow" -> List[Class[_]](sFlowClass, jFlowClass)) ::
-    ("SubFlow" -> List[Class[_]](sSubFlowClass, jSubFlowClass)) ::
-    ("Sink" -> List[Class[_]](sSinkClass, jSinkClass)) ::
-    ("RunnableFlow" -> List[Class[_]](sRunnableGraphClass, jRunnableGraphClass)) ::
+    (("Source" -> List[Class[?]](sSourceClass, jSourceClass)) ::
+    ("SubSource" -> List[Class[?]](sSubSourceClass, jSubSourceClass)) ::
+    ("Flow" -> List[Class[?]](sFlowClass, jFlowClass)) ::
+    ("SubFlow" -> List[Class[?]](sSubFlowClass, jSubFlowClass)) ::
+    ("Sink" -> List[Class[?]](sSinkClass, jSinkClass)) ::
+    ("RunnableFlow" -> List[Class[?]](sRunnableGraphClass, jRunnableGraphClass)) ::
     Nil).foreach {
       case (element, classes) =>
         s"provide same $element transforming operators" in {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/FixedBufferSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/FixedBufferSpec.scala
@@ -141,19 +141,19 @@ class FixedBufferSpec extends StreamSpec {
     }
 
     "produce BoundedBuffers when capacity > max-fixed-buffer-size" in {
-      Buffer(Int.MaxValue, default) shouldBe a[BoundedBuffer[_]]
+      Buffer(Int.MaxValue, default) shouldBe a[BoundedBuffer[?]]
     }
 
     "produce FixedSizeBuffers when capacity < max-fixed-buffer-size" in {
-      Buffer(1000, default) shouldBe a[FixedSizeBuffer.ModuloFixedSizeBuffer[_]]
-      Buffer(1024, default) shouldBe a[FixedSizeBuffer.PowerOfTwoFixedSizeBuffer[_]]
+      Buffer(1000, default) shouldBe a[FixedSizeBuffer.ModuloFixedSizeBuffer[?]]
+      Buffer(1024, default) shouldBe a[FixedSizeBuffer.PowerOfTwoFixedSizeBuffer[?]]
     }
 
     "produce FixedSizeBuffers when max-fixed-buffer-size < BoundedBufferSize" in {
       val settings = default and ActorAttributes.maxFixedBufferSize(9)
-      Buffer(5, settings) shouldBe a[FixedSizeBuffer.ModuloFixedSizeBuffer[_]]
-      Buffer(10, settings) shouldBe a[FixedSizeBuffer.ModuloFixedSizeBuffer[_]]
-      Buffer(16, settings) shouldBe a[FixedSizeBuffer.PowerOfTwoFixedSizeBuffer[_]]
+      Buffer(5, settings) shouldBe a[FixedSizeBuffer.ModuloFixedSizeBuffer[?]]
+      Buffer(10, settings) shouldBe a[FixedSizeBuffer.ModuloFixedSizeBuffer[?]]
+      Buffer(16, settings) shouldBe a[FixedSizeBuffer.PowerOfTwoFixedSizeBuffer[?]]
     }
 
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -374,7 +374,7 @@ class ActorGraphInterpreterSpec extends StreamSpec {
 
     "be able to handle Publisher spec violations without leaking" in {
       val filthyPublisher = new Publisher[Int] {
-        override def subscribe(s: Subscriber[_ >: Int]): Unit = {
+        override def subscribe(s: Subscriber[? >: Int]): Unit = {
           s.onSubscribe(new Subscription {
             override def cancel(): Unit = ()
             override def request(n: Long): Unit = throw TE("violating your spec")
@@ -468,7 +468,7 @@ class ActorGraphInterpreterSpec extends StreamSpec {
       val done = Promise[Done]()
       Source
         .single(Source.fromPublisher(new Publisher[Int] {
-          def subscribe(s: Subscriber[_ >: Int]): Unit = {
+          def subscribe(s: Subscriber[? >: Int]): Unit = {
             s.onSubscribe(new Subscription {
               def cancel(): Unit = ()
               def request(n: Long): Unit = ()

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/CoupledTerminationFlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/CoupledTerminationFlowSpec.scala
@@ -112,7 +112,7 @@ class CoupledTerminationFlowSpec extends StreamSpec("""
       val probe = TestProbe()
       val f = Flow.fromSinkAndSourceCoupledMat(Sink.cancelled,
         Source.fromPublisher(new Publisher[String] {
-          override def subscribe(subscriber: Subscriber[_ >: String]): Unit = {
+          override def subscribe(subscriber: Subscriber[? >: String]): Unit = {
             subscriber.onSubscribe(new Subscription {
               override def cancel(): Unit = probe.ref ! "cancelled"
 
@@ -159,7 +159,7 @@ class CoupledTerminationFlowSpec extends StreamSpec("""
 
     val downstreamEffect = Sink.onComplete(s => probe.ref ! s)
     val upstreamEffect = Source.fromPublisher(new Publisher[String] {
-      override def subscribe(s: Subscriber[_ >: String]): Unit =
+      override def subscribe(s: Subscriber[? >: String]): Unit =
         s.onSubscribe(new Subscription {
           override def cancel(): Unit = probe.ref ! "cancel-received"
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCompileSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCompileSpec.scala
@@ -34,47 +34,47 @@ class FlowCompileSpec extends StreamSpec {
 
   "Flow" should {
     "not run" in {
-      val open: Flow[Int, Int, _] = Flow[Int]
+      val open: Flow[Int, Int, ?] = Flow[Int]
       "open.run()" shouldNot compile
     }
     "accept Iterable" in {
-      val f: Source[Int, _] = intSeq.via(Flow[Int])
+      val f: Source[Int, ?] = intSeq.via(Flow[Int])
     }
     "accept Future" in {
-      val f: Source[Int, _] = intFut.via(Flow[Int])
+      val f: Source[Int, ?] = intFut.via(Flow[Int])
     }
     "append Flow" in {
-      val open1: Flow[Int, String, _] = Flow[Int].map(_.toString)
-      val open2: Flow[String, Int, _] = Flow[String].map(_.hashCode)
-      val open3: Flow[Int, Int, _] = open1.via(open2)
+      val open1: Flow[Int, String, ?] = Flow[Int].map(_.toString)
+      val open2: Flow[String, Int, ?] = Flow[String].map(_.hashCode)
+      val open3: Flow[Int, Int, ?] = open1.via(open2)
       "open3.run()" shouldNot compile
 
-      val closedSource: Source[Int, _] = intSeq.via(open3)
-      val closedSink: Sink[Int, _] = open3.to(Sink.asPublisher[Int](false))
+      val closedSource: Source[Int, ?] = intSeq.via(open3)
+      val closedSink: Sink[Int, ?] = open3.to(Sink.asPublisher[Int](false))
       "closedSink.run()" shouldNot compile
 
       closedSource.to(Sink.asPublisher[Int](false)).run()
       intSeq.to(closedSink).run()
     }
     "append Sink" in {
-      val open: Flow[Int, String, _] = Flow[Int].map(_.toString)
-      val closedSink: Sink[String, _] = Flow[String].map(_.hashCode).to(Sink.asPublisher[Int](false))
-      val appended: Sink[Int, _] = open.to(closedSink)
+      val open: Flow[Int, String, ?] = Flow[Int].map(_.toString)
+      val closedSink: Sink[String, ?] = Flow[String].map(_.hashCode).to(Sink.asPublisher[Int](false))
+      val appended: Sink[Int, ?] = open.to(closedSink)
       "appended.run()" shouldNot compile
       "appended.to(Sink.head[Int])" shouldNot compile
       intSeq.to(appended).run()
     }
     "be appended to Source" in {
-      val open: Flow[Int, String, _] = Flow[Int].map(_.toString)
-      val closedSource: Source[Int, _] = strSeq.via(Flow[String].map(_.hashCode))
-      val closedSource2: Source[String, _] = closedSource.via(open)
+      val open: Flow[Int, String, ?] = Flow[Int].map(_.toString)
+      val closedSource: Source[Int, ?] = strSeq.via(Flow[String].map(_.hashCode))
+      val closedSource2: Source[String, ?] = closedSource.via(open)
       "strSeq.to(closedSource2)" shouldNot compile
       closedSource2.to(Sink.asPublisher[String](false)).run()
     }
   }
 
   "Sink" should {
-    val openSink: Sink[Int, _] =
+    val openSink: Sink[Int, ?] =
       Flow[Int].map(_.toString).to(Sink.asPublisher[String](false))
     "accept Source" in {
       intSeq.to(openSink)
@@ -88,7 +88,7 @@ class FlowCompileSpec extends StreamSpec {
   }
 
   "Source" should {
-    val openSource: Source[String, _] =
+    val openSource: Source[String, ?] =
       Source(Seq(1, 2, 3)).map(_.toString)
     "accept Sink" in {
       openSource.to(Sink.asPublisher[String](false))

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowConcatAllSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowConcatAllSpec.scala
@@ -117,7 +117,7 @@ class FlowConcatAllSpec extends StreamSpec("""
     }
 
     "on onError on opening substream, cancel the master stream and signal error " in {
-      val publisher = TestPublisher.manualProbe[Source[Int, _]]()
+      val publisher = TestPublisher.manualProbe[Source[Int, ?]]()
       val subscriber = TestSubscriber.manualProbe[Int]()
       Source.fromPublisher(publisher).flatMapConcat(_ => throw testException).to(Sink.fromSubscriber(subscriber)).run()
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowConcatSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowConcatSpec.scala
@@ -49,9 +49,9 @@ abstract class AbstractFlowConcatSpec extends BaseTwoStreamsSetup {
   s"${if (eager) "An eager" else "A lazy"} Concat for Flow " must {
 
     "be able to concat Flow with a Source" in {
-      val f1: Flow[Int, String, _] = Flow[Int].map(_.toString + "-s")
-      val s1: Source[Int, _] = Source(List(1, 2, 3))
-      val s2: Source[String, _] = Source(List(4, 5, 6)).map(_.toString + "-s")
+      val f1: Flow[Int, String, ?] = Flow[Int].map(_.toString + "-s")
+      val s1: Source[Int, ?] = Source(List(1, 2, 3))
+      val s2: Source[String, ?] = Source(List(4, 5, 6)).map(_.toString + "-s")
 
       val subs = TestSubscriber.manualProbe[Any]()
       val subSink = Sink.asPublisher[Any](false)
@@ -67,9 +67,9 @@ abstract class AbstractFlowConcatSpec extends BaseTwoStreamsSetup {
     }
 
     "be able to prepend a Source to a Flow" in {
-      val s1: Source[String, _] = Source(List(1, 2, 3)).map(_.toString + "-s")
-      val s2: Source[Int, _] = Source(List(4, 5, 6))
-      val f2: Flow[Int, String, _] = Flow[Int].map(_.toString + "-s")
+      val s1: Source[String, ?] = Source(List(1, 2, 3)).map(_.toString + "-s")
+      val s2: Source[Int, ?] = Source(List(4, 5, 6))
+      val f2: Flow[Int, String, ?] = Flow[Int].map(_.toString + "-s")
 
       val subs = TestSubscriber.manualProbe[Any]()
       val subSink = Sink.asPublisher[Any](false)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupBySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupBySpec.scala
@@ -75,17 +75,17 @@ class FlowGroupBySpec extends StreamSpec("""
     val max = if (maxSubstreams > 0) maxSubstreams else groupCount
     val groupStream =
       Source.fromPublisher(source).groupBy(max, _ % groupCount).lift(_ % groupCount).runWith(Sink.asPublisher(false))
-    val masterSubscriber = TestSubscriber.manualProbe[(Int, Source[Int, _])]()
+    val masterSubscriber = TestSubscriber.manualProbe[(Int, Source[Int, ?])]()
 
     groupStream.subscribe(masterSubscriber)
     val masterSubscription = masterSubscriber.expectSubscription()
 
-    def getSubFlow(expectedKey: Int): Source[Int, _] = {
+    def getSubFlow(expectedKey: Int): Source[Int, ?] = {
       masterSubscription.request(1)
       expectSubFlow(expectedKey)
     }
 
-    def expectSubFlow(expectedKey: Int): Source[Int, _] = {
+    def expectSubFlow(expectedKey: Int): Source[Int, ?] = {
       val (key, substream) = masterSubscriber.expectNext()
       key should be(expectedKey)
       substream
@@ -184,7 +184,7 @@ class FlowGroupBySpec extends StreamSpec("""
       val publisherProbeProbe = TestPublisher.manualProbe[Int]()
       val publisher =
         Source.fromPublisher(publisherProbeProbe).groupBy(2, _ % 2).lift(_ % 2).runWith(Sink.asPublisher(false))
-      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, ?])]()
       publisher.subscribe(subscriber)
 
       val upstreamSubscription = publisherProbeProbe.expectSubscription()
@@ -195,7 +195,7 @@ class FlowGroupBySpec extends StreamSpec("""
 
     "work with empty input stream" in {
       val publisher = Source(List.empty[Int]).groupBy(2, _ % 2).lift(_ % 2).runWith(Sink.asPublisher(false))
-      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, ?])]()
       publisher.subscribe(subscriber)
 
       subscriber.expectSubscriptionAndComplete()
@@ -205,7 +205,7 @@ class FlowGroupBySpec extends StreamSpec("""
       val publisherProbeProbe = TestPublisher.manualProbe[Int]()
       val publisher =
         Source.fromPublisher(publisherProbeProbe).groupBy(2, _ % 2).lift(_ % 2).runWith(Sink.asPublisher(false))
-      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, ?])]()
       publisher.subscribe(subscriber)
 
       val upstreamSubscription = publisherProbeProbe.expectSubscription()
@@ -223,7 +223,7 @@ class FlowGroupBySpec extends StreamSpec("""
       val publisherProbeProbe = TestPublisher.manualProbe[Int]()
       val publisher =
         Source.fromPublisher(publisherProbeProbe).groupBy(2, _ % 2).lift(_ % 2).runWith(Sink.asPublisher(false))
-      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, ?])]()
       publisher.subscribe(subscriber)
 
       val upstreamSubscription = publisherProbeProbe.expectSubscription()

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowOnCompleteSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowOnCompleteSpec.scala
@@ -98,7 +98,7 @@ class FlowOnCompleteSpec extends StreamSpec("""
       proc.expectRequest()
       mat.shutdown()
 
-      onCompleteProbe.expectMsgType[Failure[_]]
+      onCompleteProbe.expectMsgType[Failure[?]]
     }
 
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrefixAndTailSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrefixAndTailSpec.scala
@@ -32,7 +32,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     val testException = new Exception("test") with NoStackTrace
 
-    def newHeadSink = Sink.head[(immutable.Seq[Int], Source[Int, _])]
+    def newHeadSink = Sink.head[(immutable.Seq[Int], Source[Int, ?])]
 
     "work on empty input" in {
       val futureSink = newHeadSink
@@ -171,7 +171,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "handle onError when no substream open" in {
       val publisher = TestPublisher.manualProbe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
 
       Source.fromPublisher(publisher).prefixAndTail(3).to(Sink.fromSubscriber(subscriber)).run()
 
@@ -189,7 +189,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "handle onError when substream is open" in {
       val publisher = TestPublisher.manualProbe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
 
       Source.fromPublisher(publisher).prefixAndTail(1).to(Sink.fromSubscriber(subscriber)).run()
 
@@ -216,7 +216,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "handle master stream cancellation" in {
       val publisher = TestPublisher.manualProbe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
 
       Source.fromPublisher(publisher).prefixAndTail(3).to(Sink.fromSubscriber(subscriber)).run()
 
@@ -234,7 +234,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "handle substream cancellation" in {
       val publisher = TestPublisher.manualProbe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
 
       Source.fromPublisher(publisher).prefixAndTail(1).to(Sink.fromSubscriber(subscriber)).run()
 
@@ -260,7 +260,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "pass along early cancellation" in {
       val up = TestPublisher.manualProbe[Int]()
-      val down = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, _])]()
+      val down = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
 
       val flowSubscriber = Source.asSubscriber[Int].prefixAndTail(1).to(Sink.fromSubscriber(down)).run()
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowScanAsyncSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowScanAsyncSpec.scala
@@ -276,7 +276,7 @@ class FlowScanAsyncSpec extends StreamSpec with Matchers {
         elements: immutable.Seq[String],
         zero: String,
         decider: Supervision.Decider = Supervision.stoppingDecider): Probe[String] = {
-      val nullFutureScanFlow: Flow[String, String, _] = Flow[String].scanAsync(zero) { (_: String, next: String) =>
+      val nullFutureScanFlow: Flow[String, String, ?] = Flow[String].scanAsync(zero) { (_: String, next: String) =>
         if (next != "null") Future(next)
         else Future(null)
       }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSplitAfterSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSplitAfterSpec.scala
@@ -68,17 +68,17 @@ class FlowSplitAfterSpec extends StreamSpec("""
       .lift
       .withAttributes(ActorAttributes.supervisionStrategy(decider))
       .runWith(Sink.asPublisher(false))
-    val masterSubscriber = TestSubscriber.manualProbe[Source[Int, _]]()
+    val masterSubscriber = TestSubscriber.manualProbe[Source[Int, ?]]()
 
     groupStream.subscribe(masterSubscriber)
     val masterSubscription = masterSubscriber.expectSubscription()
 
-    def expectSubFlow(): Source[Int, _] = {
+    def expectSubFlow(): Source[Int, ?] = {
       masterSubscription.request(1)
       expectSubPublisher()
     }
 
-    def expectSubPublisher(): Source[Int, _] = {
+    def expectSubPublisher(): Source[Int, ?] = {
       val substream = masterSubscriber.expectNext()
       substream
     }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSplitWhenSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSplitWhenSpec.scala
@@ -61,17 +61,17 @@ class FlowSplitWhenSpec extends StreamSpec("""
       .lift
       .withAttributes(ActorAttributes.supervisionStrategy(decider))
       .runWith(Sink.asPublisher(false))
-    val masterSubscriber = TestSubscriber.manualProbe[Source[Int, _]]()
+    val masterSubscriber = TestSubscriber.manualProbe[Source[Int, ?]]()
 
     groupStream.subscribe(masterSubscriber)
     val masterSubscription = masterSubscriber.expectSubscription()
 
-    def getSubFlow(): Source[Int, _] = {
+    def getSubFlow(): Source[Int, ?] = {
       masterSubscription.request(1)
       expectSubPublisher()
     }
 
-    def expectSubPublisher(): Source[Int, _] = {
+    def expectSubPublisher(): Source[Int, ?] = {
       val substream = masterSubscriber.expectNext()
       substream
     }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowTakeSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowTakeSpec.scala
@@ -28,7 +28,7 @@ class FlowTakeSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2
   """) with ScriptedTest {
 
-  muteDeadLetters(classOf[OnNext], OnComplete.getClass, classOf[RequestMore[_]])()
+  muteDeadLetters(classOf[OnNext], OnComplete.getClass, classOf[RequestMore[?]])()
 
   "A Take" must {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphConcatSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphConcatSpec.scala
@@ -24,7 +24,7 @@ class GraphConcatSpec extends TwoStreamsSetup {
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val concat = b.add(Concat[Outputs]())
 
     override def left: Inlet[Outputs] = concat.in(0)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeLatestSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeLatestSpec.scala
@@ -27,7 +27,7 @@ class GraphMergeLatestSpec extends TwoStreamsSetup {
 
   override type Outputs = List[Int]
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val merge = b.add(MergeLatest[Int](2))
 
     override def left: Inlet[Int] = merge.in(0)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergePreferredSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergePreferredSpec.scala
@@ -27,7 +27,7 @@ class GraphMergePreferredSpec extends TwoStreamsSetup {
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val merge = b.add(MergePreferred[Outputs](1))
 
     override def left: Inlet[Outputs] = merge.preferred

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergePrioritizedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergePrioritizedSpec.scala
@@ -26,7 +26,7 @@ class GraphMergePrioritizedSpec extends TwoStreamsSetup {
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val mergePrioritized = b.add(MergePrioritized[Outputs](Seq(2, 8)))
 
     override def left: Inlet[Outputs] = mergePrioritized.in(0)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSequenceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSequenceSpec.scala
@@ -27,7 +27,7 @@ class GraphMergeSequenceSpec extends TwoStreamsSetup {
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val merge = b.add(MergeSequence[Outputs](2)(i => i))
 
     override def left: Inlet[Outputs] = merge.in(0)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSortedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSortedSpec.scala
@@ -28,7 +28,7 @@ class GraphMergeSortedSpec extends TwoStreamsSetup with ScalaCheckPropertyChecks
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val merge = b.add(new MergeSorted[Outputs])
 
     override def left: Inlet[Outputs] = merge.in0

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSpec.scala
@@ -26,7 +26,7 @@ class GraphMergeSpec extends TwoStreamsSetup {
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val merge = b.add(Merge[Outputs](2))
 
     override def left: Inlet[Outputs] = merge.in(0)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphOpsIntegrationSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphOpsIntegrationSpec.scala
@@ -30,13 +30,13 @@ object GraphOpsIntegrationSpec {
 
     case class ShufflePorts[In, Out](in1: Inlet[In], in2: Inlet[In], out1: Outlet[Out], out2: Outlet[Out])
         extends Shape {
-      override def inlets: immutable.Seq[Inlet[_]] = List(in1, in2)
-      override def outlets: immutable.Seq[Outlet[_]] = List(out1, out2)
+      override def inlets: immutable.Seq[Inlet[?]] = List(in1, in2)
+      override def outlets: immutable.Seq[Outlet[?]] = List(out1, out2)
 
       override def deepCopy() = ShufflePorts(in1.carbonCopy(), in2.carbonCopy(), out1.carbonCopy(), out2.carbonCopy())
     }
 
-    def apply[In, Out](pipeline: Flow[In, Out, _]): Graph[ShufflePorts[In, Out], NotUsed] = {
+    def apply[In, Out](pipeline: Flow[In, Out, ?]): Graph[ShufflePorts[In, Out], NotUsed] = {
       GraphDSL.create() { implicit b =>
         val merge = b.add(Merge[In](2))
         val balance = b.add(Balance[Out](2))

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphUnzipWithSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphUnzipWithSpec.scala
@@ -41,7 +41,7 @@ class GraphUnzipWithSpec extends StreamSpec("""
   type LeftOutput = Int
   type RightOutput = String
 
-  abstract class Fixture(@unused b: GraphDSL.Builder[_]) {
+  abstract class Fixture(@unused b: GraphDSL.Builder[?]) {
     def in: Inlet[Int]
     def left: Outlet[LeftOutput]
     def right: Outlet[RightOutput]
@@ -49,7 +49,7 @@ class GraphUnzipWithSpec extends StreamSpec("""
 
   val f: (Int => (Int, String)) = b => (b + b, s"$b + $b")
 
-  def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture(b) {
+  def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture(b) {
     val unzip = b.add(UnzipWith[Int, Int, String](f))
 
     override def in: Inlet[Int] = unzip.in
@@ -232,7 +232,7 @@ class GraphUnzipWithSpec extends StreamSpec("""
           ClosedShape
         })
         .run()
-      val termination = probe.expectMsgType[Future[_]].asInstanceOf[Future[Done]]
+      val termination = probe.expectMsgType[Future[?]].asInstanceOf[Future[Done]]
       val killSwitch1 = probe.expectMsgType[UniqueKillSwitch]
       val killSwitch2 = probe.expectMsgType[UniqueKillSwitch]
       val boom = TE("Boom")

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipLatestWithSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipLatestWithSpec.scala
@@ -28,7 +28,7 @@ class GraphZipLatestWithSpec extends TwoStreamsSetup {
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val zip = b.add(ZipWith((_: Int) + (_: Int)))
     override def left: Inlet[Int] = zip.in0
     override def right: Inlet[Int] = zip.in1

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipNSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipNSpec.scala
@@ -26,7 +26,7 @@ class GraphZipNSpec extends TwoStreamsSetup {
 
   override type Outputs = immutable.Seq[Int]
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val zipN = b.add(ZipN[Int](2))
 
     override def left: Inlet[Int] = zipN.in(0)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipSpec.scala
@@ -26,7 +26,7 @@ class GraphZipSpec extends TwoStreamsSetup {
 
   override type Outputs = (Int, Int)
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val zip = b.add(Zip[Int, Int]())
 
     override def left: Inlet[Int] = zip.in0

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipWithNSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipWithNSpec.scala
@@ -26,7 +26,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val zip = b.add(ZipWithN((_: immutable.Seq[Int]).sum)(2))
     override def left: Inlet[Int] = zip.in(0)
     override def right: Inlet[Int] = zip.in(1)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipWithSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipWithSpec.scala
@@ -25,7 +25,7 @@ class GraphZipWithSpec extends TwoStreamsSetup {
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture {
+  override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val zip = b.add(ZipWith((_: Int) + (_: Int)))
     override def left: Inlet[Int] = zip.in0
     override def right: Inlet[Int] = zip.in1

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/RestartSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/RestartSpec.scala
@@ -674,7 +674,7 @@ class RestartSpec
     // helps reuse all the setupFlow code for both methods: withBackoff, and onlyOnFailuresWithBackoff
     def RestartFlowFactory[In, Out](
         onlyOnFailures: Boolean,
-        settings: RestartSettings): (() => Flow[In, Out, _]) => Flow[In, Out, NotUsed] =
+        settings: RestartSettings): (() => Flow[In, Out, ?]) => Flow[In, Out, NotUsed] =
       if (onlyOnFailures) RestartFlow.onFailuresWithBackoff(settings)
       else RestartFlow.withBackoff(settings)
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SubstreamSubscriptionTimeoutSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SubstreamSubscriptionTimeoutSpec.scala
@@ -35,7 +35,7 @@ class SubstreamSubscriptionTimeoutSpec extends StreamSpec("""
   "groupBy and splitwhen" must {
 
     "timeout and cancel substream publishers when no-one subscribes to them after some time (time them out)" in {
-      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, ?])]()
       val publisherProbe = TestPublisher.probe[Int]()
       Source.fromPublisher(publisherProbe).groupBy(3, _ % 3).lift(_ % 3).runWith(Sink.fromSubscriber(subscriber))
 
@@ -76,7 +76,7 @@ class SubstreamSubscriptionTimeoutSpec extends StreamSpec("""
 
     "timeout and stop groupBy parent actor if none of the substreams are actually consumed" in {
       val publisherProbe = TestPublisher.probe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, ?])]()
       Source.fromPublisher(publisherProbe).groupBy(2, _ % 2).lift(_ % 2).runWith(Sink.fromSubscriber(subscriber))
 
       val downstreamSubscription = subscriber.expectSubscription()
@@ -93,7 +93,7 @@ class SubstreamSubscriptionTimeoutSpec extends StreamSpec("""
 
     "not timeout and cancel substream publishers when they have been subscribed to" in {
       val publisherProbe = TestPublisher.probe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, _])]()
+      val subscriber = TestSubscriber.manualProbe[(Int, Source[Int, ?])]()
       Source.fromPublisher(publisherProbe).groupBy(2, _ % 2).lift(_ % 2).runWith(Sink.fromSubscriber(subscriber))
 
       val downstreamSubscription = subscriber.expectSubscription()

--- a/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
+++ b/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
@@ -96,7 +96,7 @@ class MapAsyncPartitionedSpec
     timeout = 5 seconds,
     interval = 100 millis)
 
-  private implicit val system: ActorSystem[_] = ActorSystem(Behaviors.empty, "test-system")
+  private implicit val system: ActorSystem[?] = ActorSystem(Behaviors.empty, "test-system")
   private implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
 
   override protected def afterAll(): Unit = {

--- a/stream-typed/src/test/scala/docs/org/apache/pekko/stream/typed/ActorSourceSinkExample.scala
+++ b/stream-typed/src/test/scala/docs/org/apache/pekko/stream/typed/ActorSourceSinkExample.scala
@@ -21,7 +21,7 @@ import pekko.actor.typed.scaladsl.Behaviors
 object ActorSourceSinkExample {
 
   def compileOnlySourceRef() = {
-    implicit val system: ActorSystem[_] = ActorSystem(Behaviors.empty, "ActorSourceSinkExample")
+    implicit val system: ActorSystem[?] = ActorSystem(Behaviors.empty, "ActorSourceSinkExample")
 
     // #actor-source-ref
     import org.apache.pekko
@@ -80,7 +80,7 @@ object ActorSourceSinkExample {
           sender(streamActor, 0)
         }
 
-      private def runStream(ackReceiver: ActorRef[Emitted.type])(implicit system: ActorSystem[_]): ActorRef[Event] = {
+      private def runStream(ackReceiver: ActorRef[Emitted.type])(implicit system: ActorSystem[?]): ActorRef[Event] = {
         val source =
           ActorSource.actorRefWithBackpressure[Event, Emitted.type](
             // get demand signalled to this actor receiving Ack
@@ -128,7 +128,7 @@ object ActorSourceSinkExample {
   }
 
   def compileOnlyAcotrRef() = {
-    implicit val system: ActorSystem[_] = ActorSystem(Behaviors.empty, "ActorSourceSinkExample")
+    implicit val system: ActorSystem[?] = ActorSystem(Behaviors.empty, "ActorSourceSinkExample")
 
     def targetActor(): ActorRef[Protocol] = ???
 
@@ -154,7 +154,7 @@ object ActorSourceSinkExample {
   }
 
   def compileOnlySinkWithBackpressure() = {
-    implicit val system: ActorSystem[_] = ActorSystem(Behaviors.empty, "ActorSourceSinkExample")
+    implicit val system: ActorSystem[?] = ActorSystem(Behaviors.empty, "ActorSourceSinkExample")
 
     def targetActor(): ActorRef[Protocol] = ???
 

--- a/stream/src/main/scala/com/typesafe/sslconfig/pekko/util/PekkoLoggerBridge.scala
+++ b/stream/src/main/scala/com/typesafe/sslconfig/pekko/util/PekkoLoggerBridge.scala
@@ -21,14 +21,14 @@ import pekko.event.Logging._
 import com.typesafe.sslconfig.util.{ LoggerFactory, NoDepsLogger }
 
 final class PekkoLoggerFactory(system: ActorSystem) extends LoggerFactory {
-  override def apply(clazz: Class[_]): NoDepsLogger = new PekkoLoggerBridge(system.eventStream, clazz)
+  override def apply(clazz: Class[?]): NoDepsLogger = new PekkoLoggerBridge(system.eventStream, clazz)
 
   override def apply(name: String): NoDepsLogger =
     new PekkoLoggerBridge(system.eventStream, name, classOf[DummyClassForStringSources])
 }
 
-class PekkoLoggerBridge(bus: EventStream, logSource: String, logClass: Class[_]) extends NoDepsLogger {
-  def this(bus: EventStream, clazz: Class[_]) = this(bus, clazz.getCanonicalName, clazz)
+class PekkoLoggerBridge(bus: EventStream, logSource: String, logClass: Class[?]) extends NoDepsLogger {
+  def this(bus: EventStream, clazz: Class[?]) = this(bus, clazz.getCanonicalName, clazz)
 
   override def isDebugEnabled: Boolean = true
 

--- a/stream/src/main/scala/org/apache/pekko/stream/FanInShape.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/FanInShape.scala
@@ -19,14 +19,14 @@ import scala.collection.immutable
 object FanInShape {
   sealed trait Init[O] {
     def outlet: Outlet[O]
-    def inlets: immutable.Seq[Inlet[_]]
+    def inlets: immutable.Seq[Inlet[?]]
     def name: String
   }
   final case class Name[O](override val name: String) extends Init[O] {
     override def outlet: Outlet[O] = Outlet(s"$name.out")
-    override def inlets: immutable.Seq[Inlet[_]] = Nil
+    override def inlets: immutable.Seq[Inlet[?]] = Nil
   }
-  final case class Ports[O](override val outlet: Outlet[O], override val inlets: immutable.Seq[Inlet[_]])
+  final case class Ports[O](override val outlet: Outlet[O], override val inlets: immutable.Seq[Inlet[?]])
       extends Init[O] {
     override def name: String = "FanIn"
   }
@@ -34,7 +34,7 @@ object FanInShape {
 
 abstract class FanInShape[+O] private (
     _out: Outlet[O @uncheckedVariance],
-    _registered: Iterator[Inlet[_]],
+    _registered: Iterator[Inlet[?]],
     _name: String)
     extends Shape {
   import FanInShape._
@@ -47,12 +47,12 @@ abstract class FanInShape[+O] private (
   /**
    * Not meant for overriding outside of Apache Pekko.
    */
-  override def inlets: immutable.Seq[Inlet[_]] = _inlets
+  override def inlets: immutable.Seq[Inlet[?]] = _inlets
 
   /**
    * Performance of subclass `UniformFanInShape` relies on `_inlets` being a `Vector`, not a `List`.
    */
-  private var _inlets: Vector[Inlet[_]] = Vector.empty
+  private var _inlets: Vector[Inlet[?]] = Vector.empty
   protected def newInlet[T](name: String): Inlet[T] = {
     val p = if (_registered.hasNext) _registered.next().asInstanceOf[Inlet[T]] else Inlet[T](s"${_name}.$name")
     _inlets :+= p

--- a/stream/src/main/scala/org/apache/pekko/stream/FanOutShape.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/FanOutShape.scala
@@ -19,14 +19,14 @@ import scala.collection.immutable
 object FanOutShape {
   sealed trait Init[I] {
     def inlet: Inlet[I]
-    def outlets: immutable.Seq[Outlet[_]]
+    def outlets: immutable.Seq[Outlet[?]]
     def name: String
   }
   final case class Name[I](override val name: String) extends Init[I] {
     override def inlet: Inlet[I] = Inlet(s"$name.in")
-    override def outlets: immutable.Seq[Outlet[_]] = Nil
+    override def outlets: immutable.Seq[Outlet[?]] = Nil
   }
-  final case class Ports[I](override val inlet: Inlet[I], override val outlets: immutable.Seq[Outlet[_]])
+  final case class Ports[I](override val inlet: Inlet[I], override val outlets: immutable.Seq[Outlet[?]])
       extends Init[I] {
     override def name: String = "FanOut"
   }
@@ -34,7 +34,7 @@ object FanOutShape {
 
 abstract class FanOutShape[-I] private (
     _in: Inlet[I @uncheckedVariance],
-    _registered: Iterator[Outlet[_]],
+    _registered: Iterator[Outlet[?]],
     _name: String)
     extends Shape {
   import FanOutShape._
@@ -46,13 +46,13 @@ abstract class FanOutShape[-I] private (
   /**
    * Not meant for overriding outside of Apache Pekko.
    */
-  override def outlets: immutable.Seq[Outlet[_]] = _outlets
+  override def outlets: immutable.Seq[Outlet[?]] = _outlets
   final override def inlets: immutable.Seq[Inlet[I @uncheckedVariance]] = in :: Nil
 
   /**
    * Performance of subclass `UniformFanOutShape` relies on `_outlets` being a `Vector`, not a `List`.
    */
-  private var _outlets: Vector[Outlet[_]] = Vector.empty
+  private var _outlets: Vector[Outlet[?]] = Vector.empty
   protected def newOutlet[T](name: String): Outlet[T] = {
     val p = if (_registered.hasNext) _registered.next().asInstanceOf[Outlet[T]] else Outlet[T](s"${_name}.$name")
     _outlets :+= p

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorPublisher.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorPublisher.scala
@@ -58,11 +58,11 @@ import org.reactivestreams.Subscription
   // SubscribePending message. The AtomicReference is set to null by the shutdown method, which is
   // called by the actor from postStop. Pending (unregistered) subscription attempts are denied by
   // the shutdown method. Subscription attempts after shutdown can be denied immediately.
-  private val pendingSubscribers = new AtomicReference[immutable.Seq[Subscriber[_ >: T]]](Nil)
+  private val pendingSubscribers = new AtomicReference[immutable.Seq[Subscriber[? >: T]]](Nil)
 
   protected val wakeUpMsg: Any = SubscribePending
 
-  override def subscribe(subscriber: Subscriber[_ >: T]): Unit = {
+  override def subscribe(subscriber: Subscriber[? >: T]): Unit = {
     requireNonNullSubscriber(subscriber)
     @tailrec def doSubscribe(): Unit = {
       val current = pendingSubscribers.get
@@ -79,7 +79,7 @@ import org.reactivestreams.Subscription
     doSubscribe()
   }
 
-  def takePendingSubscribers(): immutable.Seq[Subscriber[_ >: T]] = {
+  def takePendingSubscribers(): immutable.Seq[Subscriber[? >: T]] = {
     val pending = pendingSubscribers.getAndSet(Nil)
     if (pending eq null) Nil else pending.reverse
   }
@@ -94,7 +94,7 @@ import org.reactivestreams.Subscription
 
   @volatile private var shutdownReason: Option[Throwable] = None
 
-  private def reportSubscribeFailure(subscriber: Subscriber[_ >: T]): Unit =
+  private def reportSubscribeFailure(subscriber: Subscriber[? >: T]): Unit =
     try shutdownReason match {
         case Some(_: SpecViolation) => // ok, not allowed to call onError
         case Some(e) =>
@@ -115,7 +115,7 @@ import org.reactivestreams.Subscription
  */
 @InternalApi private[pekko] class ActorSubscription[T](
     final val impl: ActorRef,
-    final val subscriber: Subscriber[_ >: T])
+    final val subscriber: Subscriber[? >: T])
     extends Subscription {
   override def request(elements: Long): Unit = impl ! RequestMore(this, elements)
   override def cancel(): Unit = impl ! Cancel(this)
@@ -124,7 +124,7 @@ import org.reactivestreams.Subscription
 /**
  * INTERNAL API
  */
-@InternalApi private[pekko] class ActorSubscriptionWithCursor[T](_impl: ActorRef, _subscriber: Subscriber[_ >: T])
+@InternalApi private[pekko] class ActorSubscriptionWithCursor[T](_impl: ActorRef, _subscriber: Subscriber[? >: T])
     extends ActorSubscription[T](_impl, _subscriber)
     with SubscriptionWithCursor[T]
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorRefBackpressureSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorRefBackpressureSource.scala
@@ -51,7 +51,7 @@ private object ActorRefBackpressureSource {
       with OutHandler
       with StageLogging
       with ActorRefStage {
-      override protected def logSource: Class[_] = classOf[ActorRefSource[_]]
+      override protected def logSource: Class[?] = classOf[ActorRefSource[?]]
 
       private var isCompleting: Boolean = false
       private var element: OptionVal[(ActorRef, T)] = OptionVal.none

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorRefSinkStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorRefSinkStage.scala
@@ -39,7 +39,7 @@ final private[pekko] class ActorRefSinkStage[T](
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with StageLogging {
 
-      override protected def logSource: Class[_] = classOf[ActorRefSinkStage[_]]
+      override protected def logSource: Class[?] = classOf[ActorRefSinkStage[?]]
 
       var completionSignalled = false
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorRefSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorRefSource.scala
@@ -50,7 +50,7 @@ private object ActorRefSource {
       with OutHandler
       with StageLogging
       with ActorRefStage {
-      override protected def logSource: Class[_] = classOf[ActorRefSource[_]]
+      override protected def logSource: Class[?] = classOf[ActorRefSource[?]]
 
       private val buffer: OptionVal[Buffer[T]] =
         if (maxBuffer != 0)

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/CompletedPublishers.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/CompletedPublishers.scala
@@ -22,7 +22,7 @@ import org.reactivestreams.{ Publisher, Subscriber, Subscription }
  */
 @InternalApi private[pekko] case object EmptyPublisher extends Publisher[Nothing] {
   import ReactiveStreamsCompliance._
-  override def subscribe(subscriber: Subscriber[_ >: Nothing]): Unit =
+  override def subscribe(subscriber: Subscriber[? >: Nothing]): Unit =
     try {
       requireNonNullSubscriber(subscriber)
       tryOnSubscribe(subscriber, CancelledSubscription)
@@ -41,7 +41,7 @@ import org.reactivestreams.{ Publisher, Subscriber, Subscription }
   ReactiveStreamsCompliance.requireNonNullElement(t)
 
   import ReactiveStreamsCompliance._
-  override def subscribe(subscriber: Subscriber[_ >: Nothing]): Unit =
+  override def subscribe(subscriber: Subscriber[? >: Nothing]): Unit =
     try {
       requireNonNullSubscriber(subscriber)
       tryOnSubscribe(subscriber, CancelledSubscription)
@@ -78,7 +78,7 @@ import org.reactivestreams.{ Publisher, Subscriber, Subscription }
  */
 @InternalApi private[pekko] case object RejectAdditionalSubscribers extends Publisher[Nothing] {
   import ReactiveStreamsCompliance._
-  override def subscribe(subscriber: Subscriber[_ >: Nothing]): Unit =
+  override def subscribe(subscriber: Subscriber[? >: Nothing]): Unit =
     try rejectAdditionalSubscriber(subscriber, "Publisher")
     catch {
       case _: SpecViolation => // nothing we can do

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanOut.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanOut.scala
@@ -336,7 +336,7 @@ import org.reactivestreams.Subscription
           outputBunch.enqueue(0, a)
           outputBunch.enqueue(1, b)
 
-        case t: pekko.japi.Pair[_, _] =>
+        case t: pekko.japi.Pair[?, ?] =>
           outputBunch.enqueue(0, t.first)
           outputBunch.enqueue(1, t.second)
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanoutProcessor.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanoutProcessor.scala
@@ -40,8 +40,8 @@ import org.reactivestreams.Subscriber
   private var _subscribed = false
   def subscribed: Boolean = _subscribed
 
-  override type S = ActorSubscriptionWithCursor[_ >: Any]
-  override def createSubscription(subscriber: Subscriber[_ >: Any]): S = {
+  override type S = ActorSubscriptionWithCursor[? >: Any]
+  override def createSubscription(subscriber: Subscriber[? >: Any]): S = {
     _subscribed = true
     new ActorSubscriptionWithCursor(self, subscriber)
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/PhasedFusingActorMaterializer.scala
@@ -922,7 +922,7 @@ private final case class SavedIslandData(
 
   override def takePublisher(slot: Int, publisher: Publisher[Any], attributes: Attributes): Unit = {
     subscriberOrVirtualPublisher match {
-      case v: VirtualPublisher[_]        => v.registerPublisher(publisher)
+      case v: VirtualPublisher[?]        => v.registerPublisher(publisher)
       case s: Subscriber[Any] @unchecked => publisher.subscribe(s)
       case _                             => throw new IllegalStateException() // won't happen, compiler exhaustiveness check pleaser
     }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/QueueSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/QueueSource.scala
@@ -55,7 +55,7 @@ import pekko.stream.stage._
     val name = inheritedAttributes.nameOrDefault(getClass.toString)
 
     val stageLogic = new GraphStageLogic(shape) with OutHandler with SourceQueueWithComplete[T] with StageLogging {
-      override protected def logSource: Class[_] = classOf[QueueSource[_]]
+      override protected def logSource: Class[?] = classOf[QueueSource[?]]
 
       var buffer: Buffer[T] = _
       var pendingOffers: Buffer[Offer[T]] = _

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
@@ -245,7 +245,7 @@ import org.reactivestreams.Subscriber
 /**
  * INTERNAL API
  */
-@InternalApi private[pekko] final class SeqStage[T, That](implicit cbf: Factory[T, That with immutable.Iterable[_]])
+@InternalApi private[pekko] final class SeqStage[T, That](implicit cbf: Factory[T, That with immutable.Iterable[?]])
     extends GraphStageWithMaterializedValue[SinkShape[T], Future[That]] {
   val in = Inlet[T]("seq.in")
 
@@ -345,7 +345,7 @@ import org.reactivestreams.Subscriber
         val e = buffer.dequeue()
         promise.complete(e)
         e match {
-          case Success(_: Some[_]) => // do nothing
+          case Success(_: Some[?]) => // do nothing
           case Success(None)       => completeStage()
           case Failure(t)          => failStage(t)
         }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/StreamSubscriptionTimeout.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/StreamSubscriptionTimeout.scala
@@ -93,17 +93,17 @@ import org.reactivestreams._
         cancellable
     }
 
-  private def cancel(target: Publisher[_], timeout: FiniteDuration): Unit = {
+  private def cancel(target: Publisher[?], timeout: FiniteDuration): Unit = {
     val millis = timeout.toMillis
     target match {
-      case p: Processor[_, _] =>
+      case p: Processor[?, ?] =>
         log.debug("Cancelling {} Processor's publisher and subscriber sides (after {} ms)", p, millis)
         handleSubscriptionTimeout(
           target,
           new SubscriptionTimeoutException(s"Publisher was not attached to upstream within deadline ($millis) ms")
             with NoStackTrace)
 
-      case p: Publisher[_] =>
+      case p: Publisher[?] =>
         log.debug("Cancelling {} (after: {} ms)", p, millis)
         handleSubscriptionTimeout(
           target,
@@ -113,7 +113,7 @@ import org.reactivestreams._
     }
   }
 
-  private def warn(target: Publisher[_], timeout: FiniteDuration): Unit = {
+  private def warn(target: Publisher[?], timeout: FiniteDuration): Unit = {
     log.warning(
       "Timed out {} detected (after {} ms)! You should investigate if you either cancel or consume all {} instances",
       target,
@@ -125,7 +125,7 @@ import org.reactivestreams._
    * Called by the actor when a subscription has timed out. Expects the actual `Publisher` or `Processor` target.
    */
   @nowarn("msg=deprecated")
-  protected def subscriptionTimedOut(target: Publisher[_]): Unit = subscriptionTimeoutSettings.mode match {
+  protected def subscriptionTimedOut(target: Publisher[?]): Unit = subscriptionTimeoutSettings.mode match {
     case NoopTermination   => // ignore...
     case WarnTermination   => warn(target, subscriptionTimeoutSettings.timeout)
     case CancelTermination => cancel(target, subscriptionTimeoutSettings.timeout)
@@ -134,7 +134,7 @@ import org.reactivestreams._
   /**
    * Callback that should ensure that the target is canceled with the given cause.
    */
-  protected def handleSubscriptionTimeout(target: Publisher[_], cause: Exception): Unit
+  protected def handleSubscriptionTimeout(target: Publisher[?], cause: Exception): Unit
 }
 
 /**

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/SubscriberManagement.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/SubscriberManagement.scala
@@ -49,7 +49,7 @@ private[pekko] object SubscriberManagement {
 private[pekko] trait SubscriptionWithCursor[T] extends Subscription with ResizableMultiReaderRingBuffer.Cursor {
   import ReactiveStreamsCompliance._
 
-  def subscriber: Subscriber[_ >: T]
+  def subscriber: Subscriber[? >: T]
 
   def dispatch(element: T): Unit = tryOnNext(subscriber, element)
 
@@ -91,7 +91,7 @@ private[pekko] trait SubscriberManagement[T] extends ResizableMultiReaderRingBuf
   /**
    * Use to register a subscriber
    */
-  protected def createSubscription(subscriber: Subscriber[_ >: T]): S
+  protected def createSubscription(subscriber: Subscriber[? >: T]): S
 
   private[this] val buffer = new ResizableMultiReaderRingBuffer[T](initialBufferSize, maxBufferSize, this)
 
@@ -232,7 +232,7 @@ private[pekko] trait SubscriberManagement[T] extends ResizableMultiReaderRingBuf
   /**
    * Register a new subscriber.
    */
-  protected def registerSubscriber(subscriber: Subscriber[_ >: T]): Unit = endOfStream match {
+  protected def registerSubscriber(subscriber: Subscriber[? >: T]): Unit = endOfStream match {
     case NotReached if subscriptions.exists(_.subscriber == subscriber) =>
       ReactiveStreamsCompliance.rejectDuplicateSubscriber(subscriber)
     case NotReached                   => addSubscription(subscriber)
@@ -240,7 +240,7 @@ private[pekko] trait SubscriberManagement[T] extends ResizableMultiReaderRingBuf
     case eos                          => eos(subscriber)
   }
 
-  private def addSubscription(subscriber: Subscriber[_ >: T]): Unit = {
+  private def addSubscription(subscriber: Subscriber[? >: T]): Unit = {
     import ReactiveStreamsCompliance._
     val newSubscription = createSubscription(subscriber)
     subscriptions ::= newSubscription

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/TraversalBuilder.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/TraversalBuilder.scala
@@ -353,7 +353,7 @@ import pekko.util.unused
    * Try to find `SingleSource` or wrapped such. This is used as a
    * performance optimization in FlattenMerge and possibly other places.
    */
-  def getSingleSource[A >: Null](graph: Graph[SourceShape[A], _]): OptionVal[SingleSource[A]] = {
+  def getSingleSource[A >: Null](graph: Graph[SourceShape[A], ?]): OptionVal[SingleSource[A]] = {
     graph match {
       case single: SingleSource[A] @unchecked => OptionVal.Some(single)
       case _ =>
@@ -362,7 +362,7 @@ import pekko.util.unused
             l.pendingBuilder match {
               case OptionVal.Some(a: AtomicTraversalBuilder) =>
                 a.module match {
-                  case m: GraphStageModule[_, _] =>
+                  case m: GraphStageModule[?, ?] =>
                     m.stage match {
                       case single: SingleSource[A] @unchecked =>
                         // It would be != EmptyTraversal if mapMaterializedValue was used and then we can't optimize.
@@ -383,9 +383,9 @@ import pekko.util.unused
   /**
    * Test if a Graph is an empty Source.
    */
-  def isEmptySource(graph: Graph[SourceShape[_], _]): Boolean = graph match {
-    case source: scaladsl.Source[_, _] if source eq scaladsl.Source.empty => true
-    case source: javadsl.Source[_, _] if source eq javadsl.Source.empty() => true
+  def isEmptySource(graph: Graph[SourceShape[?], ?]): Boolean = graph match {
+    case source: scaladsl.Source[?, ?] if source eq scaladsl.Source.empty => true
+    case source: javadsl.Source[?, ?] if source eq javadsl.Source.empty() => true
     case _                                                                => false
   }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -332,7 +332,7 @@ import org.reactivestreams.Subscription
 
     protected val wakeUpMsg: Any = SubscribePending(boundary)
 
-    override def subscribe(subscriber: Subscriber[_ >: Any]): Unit = {
+    override def subscribe(subscriber: Subscriber[? >: Any]): Unit = {
       requireNonNullSubscriber(subscriber)
       @tailrec def doSubscribe(): Unit = {
         val current = pendingSubscribers.get

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphStages.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphStages.scala
@@ -176,7 +176,7 @@ import pekko.stream.stage._
 
   private class FlowMonitorImpl[T] extends AtomicReference[Any](Initialized) with FlowMonitor[T] {
     override def state = get match {
-      case s: StreamState[_] => s.asInstanceOf[StreamState[T]]
+      case s: StreamState[?] => s.asInstanceOf[StreamState[T]]
       case msg               => Received(msg.asInstanceOf[T])
     }
   }
@@ -194,7 +194,7 @@ import pekko.stream.stage._
         def onPush(): Unit = {
           val msg = grab(in)
           push(out, msg)
-          monitor.set(if (msg.isInstanceOf[StreamState[_]]) Received(msg) else msg)
+          monitor.set(if (msg.isInstanceOf[StreamState[?]]) Received(msg) else msg)
         }
 
         override def onUpstreamFinish(): Unit = {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -945,7 +945,7 @@ private[stream] object Collect {
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
-      override protected def logSource: Class[_] = classOf[Buffer[_]]
+      override protected def logSource: Class[?] = classOf[Buffer[?]]
 
       private val buffer: BufferImpl[T] = BufferImpl(size, inheritedAttributes)
 
@@ -1469,7 +1469,7 @@ private[stream] object Collect {
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
-      override protected def logSource: Class[_] = classOf[Watch[_]]
+      override protected def logSource: Class[?] = classOf[Watch[?]]
 
       override def preStart(): Unit = {
         val self = getStageActor {
@@ -1589,7 +1589,7 @@ private[stream] object Collect {
   final val fromMaterializer = new LogSource[Materializer] {
 
     // do not expose private context classes (of OneBoundedInterpreter)
-    override def getClazz(t: Materializer): Class[_] = classOf[Materializer]
+    override def getClazz(t: Materializer): Class[?] = classOf[Materializer]
 
     override def genString(t: Materializer): String = {
       try s"$DefaultLoggerName(${t.supervisor.path})"
@@ -1709,7 +1709,7 @@ private[stream] object Collect {
   final val fromMaterializer = new LogSource[Materializer] {
 
     // do not expose private context classes (of OneBoundedInterpreter)
-    override def getClazz(t: Materializer): Class[_] = classOf[Materializer]
+    override def getClazz(t: Materializer): Class[?] = classOf[Materializer]
 
     override def genString(t: Materializer): String = {
       try s"$DefaultLoggerName(${t.supervisor.path})"

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
@@ -134,7 +134,7 @@ import pekko.util.ccompat.JavaConverters._
         src match {
           case sub: SubSinkInlet[T] @unchecked =>
             sources -= sub
-          case _: SingleSource[_] =>
+          case _: SingleSource[?] =>
             pendingSingleSources -= 1
           case other => throw new IllegalArgumentException(s"Unexpected source type: '${other.getClass}'")
         }
@@ -735,7 +735,7 @@ import pekko.util.ccompat.JavaConverters._
   override def createLogic(attr: Attributes) = new GraphStageLogic(shape) with InHandler {
     // check for previous materialization eagerly so we fail with a more useful stacktrace
     private[this] val materializationException: OptionVal[IllegalStateException] =
-      if (status.get.isInstanceOf[AsyncCallback[_]])
+      if (status.get.isInstanceOf[AsyncCallback[?]])
         OptionVal.Some(createMaterializedTwiceException())
       else
         OptionVal.None
@@ -830,7 +830,7 @@ import pekko.util.ccompat.JavaConverters._
   override def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with OutHandler {
     // check for previous materialization eagerly so we fail with a more useful stacktrace
     private[this] val materializationException: OptionVal[IllegalStateException] =
-      if (status.get.isInstanceOf[AsyncCallback[_]])
+      if (status.get.isInstanceOf[AsyncCallback[?]])
         OptionVal.Some(createMaterializedTwiceException())
       else
         OptionVal.None
@@ -842,7 +842,7 @@ import pekko.util.ccompat.JavaConverters._
         case null                               => if (!status.compareAndSet(null, cb)) setCB(cb)
         case ActorSubscriberMessage.OnComplete  => completeStage()
         case ActorSubscriberMessage.OnError(ex) => failStage(ex)
-        case _: AsyncCallback[_] =>
+        case _: AsyncCallback[?] =>
           failStage(materializationException.getOrElse(createMaterializedTwiceException()))
         case _ => throw new RuntimeException() // won't happen, compiler exhaustiveness check pleaser
       }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/InputStreamSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/InputStreamSource.scala
@@ -56,7 +56,7 @@ private[pekko] final class InputStreamSource(factory: () => InputStream, chunkSi
       private var inputStream: InputStream = _
       private def isClosed = mat.isCompleted
 
-      override protected def logSource: Class[_] = classOf[InputStreamSource]
+      override protected def logSource: Class[?] = classOf[InputStreamSource]
 
       override def preStart(): Unit = {
         try {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/OutputStreamGraphStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/OutputStreamGraphStage.scala
@@ -44,7 +44,7 @@ private[pekko] final class OutputStreamGraphStage(factory: () => OutputStream, a
       var outputStream: OutputStream = _
       var bytesWritten: Long = 0L
 
-      override protected def logSource: Class[_] = classOf[OutputStreamGraphStage]
+      override protected def logSource: Class[?] = classOf[OutputStreamGraphStage]
 
       override def preStart(): Unit = {
         try {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SinkRefImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SinkRefImpl.scala
@@ -69,7 +69,7 @@ private[stream] final class SinkRefStageImpl[In] private[pekko] (val initialPart
       eagerMaterializer: Materializer): (GraphStageLogic, SourceRef[In]) = {
 
     val logic = new TimerGraphStageLogic(shape) with StageLogging with ActorRefStage with InHandler {
-      override protected def logSource: Class[_] = classOf[SinkRefStageImpl[_]]
+      override protected def logSource: Class[?] = classOf[SinkRefStageImpl[?]]
 
       private[this] val streamRefsMaster = StreamRefsMaster(eagerMaterializer.system)
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SourceRefImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SourceRefImpl.scala
@@ -128,7 +128,7 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
       eagerMaterializer: Materializer): (GraphStageLogic, SinkRef[Out]) = {
 
     val logic = new TimerGraphStageLogic(shape) with StageLogging with ActorRefStage with OutHandler {
-      override protected def logSource: Class[_] = classOf[SourceRefStageImpl[_]]
+      override protected def logSource: Class[?] = classOf[SourceRefStageImpl[?]]
 
       private[this] val streamRefsMaster = StreamRefsMaster(eagerMaterializer.system)
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -124,7 +124,7 @@ object Flow {
    *
    * See also [[fromSinkAndSourceMat]] when access to materialized values of the parameters is needed.
    */
-  def fromSinkAndSource[I, O](sink: Graph[SinkShape[I], _], source: Graph[SourceShape[O], _]): Flow[I, O, NotUsed] =
+  def fromSinkAndSource[I, O](sink: Graph[SinkShape[I], ?], source: Graph[SourceShape[O], ?]): Flow[I, O, NotUsed] =
     new Flow(scaladsl.Flow.fromSinkAndSourceMat(sink, source)(scaladsl.Keep.none))
 
   /**
@@ -219,8 +219,8 @@ object Flow {
    * See also [[fromSinkAndSourceCoupledMat]] when access to materialized values of the parameters is needed.
    */
   def fromSinkAndSourceCoupled[I, O](
-      sink: Graph[SinkShape[I], _],
-      source: Graph[SourceShape[O], _]): Flow[I, O, NotUsed] =
+      sink: Graph[SinkShape[I], ?],
+      source: Graph[SourceShape[O], ?]): Flow[I, O, NotUsed] =
     new Flow(scaladsl.Flow.fromSinkAndSourceCoupled(sink, source))
 
   /**
@@ -507,7 +507,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * See also [[toMat]] when access to materialized values of the parameter is needed.
    */
-  def to(sink: Graph[SinkShape[Out], _]): javadsl.Sink[In, Mat] =
+  def to(sink: Graph[SinkShape[Out], ?]): javadsl.Sink[In, Mat] =
     new Sink(delegate.to(sink))
 
   /**
@@ -1822,7 +1822,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def recover(clazz: Class[_ <: Throwable], supplier: Supplier[Out]): javadsl.Flow[In, Out, Mat] =
+  def recover(clazz: Class[? <: Throwable], supplier: Supplier[Out]): javadsl.Flow[In, Out, Mat] =
     recover {
       case elem if clazz.isInstance(elem) => supplier.get()
     }
@@ -1890,7 +1890,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def recoverWith(pf: PartialFunction[Throwable, _ <: Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
+  def recoverWith(pf: PartialFunction[Throwable, ? <: Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.recoverWith(pf))
 
   /**
@@ -1916,7 +1916,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    */
   @deprecated("Use recoverWithRetries instead.", "Akka 2.6.6")
   def recoverWith(
-      clazz: Class[_ <: Throwable],
+      clazz: Class[? <: Throwable],
       supplier: Supplier[Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
     recoverWith({
       case elem if clazz.isInstance(elem) => supplier.get()
@@ -1980,7 +1980,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    */
   def recoverWithRetries(
       attempts: Int,
-      clazz: Class[_ <: Throwable],
+      clazz: Class[? <: Throwable],
       supplier: Supplier[Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
     recoverWithRetries(attempts,
       {
@@ -2019,7 +2019,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    *  @since 1.1.0
    */
-  def onErrorComplete(clazz: Class[_ <: Throwable]): javadsl.Flow[In, Out, Mat] =
+  def onErrorComplete(clazz: Class[? <: Throwable]): javadsl.Flow[In, Out, Mat] =
     onErrorComplete(ex => clazz.isInstance(ex))
 
   /**
@@ -2037,7 +2037,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    *  @since 1.1.0
    */
-  def onErrorComplete(predicate: java.util.function.Predicate[_ >: Throwable]): javadsl.Flow[In, Out, Mat] =
+  def onErrorComplete(predicate: java.util.function.Predicate[? >: Throwable]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.onErrorComplete {
       case ex: Throwable if predicate.test(ex) => true
     })
@@ -2629,7 +2629,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def flatMapConcat[T, M](f: function.Function[Out, _ <: Graph[SourceShape[T], M]]): Flow[In, T, Mat] =
+  def flatMapConcat[T, M](f: function.Function[Out, ? <: Graph[SourceShape[T], M]]): Flow[In, T, Mat] =
     new Flow(delegate.flatMapConcat[T, M](x => f(x)))
 
   /**
@@ -2645,7 +2645,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def flatMapMerge[T, M](breadth: Int, f: function.Function[Out, _ <: Graph[SourceShape[T], M]]): Flow[In, T, Mat] =
+  def flatMapMerge[T, M](breadth: Int, f: function.Function[Out, ? <: Graph[SourceShape[T], M]]): Flow[In, T, Mat] =
     new Flow(delegate.flatMapMerge(breadth, o => f(o)))
 
   /**
@@ -2723,7 +2723,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    */
   @varargs
   @SafeVarargs
-  def concatAllLazy(those: Graph[SourceShape[Out], _]*): javadsl.Flow[In, Out, Mat] =
+  def concatAllLazy(those: Graph[SourceShape[Out], ?]*): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.concatAllLazy(those: _*))
 
   /**
@@ -2913,7 +2913,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream or Sink cancels
    */
-  def alsoTo(that: Graph[SinkShape[Out], _]): javadsl.Flow[In, Out, Mat] =
+  def alsoTo(that: Graph[SinkShape[Out], ?]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.alsoTo(that))
 
   /**
@@ -2932,7 +2932,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    */
   @varargs
   @SafeVarargs
-  def alsoToAll(those: Graph[SinkShape[Out], _]*): javadsl.Flow[In, Out, Mat] =
+  def alsoToAll(those: Graph[SinkShape[Out], ?]*): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.alsoToAll(those: _*))
 
   /**
@@ -2963,7 +2963,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' any of the downstreams cancel
    */
-  def divertTo(that: Graph[SinkShape[Out], _], when: function.Predicate[Out]): javadsl.Flow[In, Out, Mat] =
+  def divertTo(that: Graph[SinkShape[Out], ?], when: function.Predicate[Out]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.divertTo(that, when.test))
 
   /**
@@ -2997,7 +2997,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def wireTap(that: Graph[SinkShape[Out], _]): javadsl.Flow[In, Out, Mat] =
+  def wireTap(that: Graph[SinkShape[Out], ?]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.wireTap(that))
 
   /**
@@ -3042,7 +3042,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def interleave(that: Graph[SourceShape[Out], _], segmentSize: Int): javadsl.Flow[In, Out, Mat] =
+  def interleave(that: Graph[SourceShape[Out], ?], segmentSize: Int): javadsl.Flow[In, Out, Mat] =
     interleave(that, segmentSize, eagerClose = false)
 
   /**
@@ -3065,7 +3065,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def interleave(that: Graph[SourceShape[Out], _], segmentSize: Int, eagerClose: Boolean): javadsl.Flow[In, Out, Mat] =
+  def interleave(that: Graph[SourceShape[Out], ?], segmentSize: Int, eagerClose: Boolean): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.interleave(that, segmentSize, eagerClose))
 
   /**
@@ -3132,11 +3132,11 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    */
   def interleaveAll(
-      those: java.util.List[_ <: Graph[SourceShape[Out], _ <: Any]],
+      those: java.util.List[? <: Graph[SourceShape[Out], ? <: Any]],
       segmentSize: Int,
       eagerClose: Boolean): javadsl.Flow[In, Out, Mat] = {
     val seq = if (those != null) Util.immutableSeq(those).collect {
-      case source: Source[Out @unchecked, _] => source.asScala
+      case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
     else immutable.Seq()
@@ -3155,7 +3155,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def merge(that: Graph[SourceShape[Out], _]): javadsl.Flow[In, Out, Mat] =
+  def merge(that: Graph[SourceShape[Out], ?]): javadsl.Flow[In, Out, Mat] =
     merge(that, eagerComplete = false)
 
   /**
@@ -3170,7 +3170,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def merge(that: Graph[SourceShape[Out], _], eagerComplete: Boolean): javadsl.Flow[In, Out, Mat] =
+  def merge(that: Graph[SourceShape[Out], ?], eagerComplete: Boolean): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.merge(that, eagerComplete))
 
   /**
@@ -3215,10 +3215,10 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    */
   def mergeAll(
-      those: java.util.List[_ <: Graph[SourceShape[Out], _ <: Any]],
+      those: java.util.List[? <: Graph[SourceShape[Out], ? <: Any]],
       eagerComplete: Boolean): javadsl.Flow[In, Out, Mat] = {
     val seq = if (those != null) Util.immutableSeq(those).collect {
-      case source: Source[Out @unchecked, _] => source.asScala
+      case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
     else immutable.Seq()
@@ -3236,7 +3236,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Completes when''' all upstreams complete (eagerClose=false) or one upstream completes (eagerClose=true)
    */
   def mergeLatest(
-      that: Graph[SourceShape[Out], _],
+      that: Graph[SourceShape[Out], ?],
       eagerComplete: Boolean): javadsl.Flow[In, java.util.List[Out], Mat] =
     new Flow(delegate.mergeLatest(that, eagerComplete).map(_.asJava))
 
@@ -3265,7 +3265,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''completes''' when all upstreams complete (This behavior is changeable to completing when any upstream completes by setting `eagerComplete=true`.)
    */
   def mergePreferred(
-      that: Graph[SourceShape[Out], _],
+      that: Graph[SourceShape[Out], ?],
       preferred: Boolean,
       eagerComplete: Boolean): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.mergePreferred(that, preferred, eagerComplete))
@@ -3293,7 +3293,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''completes''' when both upstreams complete (This behavior is changeable to completing when any upstream completes by setting `eagerComplete=true`.)
    */
   def mergePrioritized(
-      that: Graph[SourceShape[Out], _],
+      that: Graph[SourceShape[Out], ?],
       leftPriority: Int,
       rightPriority: Int,
       eagerComplete: Boolean): javadsl.Flow[In, Out, Mat] =
@@ -3360,7 +3360,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def zip[T](source: Graph[SourceShape[T], _]): javadsl.Flow[In, Out Pair T, Mat] =
+  def zip[T](source: Graph[SourceShape[T], ?]): javadsl.Flow[In, Out Pair T, Mat] =
     zipMat(source, Keep.left)
 
   /**
@@ -3397,7 +3397,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): Flow[In, Pair[A, U], Mat] =
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], ?], thisElem: A, thatElem: U): Flow[In, Pair[A, U], Mat] =
     new Flow(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
 
   /**
@@ -3433,7 +3433,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipLatest[T](source: Graph[SourceShape[T], _]): javadsl.Flow[In, Out Pair T, Mat] =
+  def zipLatest[T](source: Graph[SourceShape[T], ?]): javadsl.Flow[In, Out Pair T, Mat] =
     zipLatestMat(source, Keep.left)
 
   /**
@@ -3472,7 +3472,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    */
   def zipWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       combine: function.Function2[Out, Out2, Out3]): javadsl.Flow[In, Out3, Mat] =
     new Flow(delegate.zipWith[Out2, Out3](that)(combinerToScala(combine)))
 
@@ -3509,7 +3509,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *   '''Cancels when''' downstream cancels
    */
   def zipLatestWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       combine: function.Function2[Out, Out2, Out3]): javadsl.Flow[In, Out3, Mat] =
     new Flow(delegate.zipLatestWith[Out2, Out3](that)(combinerToScala(combine)))
 
@@ -3531,7 +3531,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *   '''Cancels when''' downstream cancels
    */
   def zipLatestWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       eagerComplete: Boolean,
       combine: function.Function2[Out, Out2, Out3]): javadsl.Flow[In, Out3, Mat] =
     new Flow(delegate.zipLatestWith[Out2, Out3](that, eagerComplete)(combinerToScala(combine)))

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
@@ -238,7 +238,7 @@ final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
    * @see [[pekko.stream.javadsl.Flow.mapConcat]]
    */
   def mapConcat[Out2](
-      f: function.Function[Out, _ <: java.lang.Iterable[Out2]]): FlowWithContext[In, CtxIn, Out2, CtxOut, Mat] =
+      f: function.Function[Out, ? <: java.lang.Iterable[Out2]]): FlowWithContext[In, CtxIn, Out2, CtxOut, Mat] =
     viaScala(_.mapConcat(elem => Util.immutableSeq(f.apply(elem))))
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Graph.scala
@@ -648,7 +648,7 @@ object GraphDSL extends GraphCreate {
      * materialized value and returning the copied Ports that are now to be
      * connected.
      */
-    def add[S <: Shape](graph: Graph[S, _]): S = delegate.add(graph)
+    def add[S <: Shape](graph: Graph[S, ?]): S = delegate.add(graph)
 
     /**
      * Returns an [[Outlet]] that gives access to the materialized value of this graph. Once the graph is materialized
@@ -679,24 +679,24 @@ object GraphDSL extends GraphCreate {
     def to[I, O](j: UniformFanOutShape[I, O]): ReverseOps[I] = new ReverseOps(j.in)
 
     final class ForwardOps[T](_out: Outlet[T]) {
-      def toInlet(in: Inlet[_ >: T]): Builder[Mat] = { _out ~> in; self }
-      def to(dst: SinkShape[_ >: T]): Builder[Mat] = { _out ~> dst; self }
-      def toFanIn[U](j: UniformFanInShape[_ >: T, U]): Builder[Mat] = { _out ~> j; self }
-      def toFanOut[U](j: UniformFanOutShape[_ >: T, U]): Builder[Mat] = { _out ~> j; self }
-      def via[U](f: FlowShape[_ >: T, U]): ForwardOps[U] = from((_out ~> f).outlet)
-      def viaFanIn[U](j: UniformFanInShape[_ >: T, U]): ForwardOps[U] = from((_out ~> j).outlet)
-      def viaFanOut[U](j: UniformFanOutShape[_ >: T, U]): ForwardOps[U] = from((_out ~> j).outlet)
+      def toInlet(in: Inlet[? >: T]): Builder[Mat] = { _out ~> in; self }
+      def to(dst: SinkShape[? >: T]): Builder[Mat] = { _out ~> dst; self }
+      def toFanIn[U](j: UniformFanInShape[? >: T, U]): Builder[Mat] = { _out ~> j; self }
+      def toFanOut[U](j: UniformFanOutShape[? >: T, U]): Builder[Mat] = { _out ~> j; self }
+      def via[U](f: FlowShape[? >: T, U]): ForwardOps[U] = from((_out ~> f).outlet)
+      def viaFanIn[U](j: UniformFanInShape[? >: T, U]): ForwardOps[U] = from((_out ~> j).outlet)
+      def viaFanOut[U](j: UniformFanOutShape[? >: T, U]): ForwardOps[U] = from((_out ~> j).outlet)
       def out(): Outlet[T] = _out
     }
 
     final class ReverseOps[T](out: Inlet[T]) {
-      def fromOutlet(dst: Outlet[_ <: T]): Builder[Mat] = { out <~ dst; self }
-      def from(dst: SourceShape[_ <: T]): Builder[Mat] = { out <~ dst; self }
-      def fromFanIn[U](j: UniformFanInShape[U, _ <: T]): Builder[Mat] = { out <~ j; self }
-      def fromFanOut[U](j: UniformFanOutShape[U, _ <: T]): Builder[Mat] = { out <~ j; self }
-      def via[U](f: FlowShape[U, _ <: T]): ReverseOps[U] = to((out <~ f).inlet)
-      def viaFanIn[U](j: UniformFanInShape[U, _ <: T]): ReverseOps[U] = to((out <~ j).inlet)
-      def viaFanOut[U](j: UniformFanOutShape[U, _ <: T]): ReverseOps[U] = to((out <~ j).inlet)
+      def fromOutlet(dst: Outlet[? <: T]): Builder[Mat] = { out <~ dst; self }
+      def from(dst: SourceShape[? <: T]): Builder[Mat] = { out <~ dst; self }
+      def fromFanIn[U](j: UniformFanInShape[U, ? <: T]): Builder[Mat] = { out <~ j; self }
+      def fromFanOut[U](j: UniformFanOutShape[U, ? <: T]): Builder[Mat] = { out <~ j; self }
+      def via[U](f: FlowShape[U, ? <: T]): ReverseOps[U] = to((out <~ f).inlet)
+      def viaFanIn[U](j: UniformFanInShape[U, ? <: T]): ReverseOps[U] = to((out <~ j).inlet)
+      def viaFanOut[U](j: UniformFanOutShape[U, ? <: T]): ReverseOps[U] = to((out <~ j).inlet)
     }
   }
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/RestartFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/RestartFlow.scala
@@ -57,7 +57,7 @@ object RestartFlow {
       minBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       randomFactor: Double,
-      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+      flowFactory: Creator[Flow[In, Out, ?]]): Flow[In, Out, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor)
     withBackoff(settings, flowFactory)
   }
@@ -91,7 +91,7 @@ object RestartFlow {
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
       randomFactor: Double,
-      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+      flowFactory: Creator[Flow[In, Out, ?]]): Flow[In, Out, NotUsed] = {
     val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor)
     withBackoff(settings, flowFactory)
   }
@@ -127,7 +127,7 @@ object RestartFlow {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int,
-      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+      flowFactory: Creator[Flow[In, Out, ?]]): Flow[In, Out, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, flowFactory)
   }
@@ -164,7 +164,7 @@ object RestartFlow {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
-      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+      flowFactory: Creator[Flow[In, Out, ?]]): Flow[In, Out, NotUsed] = {
     val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, flowFactory)
   }
@@ -187,7 +187,7 @@ object RestartFlow {
    * @param settings [[RestartSettings]] defining restart configuration
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  def withBackoff[In, Out](settings: RestartSettings, flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] =
+  def withBackoff[In, Out](settings: RestartSettings, flowFactory: Creator[Flow[In, Out, ?]]): Flow[In, Out, NotUsed] =
     pekko.stream.scaladsl.RestartFlow
       .withBackoff(settings) { () =>
         flowFactory.create().asScala
@@ -225,7 +225,7 @@ object RestartFlow {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int,
-      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+      flowFactory: Creator[Flow[In, Out, ?]]): Flow[In, Out, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings, flowFactory)
   }
@@ -262,7 +262,7 @@ object RestartFlow {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
-      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+      flowFactory: Creator[Flow[In, Out, ?]]): Flow[In, Out, NotUsed] = {
     val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings, flowFactory)
   }
@@ -287,7 +287,7 @@ object RestartFlow {
    */
   def onFailuresWithBackoff[In, Out](
       settings: RestartSettings,
-      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] =
+      flowFactory: Creator[Flow[In, Out, ?]]): Flow[In, Out, NotUsed] =
     pekko.stream.scaladsl.RestartFlow
       .onFailuresWithBackoff(settings) { () =>
         flowFactory.create().asScala

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/RestartSink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/RestartSink.scala
@@ -58,7 +58,7 @@ object RestartSink {
       minBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       randomFactor: Double,
-      sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
+      sinkFactory: Creator[Sink[T, ?]]): Sink[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor)
     withBackoff(settings, sinkFactory)
   }
@@ -93,7 +93,7 @@ object RestartSink {
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
       randomFactor: Double,
-      sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
+      sinkFactory: Creator[Sink[T, ?]]): Sink[T, NotUsed] = {
     val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor)
     withBackoff(settings, sinkFactory)
   }
@@ -130,7 +130,7 @@ object RestartSink {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int,
-      sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
+      sinkFactory: Creator[Sink[T, ?]]): Sink[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, sinkFactory)
   }
@@ -168,7 +168,7 @@ object RestartSink {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
-      sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
+      sinkFactory: Creator[Sink[T, ?]]): Sink[T, NotUsed] = {
     val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, sinkFactory)
   }
@@ -192,7 +192,7 @@ object RestartSink {
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
-  def withBackoff[T](settings: RestartSettings, sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] =
+  def withBackoff[T](settings: RestartSettings, sinkFactory: Creator[Sink[T, ?]]): Sink[T, NotUsed] =
     pekko.stream.scaladsl.RestartSink
       .withBackoff(settings) { () =>
         sinkFactory.create().asScala

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/RestartSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/RestartSource.scala
@@ -54,7 +54,7 @@ object RestartSource {
       minBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       randomFactor: Double,
-      sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+      sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor)
     withBackoff(settings, sourceFactory)
   }
@@ -85,7 +85,7 @@ object RestartSource {
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
       randomFactor: Double,
-      sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+      sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] = {
     val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor)
     withBackoff(settings, sourceFactory)
   }
@@ -119,7 +119,7 @@ object RestartSource {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int,
-      sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+      sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, sourceFactory)
   }
@@ -154,7 +154,7 @@ object RestartSource {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
-      sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+      sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] = {
     val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, sourceFactory)
   }
@@ -175,7 +175,7 @@ object RestartSource {
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  def withBackoff[T](settings: RestartSettings, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] =
+  def withBackoff[T](settings: RestartSettings, sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] =
     pekko.stream.scaladsl.RestartSource
       .withBackoff(settings) { () =>
         sourceFactory.create().asScala
@@ -206,7 +206,7 @@ object RestartSource {
       minBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       randomFactor: Double,
-      sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+      sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor)
     onFailuresWithBackoff(settings, sourceFactory)
   }
@@ -236,7 +236,7 @@ object RestartSource {
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
       randomFactor: Double,
-      sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+      sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] = {
     val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor)
     onFailuresWithBackoff(settings, sourceFactory)
   }
@@ -268,7 +268,7 @@ object RestartSource {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int,
-      sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+      sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings, sourceFactory)
   }
@@ -301,7 +301,7 @@ object RestartSource {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
-      sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
+      sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] = {
     val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings, sourceFactory)
   }
@@ -320,7 +320,7 @@ object RestartSource {
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  def onFailuresWithBackoff[T](settings: RestartSettings, sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] =
+  def onFailuresWithBackoff[T](settings: RestartSettings, sourceFactory: Creator[Source[T, ?]]): Source[T, NotUsed] =
     pekko.stream.scaladsl.RestartSource
       .onFailuresWithBackoff(settings) { () =>
         sourceFactory.create().asScala

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
@@ -76,7 +76,7 @@ object Sink {
    * result container, optionally transformed into a final representation after all input elements have been processed.
    * The ``Collector`` can also do reduction at the end. Reduction processing is performed sequentially.
    */
-  def collect[U, In](collector: Collector[In, _ <: Any, U]): Sink[In, CompletionStage[U]] =
+  def collect[U, In](collector: Collector[In, ? <: Any, U]): Sink[In, CompletionStage[U]] =
     StreamConverters.javaCollector(() => collector)
 
   /**
@@ -370,9 +370,9 @@ object Sink {
    * Combine several sinks with fan-out strategy like `Broadcast` or `Balance` and returns `Sink`.
    */
   def combine[T, U](
-      output1: Sink[U, _],
-      output2: Sink[U, _],
-      rest: java.util.List[Sink[U, _]],
+      output1: Sink[U, ?],
+      output2: Sink[U, ?],
+      rest: java.util.List[Sink[U, ?]],
       @nowarn
       @deprecatedName(Symbol("strategy"))
       fanOutStrategy: function.Function[java.lang.Integer, Graph[UniformFanOutShape[T, U], NotUsed]])
@@ -401,7 +401,7 @@ object Sink {
    * @since 1.1.0
    */
   def combine[T, U, M](
-      sinks: java.util.List[_ <: Graph[SinkShape[U], M]],
+      sinks: java.util.List[? <: Graph[SinkShape[U], M]],
       fanOutStrategy: function.Function[java.lang.Integer, Graph[UniformFanOutShape[T, U], NotUsed]])
       : Sink[T, java.util.List[M]] = {
     val seq = if (sinks != null) Util.immutableSeq(sinks).collect {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -213,7 +213,7 @@ object Source {
    * stream completes the materialized [[Future]] will be failed with a [[StreamDetachedException]].
    */
   @deprecated("Use 'Source.futureSource' (potentially together with `Source.fromGraph`) instead", "Akka 2.6.0")
-  def fromFutureSource[T, M](future: Future[_ <: Graph[SourceShape[T], M]]): javadsl.Source[T, Future[M]] =
+  def fromFutureSource[T, M](future: Future[? <: Graph[SourceShape[T], M]]): javadsl.Source[T, Future[M]] =
     new Source(scaladsl.Source.fromFutureSource(future))
 
   /**
@@ -224,7 +224,7 @@ object Source {
    */
   @deprecated("Use 'Source.completionStageSource' (potentially together with `Source.fromGraph`) instead", "Akka 2.6.0")
   def fromSourceCompletionStage[T, M](
-      completion: CompletionStage[_ <: Graph[SourceShape[T], M]]): javadsl.Source[T, CompletionStage[M]] =
+      completion: CompletionStage[? <: Graph[SourceShape[T], M]]): javadsl.Source[T, CompletionStage[M]] =
     completionStageSource(completion.thenApply(fromGraph[T, M]))
 
   /**
@@ -653,12 +653,12 @@ object Source {
    * Combines several sources with fan-in strategy like [[Merge]] or [[Concat]] into a single [[Source]].
    */
   def combine[T, U](
-      first: Source[T, _ <: Any],
-      second: Source[T, _ <: Any],
-      rest: java.util.List[Source[T, _ <: Any]],
+      first: Source[T, ? <: Any],
+      second: Source[T, ? <: Any],
+      rest: java.util.List[Source[T, ? <: Any]],
       @nowarn
       @deprecatedName(Symbol("strategy"))
-      fanInStrategy: function.Function[java.lang.Integer, _ <: Graph[UniformFanInShape[T, U], NotUsed]])
+      fanInStrategy: function.Function[java.lang.Integer, ? <: Graph[UniformFanInShape[T, U], NotUsed]])
       : Source[U, NotUsed] = {
     val seq = if (rest != null) Util.immutableSeq(rest).map(_.asScala) else immutable.Seq()
     new Source(scaladsl.Source.combine(first.asScala, second.asScala, seq: _*)(num => fanInStrategy.apply(num)))
@@ -672,7 +672,7 @@ object Source {
       second: Source[T, M2],
       @nowarn
       @deprecatedName(Symbol("strategy"))
-      fanInStrategy: function.Function[java.lang.Integer, _ <: Graph[UniformFanInShape[T, U], NotUsed]],
+      fanInStrategy: function.Function[java.lang.Integer, ? <: Graph[UniformFanInShape[T, U], NotUsed]],
       combine: function.Function2[M1, M2, M]): Source[U, M] = {
     new Source(
       scaladsl.Source.combineMat(first.asScala, second.asScala)(num => fanInStrategy.apply(num))(
@@ -684,7 +684,7 @@ object Source {
    * @since 1.1.0
    */
   def combine[T, U, M](
-      sources: java.util.List[_ <: Graph[SourceShape[T], M]],
+      sources: java.util.List[? <: Graph[SourceShape[T], M]],
       fanInStrategy: function.Function[java.lang.Integer, Graph[UniformFanInShape[T, U], NotUsed]])
       : Source[U, java.util.List[M]] = {
     val seq = if (sources != null) Util.immutableSeq(sources).collect {
@@ -699,7 +699,7 @@ object Source {
   /**
    * Combine the elements of multiple streams into a stream of lists.
    */
-  def zipN[T](sources: java.util.List[Source[T, _ <: Any]]): Source[java.util.List[T], NotUsed] = {
+  def zipN[T](sources: java.util.List[Source[T, ? <: Any]]): Source[java.util.List[T], NotUsed] = {
     val seq = if (sources != null) Util.immutableSeq(sources).map(_.asScala) else immutable.Seq()
     new Source(scaladsl.Source.zipN(seq).map(_.asJava))
   }
@@ -709,7 +709,7 @@ object Source {
    */
   def zipWithN[T, O](
       zipper: function.Function[java.util.List[T], O],
-      sources: java.util.List[Source[T, _ <: Any]]): Source[O, NotUsed] = {
+      sources: java.util.List[Source[T, ? <: Any]]): Source[O, NotUsed] = {
     val seq = if (sources != null) Util.immutableSeq(sources).map(_.asScala) else immutable.Seq()
     new Source(scaladsl.Source.zipWithN[T, O](seq => zipper.apply(seq.asJava))(seq))
   }
@@ -918,7 +918,7 @@ object Source {
    * '''Cancels when''' downstream cancels
    */
   def mergePrioritizedN[T](
-      sourcesAndPriorities: java.util.List[Pair[Source[T, _ <: Any], java.lang.Integer]],
+      sourcesAndPriorities: java.util.List[Pair[Source[T, ? <: Any], java.lang.Integer]],
       eagerComplete: Boolean): javadsl.Source[T, NotUsed] = {
     val seq =
       if (sourcesAndPriorities != null)
@@ -1274,7 +1274,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    */
   @varargs
   @SafeVarargs
-  def concatAllLazy(those: Graph[SourceShape[Out], _]*): javadsl.Source[Out, Mat] =
+  def concatAllLazy(those: Graph[SourceShape[Out], ?]*): javadsl.Source[Out, Mat] =
     new Source(delegate.concatAllLazy(those: _*))
 
   /**
@@ -1464,7 +1464,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream or Sink cancels
    */
-  def alsoTo(that: Graph[SinkShape[Out], _]): javadsl.Source[Out, Mat] =
+  def alsoTo(that: Graph[SinkShape[Out], ?]): javadsl.Source[Out, Mat] =
     new Source(delegate.alsoTo(that))
 
   /**
@@ -1483,7 +1483,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    */
   @varargs
   @SafeVarargs
-  def alsoToAll(those: Graph[SinkShape[Out], _]*): javadsl.Source[Out, Mat] =
+  def alsoToAll(those: Graph[SinkShape[Out], ?]*): javadsl.Source[Out, Mat] =
     new Source(delegate.alsoToAll(those: _*))
 
   /**
@@ -1514,7 +1514,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' any of the downstreams cancel
    */
-  def divertTo(that: Graph[SinkShape[Out], _], when: function.Predicate[Out]): javadsl.Source[Out, Mat] =
+  def divertTo(that: Graph[SinkShape[Out], ?], when: function.Predicate[Out]): javadsl.Source[Out, Mat] =
     new Source(delegate.divertTo(that, when.test))
 
   /**
@@ -1548,7 +1548,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def wireTap(that: Graph[SinkShape[Out], _]): javadsl.Source[Out, Mat] =
+  def wireTap(that: Graph[SinkShape[Out], ?]): javadsl.Source[Out, Mat] =
     new Source(delegate.wireTap(that))
 
   /**
@@ -1592,7 +1592,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def interleave(that: Graph[SourceShape[Out], _], segmentSize: Int): javadsl.Source[Out, Mat] =
+  def interleave(that: Graph[SourceShape[Out], ?], segmentSize: Int): javadsl.Source[Out, Mat] =
     new Source(delegate.interleave(that, segmentSize))
 
   /**
@@ -1615,7 +1615,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def interleave(that: Graph[SourceShape[Out], _], segmentSize: Int, eagerClose: Boolean): javadsl.Source[Out, Mat] =
+  def interleave(that: Graph[SourceShape[Out], ?], segmentSize: Int, eagerClose: Boolean): javadsl.Source[Out, Mat] =
     new Source(delegate.interleave(that, segmentSize, eagerClose))
 
   /**
@@ -1682,11 +1682,11 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * '''Cancels when''' downstream cancels
    */
   def interleaveAll(
-      those: java.util.List[_ <: Graph[SourceShape[Out], _ <: Any]],
+      those: java.util.List[? <: Graph[SourceShape[Out], ? <: Any]],
       segmentSize: Int,
       eagerClose: Boolean): javadsl.Source[Out, Mat] = {
     val seq = if (those != null) Util.immutableSeq(those).collect {
-      case source: Source[Out @unchecked, _] => source.asScala
+      case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
     else immutable.Seq()
@@ -1705,7 +1705,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def merge(that: Graph[SourceShape[Out], _]): javadsl.Source[Out, Mat] =
+  def merge(that: Graph[SourceShape[Out], ?]): javadsl.Source[Out, Mat] =
     new Source(delegate.merge(that))
 
   /**
@@ -1720,7 +1720,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def merge(that: Graph[SourceShape[Out], _], eagerComplete: Boolean): javadsl.Source[Out, Mat] =
+  def merge(that: Graph[SourceShape[Out], ?], eagerComplete: Boolean): javadsl.Source[Out, Mat] =
     new Source(delegate.merge(that, eagerComplete))
 
   /**
@@ -1763,10 +1763,10 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * '''Cancels when''' downstream cancels
    */
   def mergeAll(
-      those: java.util.List[_ <: Graph[SourceShape[Out], _ <: Any]],
+      those: java.util.List[? <: Graph[SourceShape[Out], ? <: Any]],
       eagerComplete: Boolean): javadsl.Source[Out, Mat] = {
     val seq = if (those != null) Util.immutableSeq(those).collect {
-      case source: Source[Out @unchecked, _] => source.asScala
+      case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
     else immutable.Seq()
@@ -1912,7 +1912,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def zip[T](that: Graph[SourceShape[T], _]): javadsl.Source[Out @uncheckedVariance Pair T, Mat] =
+  def zip[T](that: Graph[SourceShape[T], ?]): javadsl.Source[Out @uncheckedVariance Pair T, Mat] =
     zipMat(that, Keep.left)
 
   /**
@@ -1939,7 +1939,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): Source[Pair[A, U], Mat] =
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], ?], thisElem: A, thatElem: U): Source[Pair[A, U], Mat] =
     new Source(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
 
   /**
@@ -1975,7 +1975,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipLatest[T](that: Graph[SourceShape[T], _]): javadsl.Source[Out @uncheckedVariance Pair T, Mat] =
+  def zipLatest[T](that: Graph[SourceShape[T], ?]): javadsl.Source[Out @uncheckedVariance Pair T, Mat] =
     zipLatestMat(that, Keep.left)
 
   /**
@@ -2004,7 +2004,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * '''Cancels when''' downstream cancels
    */
   def zipWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       combine: function.Function2[Out, Out2, Out3]): javadsl.Source[Out3, Mat] =
     new Source(delegate.zipWith[Out2, Out3](that)(combinerToScala(combine)))
 
@@ -2041,7 +2041,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *   '''Cancels when''' downstream cancels
    */
   def zipLatestWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       combine: function.Function2[Out, Out2, Out3]): javadsl.Source[Out3, Mat] =
     new Source(delegate.zipLatestWith[Out2, Out3](that)(combinerToScala(combine)))
 
@@ -2063,7 +2063,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *   '''Cancels when''' downstream cancels
    */
   def zipLatestWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       eagerComplete: Boolean,
       combine: function.Function2[Out, Out2, Out3]): javadsl.Source[Out3, Mat] =
     new Source(delegate.zipLatestWith[Out2, Out3](that, eagerComplete)(combinerToScala(combine)))
@@ -2217,7 +2217,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def recover(clazz: Class[_ <: Throwable], supplier: Supplier[Out]): javadsl.Source[Out, Mat] =
+  def recover(clazz: Class[? <: Throwable], supplier: Supplier[Out]): javadsl.Source[Out, Mat] =
     recover {
       case elem if clazz.isInstance(elem) => supplier.get()
     }
@@ -2287,7 +2287,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * @deprecated use `recoverWithRetries` instead
    */
-  def recoverWith(pf: PartialFunction[Throwable, _ <: Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
+  def recoverWith(pf: PartialFunction[Throwable, ? <: Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
     new Source(delegate.recoverWith(pf))
 
   /**
@@ -2314,7 +2314,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
   @deprecated("Use recoverWithRetries instead.", "Akka 2.6.6")
   @nowarn("msg=deprecated")
   def recoverWith(
-      clazz: Class[_ <: Throwable],
+      clazz: Class[? <: Throwable],
       supplier: Supplier[Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
     recoverWith({
       case elem if clazz.isInstance(elem) => supplier.get()
@@ -2344,7 +2344,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    */
   def recoverWithRetries(
       attempts: Int,
-      pf: PartialFunction[Throwable, _ <: Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
+      pf: PartialFunction[Throwable, ? <: Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
     new Source(delegate.recoverWithRetries(attempts, pf))
 
   /**
@@ -2375,7 +2375,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    */
   def recoverWithRetries(
       attempts: Int,
-      clazz: Class[_ <: Throwable],
+      clazz: Class[? <: Throwable],
       supplier: Supplier[Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
     recoverWithRetries(attempts,
       {
@@ -2414,7 +2414,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * '''Cancels when''' downstream cancels
    *  @since 1.1.0
    */
-  def onErrorComplete(clazz: Class[_ <: Throwable]): javadsl.Source[Out, Mat] =
+  def onErrorComplete(clazz: Class[? <: Throwable]): javadsl.Source[Out, Mat] =
     onErrorComplete(ex => clazz.isInstance(ex))
 
   /**
@@ -2432,7 +2432,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * '''Cancels when''' downstream cancels
    *  @since 1.1.0
    */
-  def onErrorComplete(predicate: java.util.function.Predicate[_ >: Throwable]): javadsl.Source[Out, Mat] =
+  def onErrorComplete(predicate: java.util.function.Predicate[? >: Throwable]): javadsl.Source[Out, Mat] =
     new Source(delegate.onErrorComplete {
       case ex: Throwable if predicate.test(ex) => true
     })
@@ -2458,7 +2458,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def mapConcat[T](f: function.Function[Out, _ <: java.lang.Iterable[T]]): javadsl.Source[T, Mat] =
+  def mapConcat[T](f: function.Function[Out, ? <: java.lang.Iterable[T]]): javadsl.Source[T, Mat] =
     new Source(delegate.mapConcat(elem => Util.immutableSeq(f.apply(elem))))
 
   /**
@@ -4102,7 +4102,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def flatMapConcat[T, M](f: function.Function[Out, _ <: Graph[SourceShape[T], M]]): Source[T, Mat] =
+  def flatMapConcat[T, M](f: function.Function[Out, ? <: Graph[SourceShape[T], M]]): Source[T, Mat] =
     new Source(delegate.flatMapConcat[T, M](x => f(x)))
 
   /**
@@ -4118,7 +4118,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  def flatMapMerge[T, M](breadth: Int, f: function.Function[Out, _ <: Graph[SourceShape[T], M]]): Source[T, Mat] =
+  def flatMapMerge[T, M](breadth: Int, f: function.Function[Out, ? <: Graph[SourceShape[T], M]]): Source[T, Mat] =
     new Source(delegate.flatMapMerge(breadth, o => f(o)))
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
@@ -232,7 +232,7 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
    *
    * @see [[pekko.stream.javadsl.Source.mapConcat]]
    */
-  def mapConcat[Out2](f: function.Function[Out, _ <: java.lang.Iterable[Out2]]): SourceWithContext[Out2, Ctx, Mat] =
+  def mapConcat[Out2](f: function.Function[Out, ? <: java.lang.Iterable[Out2]]): SourceWithContext[Out2, Ctx, Mat] =
     viaScala(_.mapConcat(elem => Util.immutableSeq(f.apply(elem))))
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/StreamConverters.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/StreamConverters.scala
@@ -254,7 +254,7 @@ object StreamConverters {
    * Note that a flow can be materialized multiple times, so the function producing the ``Collector`` must be able
    * to handle multiple invocations.
    */
-  def javaCollector[T, R](collector: function.Creator[Collector[T, _ <: Any, R]]): Sink[T, CompletionStage[R]] =
+  def javaCollector[T, R](collector: function.Creator[Collector[T, ? <: Any, R]]): Sink[T, CompletionStage[R]] =
     new Sink(scaladsl.StreamConverters.javaCollector[T, R](() => collector.create()).toCompletionStage())
 
   /**
@@ -268,7 +268,7 @@ object StreamConverters {
    * to handle multiple invocations.
    */
   def javaCollectorParallelUnordered[T, R](parallelism: Int)(
-      collector: function.Creator[Collector[T, _ <: Any, R]]): Sink[T, CompletionStage[R]] =
+      collector: function.Creator[Collector[T, ? <: Any, R]]): Sink[T, CompletionStage[R]] =
     new Sink(
       scaladsl.StreamConverters
         .javaCollectorParallelUnordered[T, R](parallelism)(() => collector.create())

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -134,7 +134,7 @@ class SubFlow[In, Out, Mat](
    * Note that attributes set on the returned graph, including async boundaries are now for the entire graph and not
    * the `SubFlow`. for example `async` will not have any effect as the returned graph is the entire, closed graph.
    */
-  def to(sink: Graph[SinkShape[Out], _]): Sink[In, Mat] =
+  def to(sink: Graph[SinkShape[Out], ?]): Sink[In, Mat] =
     new Sink(delegate.to(sink))
 
   /**
@@ -1261,7 +1261,7 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    *  @since 1.1.0
    */
-  def onErrorComplete(clazz: Class[_ <: Throwable]): SubFlow[In, Out, Mat] = onErrorComplete(ex => clazz.isInstance(ex))
+  def onErrorComplete(clazz: Class[? <: Throwable]): SubFlow[In, Out, Mat] = onErrorComplete(ex => clazz.isInstance(ex))
 
   /**
    * onErrorComplete allows to complete the stream when an upstream error occurs.
@@ -1278,7 +1278,7 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    *  @since 1.1.0
    */
-  def onErrorComplete(predicate: java.util.function.Predicate[_ >: Throwable]): SubFlow[In, Out, Mat] =
+  def onErrorComplete(predicate: java.util.function.Predicate[? >: Throwable]): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.onErrorComplete {
       case ex: Throwable if predicate.test(ex) => true
     })
@@ -1693,7 +1693,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def flatMapConcat[T, M](f: function.Function[Out, _ <: Graph[SourceShape[T], M]]): SubFlow[In, T, Mat] =
+  def flatMapConcat[T, M](f: function.Function[Out, ? <: Graph[SourceShape[T], M]]): SubFlow[In, T, Mat] =
     new SubFlow(delegate.flatMapConcat(x => f(x)))
 
   /**
@@ -1709,7 +1709,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def flatMapMerge[T, M](breadth: Int, f: function.Function[Out, _ <: Graph[SourceShape[T], M]]): SubFlow[In, T, Mat] =
+  def flatMapMerge[T, M](breadth: Int, f: function.Function[Out, ? <: Graph[SourceShape[T], M]]): SubFlow[In, T, Mat] =
     new SubFlow(delegate.flatMapMerge(breadth, o => f(o)))
 
   /**
@@ -1787,7 +1787,7 @@ class SubFlow[In, Out, Mat](
    */
   @varargs
   @SafeVarargs
-  def concatAllLazy(those: Graph[SourceShape[Out], _]*): SubFlow[In, Out, Mat] =
+  def concatAllLazy(those: Graph[SourceShape[Out], ?]*): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.concatAllLazy(those: _*))
 
   /**
@@ -1876,7 +1876,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream or Sink cancels
    */
-  def alsoTo(that: Graph[SinkShape[Out], _]): SubFlow[In, Out, Mat] =
+  def alsoTo(that: Graph[SinkShape[Out], ?]): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.alsoTo(that))
 
   /**
@@ -1895,7 +1895,7 @@ class SubFlow[In, Out, Mat](
    */
   @varargs
   @SafeVarargs
-  def alsoToAll(those: Graph[SinkShape[Out], _]*): SubFlow[In, Out, Mat] =
+  def alsoToAll(those: Graph[SinkShape[Out], ?]*): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.alsoToAll(those: _*))
 
   /**
@@ -1910,7 +1910,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' any of the downstreams cancel
    */
-  def divertTo(that: Graph[SinkShape[Out], _], when: function.Predicate[Out]): SubFlow[In, Out, Mat] =
+  def divertTo(that: Graph[SinkShape[Out], ?], when: function.Predicate[Out]): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.divertTo(that, when.test))
 
   /**
@@ -1929,7 +1929,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def wireTap(that: Graph[SinkShape[Out], _]): SubFlow[In, Out, Mat] =
+  def wireTap(that: Graph[SinkShape[Out], ?]): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.wireTap(that))
 
   /**
@@ -1944,7 +1944,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def merge(that: Graph[SourceShape[Out], _]): SubFlow[In, Out, Mat] =
+  def merge(that: Graph[SourceShape[Out], ?]): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.merge(that))
 
   /**
@@ -1960,10 +1960,10 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def mergeAll(
-      those: java.util.List[_ <: Graph[SourceShape[Out], _ <: Any]],
+      those: java.util.List[? <: Graph[SourceShape[Out], ? <: Any]],
       eagerComplete: Boolean): SubFlow[In, Out, Mat] = {
     val seq = if (those != null) Util.immutableSeq(those).collect {
-      case source: Source[Out @unchecked, _] => source.asScala
+      case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
     else immutable.Seq()
@@ -1993,7 +1993,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def interleave(that: Graph[SourceShape[Out], _], segmentSize: Int): SubFlow[In, Out, Mat] =
+  def interleave(that: Graph[SourceShape[Out], ?], segmentSize: Int): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.interleave(that, segmentSize))
 
   /**
@@ -2017,11 +2017,11 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def interleaveAll(
-      those: java.util.List[_ <: Graph[SourceShape[Out], _ <: Any]],
+      those: java.util.List[? <: Graph[SourceShape[Out], ? <: Any]],
       segmentSize: Int,
       eagerClose: Boolean): SubFlow[In, Out, Mat] = {
     val seq = if (those != null) Util.immutableSeq(those).collect {
-      case source: Source[Out @unchecked, _] => source.asScala
+      case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
     else immutable.Seq()
@@ -2103,7 +2103,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def zip[T](source: Graph[SourceShape[T], _]): SubFlow[In, pekko.japi.Pair[Out @uncheckedVariance, T], Mat] =
+  def zip[T](source: Graph[SourceShape[T], ?]): SubFlow[In, pekko.japi.Pair[Out @uncheckedVariance, T], Mat] =
     new SubFlow(delegate.zip(source).map { case (o, t) => pekko.japi.Pair.create(o, t) })
 
   /**
@@ -2118,7 +2118,7 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def zipAll[U, A >: Out](
-      that: Graph[SourceShape[U], _],
+      that: Graph[SourceShape[U], ?],
       thisElem: A,
       thatElem: U): SubFlow[In, pekko.japi.Pair[A, U], Mat] =
     new SubFlow(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
@@ -2135,7 +2135,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipLatest[T](source: Graph[SourceShape[T], _]): SubFlow[In, pekko.japi.Pair[Out @uncheckedVariance, T], Mat] =
+  def zipLatest[T](source: Graph[SourceShape[T], ?]): SubFlow[In, pekko.japi.Pair[Out @uncheckedVariance, T], Mat] =
     new SubFlow(delegate.zipLatest(source).map { case (o, t) => pekko.japi.Pair.create(o, t) })
 
   /**
@@ -2151,7 +2151,7 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def zipWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       combine: function.Function2[Out, Out2, Out3]): SubFlow[In, Out3, Mat] =
     new SubFlow(delegate.zipWith[Out2, Out3](that)(combinerToScala(combine)))
 
@@ -2169,7 +2169,7 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def zipLatestWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       combine: function.Function2[Out, Out2, Out3]): SubFlow[In, Out3, Mat] =
     new SubFlow(delegate.zipLatestWith[Out2, Out3](that)(combinerToScala(combine)))
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -125,7 +125,7 @@ class SubSource[Out, Mat](
    *     +----------------------------+
    * }}}
    */
-  def to(sink: Graph[SinkShape[Out], _]): RunnableGraph[Mat] =
+  def to(sink: Graph[SinkShape[Out], ?]): RunnableGraph[Mat] =
     RunnableGraph.fromGraph(delegate.to(sink))
 
   /**
@@ -1241,7 +1241,7 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels
    *  @since 1.1.0
    */
-  def onErrorComplete(clazz: Class[_ <: Throwable]): SubSource[Out, Mat] = onErrorComplete(ex => clazz.isInstance(ex))
+  def onErrorComplete(clazz: Class[? <: Throwable]): SubSource[Out, Mat] = onErrorComplete(ex => clazz.isInstance(ex))
 
   /**
    * onErrorComplete allows to complete the stream when an upstream error occurs.
@@ -1258,7 +1258,7 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels
    *  @since 1.1.0
    */
-  def onErrorComplete(predicate: java.util.function.Predicate[_ >: Throwable]): SubSource[Out, Mat] =
+  def onErrorComplete(predicate: java.util.function.Predicate[? >: Throwable]): SubSource[Out, Mat] =
     new SubSource(delegate.onErrorComplete {
       case ex: Throwable if predicate.test(ex) => true
     })
@@ -1669,7 +1669,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def flatMapConcat[T, M](f: function.Function[Out, _ <: Graph[SourceShape[T], M]]): SubSource[T, Mat] =
+  def flatMapConcat[T, M](f: function.Function[Out, ? <: Graph[SourceShape[T], M]]): SubSource[T, Mat] =
     new SubSource(delegate.flatMapConcat(x => f(x)))
 
   /**
@@ -1685,7 +1685,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def flatMapMerge[T, M](breadth: Int, f: function.Function[Out, _ <: Graph[SourceShape[T], M]]): SubSource[T, Mat] =
+  def flatMapMerge[T, M](breadth: Int, f: function.Function[Out, ? <: Graph[SourceShape[T], M]]): SubSource[T, Mat] =
     new SubSource(delegate.flatMapMerge(breadth, o => f(o)))
 
   /**
@@ -1763,7 +1763,7 @@ class SubSource[Out, Mat](
    */
   @varargs
   @SafeVarargs
-  def concatAllLazy(those: Graph[SourceShape[Out], _]*): SubSource[Out, Mat] =
+  def concatAllLazy(those: Graph[SourceShape[Out], ?]*): SubSource[Out, Mat] =
     new SubSource(delegate.concatAllLazy(those: _*))
 
   /**
@@ -1852,7 +1852,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream or Sink cancels
    */
-  def alsoTo(that: Graph[SinkShape[Out], _]): SubSource[Out, Mat] =
+  def alsoTo(that: Graph[SinkShape[Out], ?]): SubSource[Out, Mat] =
     new SubSource(delegate.alsoTo(that))
 
   /**
@@ -1871,7 +1871,7 @@ class SubSource[Out, Mat](
    */
   @varargs
   @SafeVarargs
-  def alsoToAll(those: Graph[SinkShape[Out], _]*): SubSource[Out, Mat] =
+  def alsoToAll(those: Graph[SinkShape[Out], ?]*): SubSource[Out, Mat] =
     new SubSource(delegate.alsoToAll(those: _*))
 
   /**
@@ -1886,7 +1886,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' any of the downstreams cancel
    */
-  def divertTo(that: Graph[SinkShape[Out], _], when: function.Predicate[Out]): SubSource[Out, Mat] =
+  def divertTo(that: Graph[SinkShape[Out], ?], when: function.Predicate[Out]): SubSource[Out, Mat] =
     new SubSource(delegate.divertTo(that, when.test))
 
   /**
@@ -1905,7 +1905,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def wireTap(that: Graph[SinkShape[Out], _]): SubSource[Out, Mat] =
+  def wireTap(that: Graph[SinkShape[Out], ?]): SubSource[Out, Mat] =
     new SubSource(delegate.wireTap(that))
 
   /**
@@ -1920,7 +1920,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def merge(that: Graph[SourceShape[Out], _]): SubSource[Out, Mat] =
+  def merge(that: Graph[SourceShape[Out], ?]): SubSource[Out, Mat] =
     new SubSource(delegate.merge(that))
 
   /**
@@ -1936,10 +1936,10 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def mergeAll(
-      those: java.util.List[_ <: Graph[SourceShape[Out], _ <: Any]],
+      those: java.util.List[? <: Graph[SourceShape[Out], ? <: Any]],
       eagerComplete: Boolean): SubSource[Out, Mat] = {
     val seq = if (those != null) Util.immutableSeq(those).collect {
-      case source: Source[Out @unchecked, _] => source.asScala
+      case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
     else immutable.Seq()
@@ -1970,7 +1970,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def interleave(that: Graph[SourceShape[Out], _], segmentSize: Int): SubSource[Out, Mat] =
+  def interleave(that: Graph[SourceShape[Out], ?], segmentSize: Int): SubSource[Out, Mat] =
     new SubSource(delegate.interleave(that, segmentSize))
 
   /**
@@ -1994,11 +1994,11 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def interleaveAll(
-      those: java.util.List[_ <: Graph[SourceShape[Out], _ <: Any]],
+      those: java.util.List[? <: Graph[SourceShape[Out], ? <: Any]],
       segmentSize: Int,
       eagerClose: Boolean): SubSource[Out, Mat] = {
     val seq = if (those != null) Util.immutableSeq(those).collect {
-      case source: Source[Out @unchecked, _] => source.asScala
+      case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
     else immutable.Seq()
@@ -2080,7 +2080,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def zip[T](source: Graph[SourceShape[T], _]): SubSource[pekko.japi.Pair[Out @uncheckedVariance, T], Mat] =
+  def zip[T](source: Graph[SourceShape[T], ?]): SubSource[pekko.japi.Pair[Out @uncheckedVariance, T], Mat] =
     new SubSource(delegate.zip(source).map { case (o, t) => pekko.japi.Pair.create(o, t) })
 
   /**
@@ -2095,7 +2095,7 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def zipAll[U, A >: Out](
-      that: Graph[SourceShape[U], _],
+      that: Graph[SourceShape[U], ?],
       thisElem: A,
       thatElem: U): SubSource[pekko.japi.Pair[A, U], Mat] =
     new SubSource(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
@@ -2112,7 +2112,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipLatest[T](source: Graph[SourceShape[T], _]): SubSource[pekko.japi.Pair[Out @uncheckedVariance, T], Mat] =
+  def zipLatest[T](source: Graph[SourceShape[T], ?]): SubSource[pekko.japi.Pair[Out @uncheckedVariance, T], Mat] =
     new SubSource(delegate.zipLatest(source).map { case (o, t) => pekko.japi.Pair.create(o, t) })
 
   /**
@@ -2128,7 +2128,7 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def zipWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       combine: function.Function2[Out, Out2, Out3]): SubSource[Out3, Mat] =
     new SubSource(delegate.zipWith[Out2, Out3](that)(combinerToScala(combine)))
 
@@ -2146,7 +2146,7 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def zipLatestWith[Out2, Out3](
-      that: Graph[SourceShape[Out2], _],
+      that: Graph[SourceShape[Out2], ?],
       combine: function.Function2[Out, Out2, Out3]): SubSource[Out3, Mat] =
     new SubSource(delegate.zipLatestWith[Out2, Out3](that)(combinerToScala(combine)))
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/package.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/package.scala
@@ -20,7 +20,7 @@ package object javadsl {
     f match {
       case x if x eq Keep.left   => scaladsl.Keep.left.asInstanceOf[(M1, M2) => M]
       case x if x eq Keep.right  => scaladsl.Keep.right.asInstanceOf[(M1, M2) => M]
-      case s: Function2[_, _, _] => s.asInstanceOf[(M1, M2) => M]
+      case s: Function2[?, ?, ?] => s.asInstanceOf[(M1, M2) => M]
       case other                 => other.apply _
     }
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -371,7 +371,7 @@ final class Flow[-In, +Out, +Mat](
             override def onSubscribe(s: Subscription): Unit = sub.onSubscribe(s)
             override def onComplete(): Unit = sub.onComplete()
             override def onNext(t: In): Unit = sub.onNext(t)
-            override def subscribe(s: Subscriber[_ >: Out]): Unit = pub.subscribe(s)
+            override def subscribe(s: Subscriber[? >: Out]): Unit = pub.subscribe(s)
           }
       }
 
@@ -490,7 +490,7 @@ object Flow {
    *
    * See also [[fromSinkAndSourceMat]] when access to materialized values of the parameters is needed.
    */
-  def fromSinkAndSource[I, O](sink: Graph[SinkShape[I], _], source: Graph[SourceShape[O], _]): Flow[I, O, NotUsed] =
+  def fromSinkAndSource[I, O](sink: Graph[SinkShape[I], ?], source: Graph[SourceShape[O], ?]): Flow[I, O, NotUsed] =
     fromSinkAndSourceMat(sink, source)(Keep.none)
 
   /**
@@ -585,8 +585,8 @@ object Flow {
    * See also [[fromSinkAndSourceCoupledMat]] when access to materialized values of the parameters is needed.
    */
   def fromSinkAndSourceCoupled[I, O](
-      sink: Graph[SinkShape[I], _],
-      source: Graph[SourceShape[O], _]): Flow[I, O, NotUsed] =
+      sink: Graph[SinkShape[I], ?],
+      source: Graph[SourceShape[O], ?]): Flow[I, O, NotUsed] =
     fromSinkAndSourceCoupledMat(sink, source)(Keep.none)
 
   /**
@@ -2992,7 +2992,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def zip[U](that: Graph[SourceShape[U], _]): Repr[(Out, U)] = via(zipGraph(that))
+  def zip[U](that: Graph[SourceShape[U], ?]): Repr[(Out, U)] = via(zipGraph(that))
 
   /**
    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
@@ -3005,7 +3005,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): Repr[(A, U)] = {
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], ?], thisElem: A, thatElem: U): Repr[(A, U)] = {
     via(zipAllFlow(that, thisElem, thatElem))
   }
 
@@ -3054,7 +3054,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipLatest[U](that: Graph[SourceShape[U], _]): Repr[(Out, U)] = via(zipLatestGraph(that))
+  def zipLatest[U](that: Graph[SourceShape[U], ?]): Repr[(Out, U)] = via(zipLatestGraph(that))
 
   protected def zipLatestGraph[U, M](
       that: Graph[SourceShape[U], M]): Graph[FlowShape[Out @uncheckedVariance, (Out, U)], M] =
@@ -3076,7 +3076,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipWith[Out2, Out3](that: Graph[SourceShape[Out2], _])(combine: (Out, Out2) => Out3): Repr[Out3] =
+  def zipWith[Out2, Out3](that: Graph[SourceShape[Out2], ?])(combine: (Out, Out2) => Out3): Repr[Out3] =
     via(zipWithGraph(that)(combine))
 
   protected def zipWithGraph[Out2, Out3, M](that: Graph[SourceShape[Out2], M])(
@@ -3104,7 +3104,7 @@ trait FlowOps[+Out, +Mat] {
    *
    *   '''Cancels when''' downstream cancels
    */
-  def zipLatestWith[Out2, Out3](that: Graph[SourceShape[Out2], _])(combine: (Out, Out2) => Out3): Repr[Out3] =
+  def zipLatestWith[Out2, Out3](that: Graph[SourceShape[Out2], ?])(combine: (Out, Out2) => Out3): Repr[Out3] =
     zipLatestWith(that, eagerComplete = true)(combine)
 
   /**
@@ -3124,7 +3124,7 @@ trait FlowOps[+Out, +Mat] {
    *
    *   '''Cancels when''' downstream cancels
    */
-  def zipLatestWith[Out2, Out3](that: Graph[SourceShape[Out2], _], eagerComplete: Boolean)(
+  def zipLatestWith[Out2, Out3](that: Graph[SourceShape[Out2], ?], eagerComplete: Boolean)(
       combine: (Out, Out2) => Out3): Repr[Out3] =
     via(zipLatestWithGraph(that, eagerComplete)(combine))
 
@@ -3180,7 +3180,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def interleave[U >: Out](that: Graph[SourceShape[U], _], segmentSize: Int): Repr[U] =
+  def interleave[U >: Out](that: Graph[SourceShape[U], ?], segmentSize: Int): Repr[U] =
     interleave(that, segmentSize, eagerClose = false)
 
   /**
@@ -3203,7 +3203,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def interleave[U >: Out](that: Graph[SourceShape[U], _], segmentSize: Int, eagerClose: Boolean): Repr[U] =
+  def interleave[U >: Out](that: Graph[SourceShape[U], ?], segmentSize: Int, eagerClose: Boolean): Repr[U] =
     via(interleaveGraph(that, segmentSize, eagerClose))
 
   protected def interleaveGraph[U >: Out, M](
@@ -3237,7 +3237,7 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream cancels
    */
   def interleaveAll[U >: Out](
-      those: immutable.Seq[Graph[SourceShape[U], _]],
+      those: immutable.Seq[Graph[SourceShape[U], ?]],
       segmentSize: Int,
       eagerClose: Boolean): Repr[U] = those match {
     case those if those.isEmpty => this.asInstanceOf[Repr[U]]
@@ -3287,7 +3287,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def mergeAll[U >: Out](those: immutable.Seq[Graph[SourceShape[U], _]], eagerComplete: Boolean): Repr[U] =
+  def mergeAll[U >: Out](those: immutable.Seq[Graph[SourceShape[U], ?]], eagerComplete: Boolean): Repr[U] =
     those match {
       case those if those.isEmpty => this.asInstanceOf[Repr[U]]
       case _ =>
@@ -3488,7 +3488,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def concatAllLazy[U >: Out](those: Graph[SourceShape[U], _]*): Repr[U] =
+  def concatAllLazy[U >: Out](those: Graph[SourceShape[U], ?]*): Repr[U] =
     internalConcatAll(those.toArray, detached = false)
 
   private def internalConcat[U >: Out, Mat2](that: Graph[SourceShape[U], Mat2], detached: Boolean): Repr[U] =
@@ -3502,7 +3502,7 @@ trait FlowOps[+Out, +Mat] {
         }
     }
 
-  private def internalConcatAll[U >: Out](those: Array[Graph[SourceShape[U], _]], detached: Boolean): Repr[U] =
+  private def internalConcatAll[U >: Out](those: Array[Graph[SourceShape[U], ?]], detached: Boolean): Repr[U] =
     those match {
       case those if those.isEmpty     => this.asInstanceOf[Repr[U]]
       case those if those.length == 1 => internalConcat(those.head, detached)
@@ -3652,7 +3652,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream or Sink cancels
    */
-  def alsoTo(that: Graph[SinkShape[Out], _]): Repr[Out] = via(alsoToGraph(that))
+  def alsoTo(that: Graph[SinkShape[Out], ?]): Repr[Out] = via(alsoToGraph(that))
 
   protected def alsoToGraph[M](that: Graph[SinkShape[Out], M]): Graph[FlowShape[Out @uncheckedVariance, Out], M] =
     GraphDSL.createGraph(that) { implicit b => r =>
@@ -3676,7 +3676,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream or any of the [[Sink]]s cancels
    */
-  def alsoToAll(those: Graph[SinkShape[Out], _]*): Repr[Out] = those match {
+  def alsoToAll(those: Graph[SinkShape[Out], ?]*): Repr[Out] = those match {
     case those if those.isEmpty => this.asInstanceOf[Repr[Out]]
     case _ =>
       via(GraphDSL.create() { implicit b =>
@@ -3700,7 +3700,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' any of the downstreams cancel
    */
-  def divertTo(that: Graph[SinkShape[Out], _], when: Out => Boolean): Repr[Out] = via(divertToGraph(that, when))
+  def divertTo(that: Graph[SinkShape[Out], ?], when: Out => Boolean): Repr[Out] = via(divertToGraph(that, when))
 
   protected def divertToGraph[M](
       that: Graph[SinkShape[Out], M],
@@ -3728,7 +3728,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def wireTap(that: Graph[SinkShape[Out], _]): Repr[Out] = via(wireTapGraph(that))
+  def wireTap(that: Graph[SinkShape[Out], ?]): Repr[Out] = via(wireTapGraph(that))
 
   protected def wireTapGraph[M](that: Graph[SinkShape[Out], M]): Graph[FlowShape[Out @uncheckedVariance, Out], M] =
     GraphDSL.createGraph(that) { implicit b => r =>
@@ -3801,7 +3801,7 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
     type Closed = FlowOpsMat.this.ClosedMat[M @uncheckedVariance]
     type ClosedMat[+MM] = FlowOpsMat.this.ClosedMat[MM]
   }
-  type ClosedMat[+M] <: Graph[_, M]
+  type ClosedMat[+M] <: Graph[?, M]
 
   /**
    * Transform this [[Flow]] by appending the given processing steps.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartFlow.scala
@@ -63,7 +63,7 @@ object RestartFlow {
   @deprecated("Use the overloaded method which accepts org.apache.pekko.stream.RestartSettings instead.",
     since = "Akka 2.6.10")
   def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(
-      flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+      flowFactory: () => Flow[In, Out, ?]): Flow[In, Out, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor)
     withBackoff(settings)(flowFactory)
   }
@@ -99,7 +99,7 @@ object RestartFlow {
       minBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       randomFactor: Double,
-      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+      maxRestarts: Int)(flowFactory: () => Flow[In, Out, ?]): Flow[In, Out, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings)(flowFactory)
   }
@@ -122,7 +122,7 @@ object RestartFlow {
    * @param settings [[RestartSettings]] defining restart configuration
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  def withBackoff[In, Out](settings: RestartSettings)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] =
+  def withBackoff[In, Out](settings: RestartSettings)(flowFactory: () => Flow[In, Out, ?]): Flow[In, Out, NotUsed] =
     Flow.fromGraph(new RestartWithBackoffFlow(flowFactory, settings, onlyOnFailures = false))
 
   /**
@@ -157,7 +157,7 @@ object RestartFlow {
       minBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       randomFactor: Double,
-      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+      maxRestarts: Int)(flowFactory: () => Flow[In, Out, ?]): Flow[In, Out, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings)(flowFactory)
   }
@@ -182,13 +182,13 @@ object RestartFlow {
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
   def onFailuresWithBackoff[In, Out](settings: RestartSettings)(
-      flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] =
+      flowFactory: () => Flow[In, Out, ?]): Flow[In, Out, NotUsed] =
     Flow.fromGraph(new RestartWithBackoffFlow(flowFactory, settings, onlyOnFailures = true))
 
 }
 
 private final class RestartWithBackoffFlow[In, Out](
-    flowFactory: () => Flow[In, Out, _],
+    flowFactory: () => Flow[In, Out, ?],
     settings: RestartSettings,
     onlyOnFailures: Boolean)
     extends GraphStage[FlowShape[In, Out]] { self =>
@@ -264,7 +264,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
   // don't want to restart the sub inlet when it finishes, we just finish normally.
   var finishing = false
 
-  override protected def logSource: Class[_] = classOf[RestartWithBackoffLogic[_]]
+  override protected def logSource: Class[?] = classOf[RestartWithBackoffLogic[?]]
 
   protected def startGraph(): Unit
   protected def backoff(): Unit
@@ -457,7 +457,7 @@ object RestartWithBackoffFlow {
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
       new TimerGraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
-        override protected def logSource: Class[_] = classOf[DelayCancellationStage[_]]
+        override protected def logSource: Class[?] = classOf[DelayCancellationStage[?]]
 
         private var cause: OptionVal[Throwable] = OptionVal.None
 

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartSink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartSink.scala
@@ -56,7 +56,7 @@ object RestartSink {
   @deprecated("Use the overloaded method which accepts org.apache.pekko.stream.RestartSettings instead.",
     since = "Akka 2.6.10")
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(
-      sinkFactory: () => Sink[T, _]): Sink[T, NotUsed] = {
+      sinkFactory: () => Sink[T, ?]): Sink[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor)
     withBackoff(settings)(sinkFactory)
   }
@@ -90,7 +90,7 @@ object RestartSink {
   @deprecated("Use the overloaded method which accepts org.apache.pekko.stream.RestartSettings instead.",
     since = "Akka 2.6.10")
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(
-      sinkFactory: () => Sink[T, _]): Sink[T, NotUsed] = {
+      sinkFactory: () => Sink[T, ?]): Sink[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings)(sinkFactory)
   }
@@ -114,11 +114,11 @@ object RestartSink {
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
-  def withBackoff[T](settings: RestartSettings)(sinkFactory: () => Sink[T, _]): Sink[T, NotUsed] =
+  def withBackoff[T](settings: RestartSettings)(sinkFactory: () => Sink[T, ?]): Sink[T, NotUsed] =
     Sink.fromGraph(new RestartWithBackoffSink(sinkFactory, settings))
 }
 
-private final class RestartWithBackoffSink[T](sinkFactory: () => Sink[T, _], restartSettings: RestartSettings)
+private final class RestartWithBackoffSink[T](sinkFactory: () => Sink[T, ?], restartSettings: RestartSettings)
     extends GraphStage[SinkShape[T]] { self =>
 
   val in = Inlet[T]("RestartWithBackoffSink.in")

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartSource.scala
@@ -52,7 +52,7 @@ object RestartSource {
   @deprecated("Use the overloaded method which accepts org.apache.pekko.stream.RestartSettings instead.",
     since = "Akka 2.6.10")
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(
-      sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
+      sourceFactory: () => Source[T, ?]): Source[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor)
     withBackoff(settings)(sourceFactory)
   }
@@ -83,7 +83,7 @@ object RestartSource {
   @deprecated("Use the overloaded method which accepts org.apache.pekko.stream.RestartSettings instead.",
     since = "Akka 2.6.10")
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(
-      sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
+      sourceFactory: () => Source[T, ?]): Source[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings)(sourceFactory)
   }
@@ -104,7 +104,7 @@ object RestartSource {
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  def withBackoff[T](settings: RestartSettings)(sourceFactory: () => Source[T, _]): Source[T, NotUsed] =
+  def withBackoff[T](settings: RestartSettings)(sourceFactory: () => Source[T, ?]): Source[T, NotUsed] =
     Source.fromGraph(new RestartWithBackoffSource(sourceFactory, settings, onlyOnFailures = false))
 
   /**
@@ -130,7 +130,7 @@ object RestartSource {
   @deprecated("Use the overloaded method which accepts org.apache.pekko.stream.RestartSettings instead.",
     since = "Akka 2.6.10")
   def onFailuresWithBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(
-      sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
+      sourceFactory: () => Source[T, ?]): Source[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor)
     onFailuresWithBackoff(settings)(sourceFactory)
   }
@@ -163,7 +163,7 @@ object RestartSource {
       minBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       randomFactor: Double,
-      maxRestarts: Int)(sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
+      maxRestarts: Int)(sourceFactory: () => Source[T, ?]): Source[T, NotUsed] = {
     val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings)(sourceFactory)
   }
@@ -183,12 +183,12 @@ object RestartSource {
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  def onFailuresWithBackoff[T](settings: RestartSettings)(sourceFactory: () => Source[T, _]): Source[T, NotUsed] =
+  def onFailuresWithBackoff[T](settings: RestartSettings)(sourceFactory: () => Source[T, ?]): Source[T, NotUsed] =
     Source.fromGraph(new RestartWithBackoffSource(sourceFactory, settings, onlyOnFailures = true))
 }
 
 private final class RestartWithBackoffSource[T](
-    sourceFactory: () => Source[T, _],
+    sourceFactory: () => Source[T, ?],
     settings: RestartSettings,
     onlyOnFailures: Boolean)
     extends GraphStage[SourceShape[T]] { self =>

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
@@ -287,7 +287,7 @@ object Sink {
    *
    * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
    */
-  def collection[T, That](implicit cbf: Factory[T, That with immutable.Iterable[_]]): Sink[T, Future[That]] =
+  def collection[T, That](implicit cbf: Factory[T, That with immutable.Iterable[?]]): Sink[T, Future[That]] =
     Sink.fromGraph(new SeqStage[T, That])
 
   /**
@@ -338,7 +338,7 @@ object Sink {
   /**
    * Combine several sinks with fan-out strategy like `Broadcast` or `Balance` and returns `Sink`.
    */
-  def combine[T, U](first: Sink[U, _], second: Sink[U, _], rest: Sink[U, _]*)(
+  def combine[T, U](first: Sink[U, ?], second: Sink[U, ?], rest: Sink[U, ?]*)(
       @nowarn
       @deprecatedName(Symbol("strategy"))
       fanOutStrategy: Int => Graph[UniformFanOutShape[T, U], NotUsed]): Sink[T, NotUsed] =
@@ -348,7 +348,7 @@ object Sink {
       d.out(0) ~> first
       d.out(1) ~> second
 
-      @tailrec def combineRest(idx: Int, i: Iterator[Sink[U, _]]): SinkShape[T] =
+      @tailrec def combineRest(idx: Int, i: Iterator[Sink[U, ?]]): SinkShape[T] =
         if (i.hasNext) {
           d.out(idx) ~> i.next()
           combineRest(idx + 1, i)

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/StreamConverters.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/StreamConverters.scala
@@ -115,7 +115,7 @@ object StreamConverters {
    * Note that a flow can be materialized multiple times, so the function producing the ``Collector`` must be able
    * to handle multiple invocations.
    */
-  def javaCollector[T, R](collectorFactory: () => java.util.stream.Collector[T, _ <: Any, R]): Sink[T, Future[R]] =
+  def javaCollector[T, R](collectorFactory: () => java.util.stream.Collector[T, ? <: Any, R]): Sink[T, Future[R]] =
     Flow[T]
       .fold {
         new FirstCollectorState[T,
@@ -139,7 +139,7 @@ object StreamConverters {
    * to handle multiple invocations.
    */
   def javaCollectorParallelUnordered[T, R](parallelism: Int)(
-      collectorFactory: () => java.util.stream.Collector[T, _ <: Any, R]): Sink[T, Future[R]] = {
+      collectorFactory: () => java.util.stream.Collector[T, ? <: Any, R]): Sink[T, Future[R]] = {
     if (parallelism == 1) javaCollector[T, R](collectorFactory)
     else {
       Sink

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
@@ -181,7 +181,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *                  for servers, and therefore it is the default setting.
    */
   def bindAndHandle(
-      handler: Flow[ByteString, ByteString, _],
+      handler: Flow[ByteString, ByteString, ?],
       interface: String,
       port: Int,
       backlog: Int = defaultBacklog,
@@ -443,7 +443,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * @see [[Tcp.bindAndHandle]]
    */
   def bindAndHandleWithTls(
-      handler: Flow[ByteString, ByteString, _],
+      handler: Flow[ByteString, ByteString, ?],
       interface: String,
       port: Int,
       createSSLEngine: () => SSLEngine)(implicit m: Materializer): Future[ServerBinding] =
@@ -469,7 +469,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
    * @see [[Tcp.bindAndHandle]]
    */
   def bindAndHandleWithTls(
-      handler: Flow[ByteString, ByteString, _],
+      handler: Flow[ByteString, ByteString, ?],
       interface: String,
       port: Int,
       createSSLEngine: () => SSLEngine,
@@ -500,7 +500,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
     "Setup the SSLEngine with needed parameters.",
     "Akka 2.6.0")
   def bindAndHandleTls(
-      handler: Flow[ByteString, ByteString, _],
+      handler: Flow[ByteString, ByteString, ?],
       interface: String,
       port: Int,
       sslContext: SSLContext,

--- a/stream/src/main/scala/org/apache/pekko/stream/serialization/StreamRefSerializer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/serialization/StreamRefSerializer.scala
@@ -43,7 +43,7 @@ private[pekko] final class StreamRefSerializer(val system: ExtendedActorSystem)
 
   override def manifest(o: AnyRef): String = o match {
     // protocol
-    case _: StreamRefsProtocol.SequencedOnNext[_] => SequencedOnNextManifest
+    case _: StreamRefsProtocol.SequencedOnNext[?] => SequencedOnNextManifest
     case _: StreamRefsProtocol.CumulativeDemand   => CumulativeDemandManifest
     // handshake
     case _: StreamRefsProtocol.OnSubscribeHandshake => OnSubscribeHandshakeManifest
@@ -51,9 +51,9 @@ private[pekko] final class StreamRefSerializer(val system: ExtendedActorSystem)
     case _: StreamRefsProtocol.RemoteStreamFailure   => RemoteSinkFailureManifest
     case _: StreamRefsProtocol.RemoteStreamCompleted => RemoteSinkCompletedManifest
     // refs
-    case _: SourceRefImpl[_] => SourceRefManifest
+    case _: SourceRefImpl[?] => SourceRefManifest
     //    case _: MaterializedSourceRef[_]                 => SourceRefManifest
-    case _: SinkRefImpl[_] => SinkRefManifest
+    case _: SinkRefImpl[?] => SinkRefManifest
     //    case _: MaterializedSinkRef[_]                   => SinkRefManifest
     case StreamRefsProtocol.Ack => AckManifest
     case unknown                => throw new IllegalArgumentException(s"Unsupported object ${unknown.getClass}")
@@ -61,7 +61,7 @@ private[pekko] final class StreamRefSerializer(val system: ExtendedActorSystem)
 
   override def toBinary(o: AnyRef): Array[Byte] = o match {
     // protocol
-    case o: StreamRefsProtocol.SequencedOnNext[_] => serializeSequencedOnNext(o).toByteArray
+    case o: StreamRefsProtocol.SequencedOnNext[?] => serializeSequencedOnNext(o).toByteArray
     case d: StreamRefsProtocol.CumulativeDemand   => serializeCumulativeDemand(d).toByteArray
     // handshake
     case h: StreamRefsProtocol.OnSubscribeHandshake => serializeOnSubscribeHandshake(h).toByteArray
@@ -69,9 +69,9 @@ private[pekko] final class StreamRefSerializer(val system: ExtendedActorSystem)
     case d: StreamRefsProtocol.RemoteStreamFailure   => serializeRemoteSinkFailure(d).toByteArray
     case d: StreamRefsProtocol.RemoteStreamCompleted => serializeRemoteSinkCompleted(d).toByteArray
     // refs
-    case ref: SinkRefImpl[_] => serializeSinkRef(ref).toByteArray
+    case ref: SinkRefImpl[?] => serializeSinkRef(ref).toByteArray
     //    case ref: MaterializedSinkRef[_]                 => ??? // serializeSinkRef(ref).toByteArray
-    case ref: SourceRefImpl[_] => serializeSourceRef(ref).toByteArray
+    case ref: SourceRefImpl[?] => serializeSourceRef(ref).toByteArray
     //    case ref: MaterializedSourceRef[_]               => serializeSourceRef(ref.).toByteArray
     case StreamRefsProtocol.Ack => Array.emptyByteArray
     case unknown                => throw new IllegalArgumentException(s"Unsupported object ${unknown.getClass}")
@@ -121,7 +121,7 @@ private[pekko] final class StreamRefSerializer(val system: ExtendedActorSystem)
       .build()
   }
 
-  private def serializeSequencedOnNext(o: StreamRefsProtocol.SequencedOnNext[_]) = {
+  private def serializeSequencedOnNext(o: StreamRefsProtocol.SequencedOnNext[?]) = {
     val p = o.payload.asInstanceOf[AnyRef]
     val msgSerializer = serialization.findSerializerFor(p)
 
@@ -136,7 +136,7 @@ private[pekko] final class StreamRefSerializer(val system: ExtendedActorSystem)
     StreamRefMessages.SequencedOnNext.newBuilder().setSeqNr(o.seqNr).setPayload(payloadBuilder.build()).build()
   }
 
-  private def serializeSinkRef(sink: SinkRefImpl[_]): StreamRefMessages.SinkRef = {
+  private def serializeSinkRef(sink: SinkRefImpl[?]): StreamRefMessages.SinkRef = {
     StreamRefMessages.SinkRef
       .newBuilder()
       .setTargetRef(
@@ -144,7 +144,7 @@ private[pekko] final class StreamRefSerializer(val system: ExtendedActorSystem)
       .build()
   }
 
-  private def serializeSourceRef(source: SourceRefImpl[_]): StreamRefMessages.SourceRef = {
+  private def serializeSourceRef(source: SourceRefImpl[?]): StreamRefMessages.SourceRef = {
     StreamRefMessages.SourceRef
       .newBuilder()
       .setOriginRef(

--- a/stream/src/main/scala/org/apache/pekko/stream/stage/StageLogging.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/stage/StageLogging.scala
@@ -33,7 +33,7 @@ trait StageLogging { self: GraphStageLogic =>
   private[this] var _log: LoggingAdapter = _
 
   /** Override to customise reported log source */
-  protected def logSource: Class[_] = this.getClass
+  protected def logSource: Class[?] = this.getClass
 
   def log: LoggingAdapter = {
     // only used in StageLogic, i.e. thread safe

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestEventListener.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestEventListener.scala
@@ -322,7 +322,7 @@ object EventFilter {
  * If you want to match all Error events, the most efficient is to use <code>Left("")</code>.
  */
 final case class ErrorFilter(
-    throwable: Class[_],
+    throwable: Class[?],
     override val source: Option[String],
     override val message: Either[String, Regex],
     override val complete: Boolean)(occurrences: Int)
@@ -353,7 +353,7 @@ final case class ErrorFilter(
    *   whether the event’s message must match the given message string or pattern completely
    */
   def this(
-      throwable: Class[_],
+      throwable: Class[?],
       source: String,
       message: String,
       pattern: Boolean,
@@ -370,7 +370,7 @@ final case class ErrorFilter(
   /**
    * Java API: filter only on the given type of exception
    */
-  def this(throwable: Class[_]) = this(throwable, null, null, false, false, Int.MaxValue)
+  def this(throwable: Class[?]) = this(throwable, null, null, false, false, Int.MaxValue)
 
 }
 
@@ -530,7 +530,7 @@ object DeadLettersFilter {
  * Filter which matches DeadLetter events, if the wrapped message conforms to the
  * given type.
  */
-final case class DeadLettersFilter(val messageClass: Class[_])(occurrences: Int) extends EventFilter(occurrences) {
+final case class DeadLettersFilter(val messageClass: Class[?])(occurrences: Int) extends EventFilter(occurrences) {
 
   def matches(event: LogEvent) = {
     event match {

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestJavaSerializer.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestJavaSerializer.scala
@@ -42,7 +42,7 @@ class TestJavaSerializer(val system: ExtendedActorSystem) extends BaseSerializer
     bos.toByteArray
   }
 
-  def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+  def fromBinary(bytes: Array[Byte], clazz: Option[Class[?]]): AnyRef = {
     val in = new ClassLoaderObjectInputStream(system.dynamicAccess.classLoader, new ByteArrayInputStream(bytes))
     val obj = JavaSerializer.currentSystem.withValue(system) { in.readObject }
     in.close()

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKit.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKit.scala
@@ -608,7 +608,7 @@ trait TestKitBase {
   /**
    * Same as `expectMsgAnyClassOf(remainingOrDefault, obj...)`, but correctly treating the timeFactor.
    */
-  def expectMsgAnyClassOf[C](obj: Class[_ <: C]*): C = expectMsgAnyClassOf_internal(remainingOrDefault, obj: _*)
+  def expectMsgAnyClassOf[C](obj: Class[? <: C]*): C = expectMsgAnyClassOf_internal(remainingOrDefault, obj: _*)
 
   /**
    * Receive one message from the test actor and assert that it conforms to
@@ -617,10 +617,10 @@ trait TestKitBase {
    *
    * @return the received object
    */
-  def expectMsgAnyClassOf[C](max: FiniteDuration, obj: Class[_ <: C]*): C =
+  def expectMsgAnyClassOf[C](max: FiniteDuration, obj: Class[? <: C]*): C =
     expectMsgAnyClassOf_internal(max.dilated, obj: _*)
 
-  private def expectMsgAnyClassOf_internal[C](max: FiniteDuration, obj: Class[_ <: C]*): C = {
+  private def expectMsgAnyClassOf_internal[C](max: FiniteDuration, obj: Class[? <: C]*): C = {
     val o = receiveOne(max)
     assert(o ne null, s"timeout ($max) during expectMsgAnyClassOf waiting for ${obj.mkString("(", ", ", ")")}")
     assert(obj.exists(c => BoxedType(c).isInstance(o)), s"found unexpected $o")
@@ -669,7 +669,7 @@ trait TestKitBase {
   /**
    * Same as `expectMsgAllClassOf(remainingOrDefault, obj...)`, but correctly treating the timeFactor.
    */
-  def expectMsgAllClassOf[T](obj: Class[_ <: T]*): immutable.Seq[T] =
+  def expectMsgAllClassOf[T](obj: Class[? <: T]*): immutable.Seq[T] =
     internalExpectMsgAllClassOf(remainingOrDefault, obj: _*)
 
   /**
@@ -680,10 +680,10 @@ trait TestKitBase {
    * Wait time is bounded by the given duration, with an AssertionFailure
    * being thrown in case of timeout.
    */
-  def expectMsgAllClassOf[T](max: FiniteDuration, obj: Class[_ <: T]*): immutable.Seq[T] =
+  def expectMsgAllClassOf[T](max: FiniteDuration, obj: Class[? <: T]*): immutable.Seq[T] =
     internalExpectMsgAllClassOf(max.dilated, obj: _*)
 
-  private def internalExpectMsgAllClassOf[T](max: FiniteDuration, obj: Class[_ <: T]*): immutable.Seq[T] = {
+  private def internalExpectMsgAllClassOf[T](max: FiniteDuration, obj: Class[? <: T]*): immutable.Seq[T] = {
     val recv = receiveN_internal(obj.size, max)
     val missing = obj.filterNot(x => recv.exists(_.getClass eq BoxedType(x)))
     val unexpected = recv.filterNot(x => obj.exists(c => BoxedType(c) eq x.getClass))
@@ -694,7 +694,7 @@ trait TestKitBase {
   /**
    * Same as `expectMsgAllConformingOf(remainingOrDefault, obj...)`, but correctly treating the timeFactor.
    */
-  def expectMsgAllConformingOf[T](obj: Class[_ <: T]*): immutable.Seq[T] =
+  def expectMsgAllConformingOf[T](obj: Class[? <: T]*): immutable.Seq[T] =
     internalExpectMsgAllConformingOf(remainingOrDefault, obj: _*)
 
   /**
@@ -708,10 +708,10 @@ trait TestKitBase {
    * Beware that one object may satisfy all given class constraints, which
    * may be counter-intuitive.
    */
-  def expectMsgAllConformingOf[T](max: FiniteDuration, obj: Class[_ <: T]*): immutable.Seq[T] =
+  def expectMsgAllConformingOf[T](max: FiniteDuration, obj: Class[? <: T]*): immutable.Seq[T] =
     internalExpectMsgAllConformingOf(max.dilated, obj: _*)
 
-  private def internalExpectMsgAllConformingOf[T](max: FiniteDuration, obj: Class[_ <: T]*): immutable.Seq[T] = {
+  private def internalExpectMsgAllConformingOf[T](max: FiniteDuration, obj: Class[? <: T]*): immutable.Seq[T] = {
     val recv = receiveN_internal(obj.size, max)
     val missing = obj.filterNot(x => recv.exists(BoxedType(x).isInstance(_)))
     val unexpected = recv.filterNot(x => obj.exists(c => BoxedType(c).isInstance(x)))

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
@@ -25,7 +25,7 @@ import org.apache.pekko.annotation.InternalApi
 @InternalApi
 private[pekko] object TestKitUtils {
 
-  def testNameFromCallStack(classToStartFrom: Class[_], testKitRegex: Regex): String = {
+  def testNameFromCallStack(classToStartFrom: Class[?], testKitRegex: Regex): String = {
 
     def isAbstractClass(className: String): Boolean = {
       try {

--- a/testkit/src/main/scala/org/apache/pekko/testkit/javadsl/EventFilter.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/javadsl/EventFilter.scala
@@ -20,21 +20,21 @@ import pekko.actor.ActorSystem
 import pekko.event.Logging
 import pekko.testkit.{ DebugFilter, ErrorFilter, InfoFilter, WarningFilter }
 
-class EventFilter(clazz: Class[_], system: ActorSystem) {
+class EventFilter(clazz: Class[?], system: ActorSystem) {
 
   require(
     classOf[Throwable].isAssignableFrom(clazz) || classOf[Logging.LogEvent].isAssignableFrom(clazz),
     "supplied class must either be LogEvent or Throwable")
 
-  private val _clazz: Class[_ <: Logging.LogEvent] =
+  private val _clazz: Class[? <: Logging.LogEvent] =
     if (classOf[Throwable].isAssignableFrom(clazz))
       classOf[Logging.Error]
     else
-      clazz.asInstanceOf[Class[_ <: Logging.LogEvent]]
+      clazz.asInstanceOf[Class[? <: Logging.LogEvent]]
 
-  private var exceptionType: Class[_ <: Throwable] =
+  private var exceptionType: Class[? <: Throwable] =
     if (classOf[Throwable].isAssignableFrom(clazz))
-      clazz.asInstanceOf[Class[_ <: Throwable]]
+      clazz.asInstanceOf[Class[? <: Throwable]]
     else
       null
 

--- a/testkit/src/main/scala/org/apache/pekko/testkit/javadsl/TestKit.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/javadsl/TestKit.scala
@@ -607,7 +607,7 @@ class TestKit(system: ActorSystem) {
    * Same as `expectMsgAnyClassOf(remainingOrDefault, obj...)`, but correctly treating the timeFactor.
    */
   @varargs
-  def expectMsgAnyClassOf[T](objs: Class[_]*): T = tp.expectMsgAnyClassOf(objs: _*).asInstanceOf[T]
+  def expectMsgAnyClassOf[T](objs: Class[?]*): T = tp.expectMsgAnyClassOf(objs: _*).asInstanceOf[T]
 
   /**
    * Receive one message from the test actor and assert that it conforms to
@@ -616,7 +616,7 @@ class TestKit(system: ActorSystem) {
    */
   @varargs
   @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "Akka 2.5.12")
-  def expectMsgAnyClassOf[T](max: FiniteDuration, objs: Class[_]*): T =
+  def expectMsgAnyClassOf[T](max: FiniteDuration, objs: Class[?]*): T =
     tp.expectMsgAnyClassOf(max, objs: _*).asInstanceOf[T]
 
   /**
@@ -625,7 +625,7 @@ class TestKit(system: ActorSystem) {
    * with an AssertionFailure being thrown in case of timeout.
    */
   @varargs
-  def expectMsgAnyClassOf[T](max: java.time.Duration, objs: Class[_]*): T =
+  def expectMsgAnyClassOf[T](max: java.time.Duration, objs: Class[?]*): T =
     tp.expectMsgAnyClassOf(max.asScala, objs: _*).asInstanceOf[T]
 
   /**

--- a/testkit/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
+++ b/testkit/src/test/scala/org/apache/pekko/testkit/PekkoSpec.scala
@@ -94,7 +94,7 @@ abstract class PekkoSpec(_system: ActorSystem)
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 
-  def this(configMap: Map[String, _]) = this(PekkoSpec.mapToConfig(configMap))
+  def this(configMap: Map[String, ?]) = this(PekkoSpec.mapToConfig(configMap))
 
   def this() = this(ActorSystem(TestKitUtils.testNameFromCallStack(classOf[PekkoSpec], "".r), PekkoSpec.testConf))
 
@@ -128,9 +128,9 @@ abstract class PekkoSpec(_system: ActorSystem)
 
   override def expectedTestDuration: FiniteDuration = 60 seconds
 
-  def muteDeadLetters(messageClasses: Class[_]*)(sys: ActorSystem = system): Unit =
+  def muteDeadLetters(messageClasses: Class[?]*)(sys: ActorSystem = system): Unit =
     if (!sys.log.isDebugEnabled) {
-      def mute(clazz: Class[_]): Unit =
+      def mute(clazz: Class[?]): Unit =
         sys.eventStream.publish(Mute(DeadLettersFilter(clazz)(occurrences = Int.MaxValue)))
       if (messageClasses.isEmpty) mute(classOf[AnyRef])
       else messageClasses.foreach(mute)
@@ -142,7 +142,7 @@ abstract class PekkoSpec(_system: ActorSystem)
       def areEqual(a: Class[A], b: Class[B]) = a == b
     }
 
-  implicit def setEqualityConstraint[A, T <: Set[_ <: A]]: CanEqual[Set[A], T] =
+  implicit def setEqualityConstraint[A, T <: Set[? <: A]]: CanEqual[Set[A], T] =
     new CanEqual[Set[A], T] {
       def areEqual(a: Set[A], b: T) = a == b
     }

--- a/testkit/src/test/scala/org/apache/pekko/testkit/TestActorRefSpec.scala
+++ b/testkit/src/test/scala/org/apache/pekko/testkit/TestActorRefSpec.scala
@@ -70,7 +70,7 @@ object TestActorRefSpec {
       case "work" =>
         sender() ! "workDone"
         context.stop(self)
-      case replyTo: Promise[_] => replyTo.asInstanceOf[Promise[Any]].success("complexReply")
+      case replyTo: Promise[?] => replyTo.asInstanceOf[Promise[Any]].success("complexReply")
       case replyTo: ActorRef   => replyTo ! "complexReply"
     }
 

--- a/testkit/src/test/scala/org/apache/pekko/testkit/metrics/reporter/PekkoConsoleReporter.scala
+++ b/testkit/src/test/scala/org/apache/pekko/testkit/metrics/reporter/PekkoConsoleReporter.scala
@@ -36,7 +36,7 @@ class PekkoConsoleReporter(registry: PekkoMetricRegistry, verbose: Boolean, outp
   private final val ConsoleWidth = 80
 
   override def report(
-      gauges: util.SortedMap[String, Gauge[_]],
+      gauges: util.SortedMap[String, Gauge[?]],
       counters: util.SortedMap[String, Counter],
       histograms: util.SortedMap[String, Histogram],
       meters: util.SortedMap[String, Meter],
@@ -82,7 +82,7 @@ class PekkoConsoleReporter(registry: PekkoMetricRegistry, verbose: Boolean, outp
     output.print("             count = %d%n".format(entry.getCount))
   }
 
-  private def printGauge(entry: Gauge[_]): Unit = {
+  private def printGauge(entry: Gauge[?]): Unit = {
     output.print("             value = %s%n".format(entry.getValue))
   }
 
@@ -168,7 +168,7 @@ class PekkoConsoleReporter(registry: PekkoMetricRegistry, verbose: Boolean, outp
   }
 
   /** Required for getting simple names of refined instances */
-  private def simpleName(clazz: Class[_]): String = {
+  private def simpleName(clazz: Class[?]): String = {
     val n = clazz.getName
     val i = n.lastIndexOf('.')
     n.substring(i + 1)


### PR DESCRIPTION
Motivation:
Test and migrate code to use `?`.

known issue: https://github.com/VirtusLab/scala-cli/issues/2684

Note: this pr is for testing


background: https://github.com/apache/incubator-pekko/pull/878
```
[error] -- Error: /home/runner/work/incubator-pekko/incubator-pekko/actor/src/main/scala/org/apache/pekko/actor/TypedActor.scala:277:38 
[error] 277 |      interfaces: immutable.Seq[Class[_]])
[error]     |                                      ^
[error]     |`_` is deprecated for wildcard arguments of types: use `?` instead
[error]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
```