### PR TITLE
additional mailbox selector for typed props

### DIFF
--- a/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/DispatchersDocTest.java
+++ b/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/DispatchersDocTest.java
@@ -36,19 +36,20 @@ public class DispatchersDocTest {
     context.spawn(
         behavior,
         "ExplicitDefaultDispatcher",
-        DispatcherSelector.defaultDispatcher().withMailboxFromConfig("your-mailbox"));
+        DispatcherSelector.defaultDispatcher().withMailboxFromConfig("my-app.my-special-mailbox"));
     context.spawn(
         behavior,
         "BlockingDispatcher",
-        DispatcherSelector.blocking().withMailboxFromConfig("your-mailbox"));
+        DispatcherSelector.blocking().withMailboxFromConfig("my-app.my-special-mailbox"));
     context.spawn(
         behavior,
         "ParentDispatcher",
-        DispatcherSelector.sameAsParent().withMailboxFromConfig("your-mailbox"));
+        DispatcherSelector.sameAsParent().withMailboxFromConfig("my-app.my-special-mailbox"));
     context.spawn(
         behavior,
         "DispatcherFromConfig",
-        DispatcherSelector.fromConfig("your-dispatcher").withMailboxFromConfig("your-mailbox"));
+        DispatcherSelector.fromConfig("your-dispatcher")
+            .withMailboxFromConfig("my-app.my-special-mailbox"));
     // #interoperability-with-mailbox
   }
 }

--- a/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/DispatchersDocTest.java
+++ b/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/DispatchersDocTest.java
@@ -29,4 +29,26 @@ public class DispatchersDocTest {
         behavior, "DispatcherFromConfig", DispatcherSelector.fromConfig("your-dispatcher"));
     // #spawn-dispatcher
   }
+
+  public static void spawnDispatchersWithInteroperability(
+      ActorContext<Integer> context, Behavior<String> behavior) {
+    // #interoperability-with-mailbox
+    context.spawn(
+        behavior,
+        "ExplicitDefaultDispatcher",
+        DispatcherSelector.defaultDispatcher().withMailboxFromConfig("your-mailbox"));
+    context.spawn(
+        behavior,
+        "BlockingDispatcher",
+        DispatcherSelector.blocking().withMailboxFromConfig("your-mailbox"));
+    context.spawn(
+        behavior,
+        "ParentDispatcher",
+        DispatcherSelector.sameAsParent().withMailboxFromConfig("your-mailbox"));
+    context.spawn(
+        behavior,
+        "DispatcherFromConfig",
+        DispatcherSelector.fromConfig("your-dispatcher").withMailboxFromConfig("your-mailbox"));
+    // #interoperability-with-mailbox
+  }
 }

--- a/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/MailboxDocTest.java
+++ b/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/MailboxDocTest.java
@@ -78,7 +78,7 @@ public class MailboxDocTest extends JUnitSuite {
                   childBehavior,
                   "from-config-mailbox-child",
                   MailboxSelector.fromConfig("my-app.my-special-mailbox")
-                      .withMailboxFromConfig("custom-dispatcher"));
+                      .withMailboxFromConfig("your-dispatcher"));
               // #interoperability-with-dispatcher
 
               testProbe.ref().tell(Done.getInstance());

--- a/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/MailboxDocTest.java
+++ b/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/MailboxDocTest.java
@@ -59,4 +59,33 @@ public class MailboxDocTest extends JUnitSuite {
     ActorRef<Void> ref = testKit.spawn(setup);
     testProbe.receiveMessage();
   }
+
+  @Test
+  public void startSomeActorsWithMailboxSelectorInteroperability() {
+    TestProbe<Done> testProbe = testKit.createTestProbe();
+    Behavior<String> childBehavior = Behaviors.empty();
+
+    Behavior<Void> setup =
+        Behaviors.setup(
+            context -> {
+              // #interoperability-with-dispatcher
+              context.spawn(
+                  childBehavior,
+                  "bounded-mailbox-child",
+                  MailboxSelector.bounded(100).withDispatcherDefault());
+
+              context.spawn(
+                  childBehavior,
+                  "from-config-mailbox-child",
+                  MailboxSelector.fromConfig("my-app.my-special-mailbox")
+                      .withMailboxFromConfig("custom-dispatcher"));
+              // #interoperability-with-dispatcher
+
+              testProbe.ref().tell(Done.getInstance());
+              return Behaviors.stopped();
+            });
+
+    ActorRef<Void> ref = testKit.spawn(setup);
+    testProbe.receiveMessage();
+  }
 }

--- a/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/MailboxDocTest.java
+++ b/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/MailboxDocTest.java
@@ -19,6 +19,7 @@ import org.apache.pekko.actor.testkit.typed.javadsl.TestKitJunitResource;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
+import org.apache.pekko.actor.typed.Dispatchers;
 import org.apache.pekko.actor.typed.MailboxSelector;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
 import com.typesafe.config.ConfigFactory;
@@ -78,7 +79,7 @@ public class MailboxDocTest extends JUnitSuite {
                   childBehavior,
                   "from-config-mailbox-child",
                   MailboxSelector.fromConfig("my-app.my-special-mailbox")
-                      .withMailboxFromConfig("your-dispatcher"));
+                      .withDispatcherFromConfig(Dispatchers.DefaultDispatcherId()));
               // #interoperability-with-dispatcher
 
               testProbe.ref().tell(Done.getInstance());

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/DispatchersDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/DispatchersDocSpec.scala
@@ -65,6 +65,24 @@ object DispatchersDocSpec {
     Behaviors.same
   }
 
+  val interoperableExample = Behaviors.receive[Any] { (context, _) =>
+    // #interoperability-with-mailbox
+    import org.apache.pekko.actor.typed.DispatcherSelector
+
+    context.spawn(yourBehavior, "DefaultDispatcher")
+    context.spawn(yourBehavior, "ExplicitDefaultDispatcher",
+      DispatcherSelector.default().withMailboxFromConfig("your-mailbox"))
+    context.spawn(yourBehavior, "BlockingDispatcher",
+      DispatcherSelector.blocking().withMailboxFromConfig("your-mailbox"))
+    context.spawn(yourBehavior, "ParentDispatcher",
+      DispatcherSelector.sameAsParent().withMailboxFromConfig("your-mailbox"))
+    context.spawn(yourBehavior, "DispatcherFromConfig",
+      DispatcherSelector.fromConfig("your-dispatcher").withMailboxFromConfig("your-mailbox"))
+    // #interoperability-with-mailbox
+
+    Behaviors.same
+  }
+
 }
 
 class DispatchersDocSpec

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/DispatchersDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/DispatchersDocSpec.scala
@@ -40,6 +40,9 @@ object DispatchersDocSpec {
         throughput = 1
       }
        //#config
+      your-mailbox {
+        mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
+      }
     """.stripMargin)
 
   case class WhichDispatcher(replyTo: ActorRef[Dispatcher])
@@ -71,13 +74,13 @@ object DispatchersDocSpec {
 
     context.spawn(yourBehavior, "DefaultDispatcher")
     context.spawn(yourBehavior, "ExplicitDefaultDispatcher",
-      DispatcherSelector.default().withMailboxFromConfig("my-app.my-special-mailbox"))
+      DispatcherSelector.default().withMailboxFromConfig("your-mailbox"))
     context.spawn(yourBehavior, "BlockingDispatcher",
-      DispatcherSelector.blocking().withMailboxFromConfig("my-app.my-special-mailbox"))
+      DispatcherSelector.blocking().withMailboxFromConfig("your-mailbox"))
     context.spawn(yourBehavior, "ParentDispatcher",
-      DispatcherSelector.sameAsParent().withMailboxFromConfig("my-app.my-special-mailbox"))
+      DispatcherSelector.sameAsParent().withMailboxFromConfig("your-mailbox"))
     context.spawn(yourBehavior, "DispatcherFromConfig",
-      DispatcherSelector.fromConfig("your-dispatcher").withMailboxFromConfig("my-app.my-special-mailbox"))
+      DispatcherSelector.fromConfig("your-dispatcher").withMailboxFromConfig("your-mailbox"))
     // #interoperability-with-mailbox
 
     Behaviors.same
@@ -86,8 +89,7 @@ object DispatchersDocSpec {
 }
 
 class DispatchersDocSpec
-    extends ScalaTestWithActorTestKit(
-      DispatchersDocSpec.config.withFallback(ConfigFactory.load("mailbox-config-sample.conf")))
+    extends ScalaTestWithActorTestKit(DispatchersDocSpec.config)
     with AnyWordSpecLike
     with LogCapturing {
 

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/DispatchersDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/DispatchersDocSpec.scala
@@ -71,13 +71,13 @@ object DispatchersDocSpec {
 
     context.spawn(yourBehavior, "DefaultDispatcher")
     context.spawn(yourBehavior, "ExplicitDefaultDispatcher",
-      DispatcherSelector.default().withMailboxFromConfig("your-mailbox"))
+      DispatcherSelector.default().withMailboxFromConfig("my-app.my-special-mailbox"))
     context.spawn(yourBehavior, "BlockingDispatcher",
-      DispatcherSelector.blocking().withMailboxFromConfig("your-mailbox"))
+      DispatcherSelector.blocking().withMailboxFromConfig("my-app.my-special-mailbox"))
     context.spawn(yourBehavior, "ParentDispatcher",
-      DispatcherSelector.sameAsParent().withMailboxFromConfig("your-mailbox"))
+      DispatcherSelector.sameAsParent().withMailboxFromConfig("my-app.my-special-mailbox"))
     context.spawn(yourBehavior, "DispatcherFromConfig",
-      DispatcherSelector.fromConfig("your-dispatcher").withMailboxFromConfig("your-mailbox"))
+      DispatcherSelector.fromConfig("your-dispatcher").withMailboxFromConfig("my-app.my-special-mailbox"))
     // #interoperability-with-mailbox
 
     Behaviors.same
@@ -86,7 +86,8 @@ object DispatchersDocSpec {
 }
 
 class DispatchersDocSpec
-    extends ScalaTestWithActorTestKit(DispatchersDocSpec.config)
+    extends ScalaTestWithActorTestKit(
+      DispatchersDocSpec.config.withFallback(ConfigFactory.load("mailbox-config-sample.conf")))
     with AnyWordSpecLike
     with LogCapturing {
 

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/MailboxDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/MailboxDocSpec.scala
@@ -47,6 +47,28 @@ class MailboxDocSpec
 
       probe.receiveMessage()
     }
+
+    "interoperability with DispatcherSelector" in {
+
+      val probe = createTestProbe[Done]()
+      val childBehavior: Behavior[String] = Behaviors.empty
+      val parent: Behavior[Unit] = Behaviors.setup { context =>
+        // #interoperability-with-dispatcher
+        context.spawn(childBehavior, "bounded-mailbox-child", MailboxSelector.bounded(100).withDispatcherDefault)
+
+        val props =
+          MailboxSelector.fromConfig("my-app.my-special-mailbox").withDispatcherFromConfig("custom-dispatcher")
+        context.spawn(childBehavior, "from-config-mailbox-child", props)
+        // #interoperability-with-dispatcher
+
+        probe.ref ! Done
+        Behaviors.stopped
+      }
+      spawn(parent)
+
+      probe.receiveMessage()
+
+    }
   }
 
 }

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/MailboxDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/MailboxDocSpec.scala
@@ -24,7 +24,8 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class MailboxDocSpec
-    extends ScalaTestWithActorTestKit(ConfigFactory.load("mailbox-config-sample.conf"))
+    extends ScalaTestWithActorTestKit(
+      ConfigFactory.load("mailbox-config-sample.conf").withFallback(DispatchersDocSpec.config))
     with AnyWordSpecLike
     with LogCapturing {
 
@@ -57,7 +58,7 @@ class MailboxDocSpec
         context.spawn(childBehavior, "bounded-mailbox-child", MailboxSelector.bounded(100).withDispatcherDefault)
 
         val props =
-          MailboxSelector.fromConfig("my-app.my-special-mailbox").withDispatcherFromConfig("custom-dispatcher")
+          MailboxSelector.fromConfig("my-app.my-special-mailbox").withDispatcherFromConfig("your-dispatcher")
         context.spawn(childBehavior, "from-config-mailbox-child", props)
         // #interoperability-with-dispatcher
 

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/MailboxDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/MailboxDocSpec.scala
@@ -18,10 +18,10 @@ import pekko.Done
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
 import pekko.actor.typed.Behavior
+import pekko.actor.typed.Dispatchers
 import pekko.actor.typed.MailboxSelector
 import pekko.actor.typed.scaladsl.Behaviors
 import com.typesafe.config.ConfigFactory
-import org.apache.pekko.actor.typed.Dispatchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class MailboxDocSpec

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/MailboxDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/MailboxDocSpec.scala
@@ -21,11 +21,11 @@ import pekko.actor.typed.Behavior
 import pekko.actor.typed.MailboxSelector
 import pekko.actor.typed.scaladsl.Behaviors
 import com.typesafe.config.ConfigFactory
+import org.apache.pekko.actor.typed.Dispatchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class MailboxDocSpec
-    extends ScalaTestWithActorTestKit(
-      ConfigFactory.load("mailbox-config-sample.conf").withFallback(DispatchersDocSpec.config))
+    extends ScalaTestWithActorTestKit(ConfigFactory.load("mailbox-config-sample.conf"))
     with AnyWordSpecLike
     with LogCapturing {
 
@@ -58,7 +58,8 @@ class MailboxDocSpec
         context.spawn(childBehavior, "bounded-mailbox-child", MailboxSelector.bounded(100).withDispatcherDefault)
 
         val props =
-          MailboxSelector.fromConfig("my-app.my-special-mailbox").withDispatcherFromConfig("your-dispatcher")
+          MailboxSelector.fromConfig("my-app.my-special-mailbox").withDispatcherFromConfig(
+            Dispatchers.DefaultDispatcherId)
         context.spawn(childBehavior, "from-config-mailbox-child", props)
         // #interoperability-with-dispatcher
 

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/DispatcherSelectorSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/DispatcherSelectorSpec.scala
@@ -17,9 +17,9 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.apache.pekko
-import org.apache.pekko.actor.typed.DispatcherSelector
-import org.apache.pekko.actor.typed.Props
-import org.apache.pekko.actor.typed.scaladsl.AskPattern._
+import pekko.actor.typed.DispatcherSelector
+import pekko.actor.typed.Props
+import pekko.actor.typed.scaladsl.AskPattern._
 import pekko.actor.BootstrapSetup
 import pekko.actor.setup.ActorSystemSetup
 import pekko.actor.testkit.typed.scaladsl.ActorTestKit

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/DispatcherSelectorSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/DispatcherSelectorSpec.scala
@@ -16,10 +16,8 @@ package org.apache.pekko.actor.typed.scaladsl
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
+
 import org.apache.pekko
-import pekko.actor.typed.DispatcherSelector
-import pekko.actor.typed.Props
-import pekko.actor.typed.scaladsl.AskPattern._
 import pekko.actor.BootstrapSetup
 import pekko.actor.setup.ActorSystemSetup
 import pekko.actor.testkit.typed.scaladsl.ActorTestKit
@@ -30,6 +28,9 @@ import pekko.actor.testkit.typed.scaladsl.TestProbe
 import pekko.actor.typed.ActorRef
 import pekko.actor.typed.ActorSystem
 import pekko.actor.typed.Behavior
+import pekko.actor.typed.DispatcherSelector
+import pekko.actor.typed.Props
+import pekko.actor.typed.scaladsl.AskPattern._
 import pekko.actor.typed.SpawnProtocol
 
 object DispatcherSelectorSpec {

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/DispatcherSelectorSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/DispatcherSelectorSpec.scala
@@ -18,6 +18,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.apache.pekko
 import org.apache.pekko.actor.typed.DispatcherSelector
+import org.apache.pekko.actor.typed.Props
 import org.apache.pekko.actor.typed.scaladsl.AskPattern._
 import pekko.actor.BootstrapSetup
 import pekko.actor.setup.ActorSystemSetup
@@ -32,8 +33,7 @@ import pekko.actor.typed.Behavior
 import pekko.actor.typed.SpawnProtocol
 
 object DispatcherSelectorSpec {
-  val config = ConfigFactory.parseString(
-    """
+  val config = ConfigFactory.parseString("""
       ping-pong-dispatcher {
         executor = thread-pool-executor
         type = PinnedDispatcher
@@ -42,7 +42,6 @@ object DispatcherSelectorSpec {
 
   object PingPong {
     case class Ping(replyTo: ActorRef[Pong])
-
     case class Pong(threadName: String)
 
     def apply(): Behavior[Ping] =
@@ -59,7 +58,6 @@ class DispatcherSelectorSpec(config: Config)
     extends ScalaTestWithActorTestKit(config)
     with AnyWordSpecLike
     with LogCapturing {
-
   import DispatcherSelectorSpec.PingPong
   import DispatcherSelectorSpec.PingPong._
 
@@ -69,7 +67,7 @@ class DispatcherSelectorSpec(config: Config)
 
     "select dispatcher from empty Props" in {
       val probe = createTestProbe[Pong]()
-      val pingPong = spawn(PingPong(), DispatcherSelector.fromConfig("ping-pong-dispatcher"))
+      val pingPong = spawn(PingPong(), Props.empty.withDispatcherFromConfig("ping-pong-dispatcher"))
       pingPong ! Ping(probe.ref)
 
       val response = probe.receiveMessage()

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/MailboxSelectorSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/MailboxSelectorSpec.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.actor.typed.scaladsl
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko.actor.ActorCell
+import org.apache.pekko.actor.testkit.typed.scaladsl.LogCapturing
+import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko.actor.typed.ActorRef
+import org.apache.pekko.actor.typed.Behavior
+import org.apache.pekko.actor.typed.DispatcherSelector
+import org.apache.pekko.actor.typed.MailboxSelector
+import org.apache.pekko.actor.typed.Props
+import org.apache.pekko.actor.typed.internal.adapter.ActorContextAdapter
+import org.apache.pekko.actor.typed.scaladsl.AskPattern._
+import org.apache.pekko.dispatch.BoundedMessageQueueSemantics
+import org.apache.pekko.dispatch.BoundedNodeMessageQueue
+import org.apache.pekko.dispatch.Dispatchers
+import org.apache.pekko.dispatch.MessageQueue
+import org.apache.pekko.dispatch.NodeMessageQueue
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object MailboxSelectorSpec {
+  val config = ConfigFactory.parseString(
+    """
+      specific-mailbox {
+        mailbox-type = "org.apache.pekko.dispatch.NonBlockingBoundedMailbox"
+        mailbox-capacity = 4
+      }
+    """)
+
+  object PingPong {
+    case class Ping(replyTo: ActorRef[Pong])
+
+    case class Pong(threadName: String)
+
+    def apply(): Behavior[Ping] =
+      Behaviors.receiveMessage[Ping] { message =>
+        message.replyTo ! Pong(Thread.currentThread().getName)
+        Behaviors.same
+      }
+
+  }
+
+}
+
+class MailboxSelectorSpec(config: Config)
+    extends ScalaTestWithActorTestKit(config)
+    with AnyWordSpecLike
+    with LogCapturing {
+
+  def this() = this(MailboxSelectorSpec.config)
+
+  sealed trait Command
+  case class WhatsYourMailbox(replyTo: ActorRef[MessageQueue]) extends Command
+  case class WhatsYourDispatcher(replyTo: ActorRef[String]) extends Command
+
+  private def extract[R](context: ActorContext[_], f: ActorCell => R): R = {
+    context match {
+      case adapter: ActorContextAdapter[_] =>
+        adapter.classicActorContext match {
+          case cell: ActorCell => f(cell)
+          case unexpected      => throw new RuntimeException(s"Unexpected: $unexpected")
+        }
+      case unexpected => throw new RuntimeException(s"Unexpected: $unexpected")
+    }
+  }
+
+  private def behavior: Behavior[Command] =
+    Behaviors.setup { context =>
+      Behaviors.receiveMessage[Command] {
+        case WhatsYourMailbox(replyTo) =>
+          replyTo ! extract(context, cell => cell.mailbox.messageQueue)
+          Behaviors.same
+        case WhatsYourDispatcher(replyTo) =>
+          replyTo ! extract(context, cell => cell.dispatcher.id)
+          Behaviors.same
+      }
+    }
+
+  "MailboxSelectorSpec" must {
+
+    "default is unbounded" in {
+      val actor = spawn(behavior)
+      val mailbox = actor.ask(WhatsYourMailbox(_)).futureValue
+      mailbox shouldBe a[NodeMessageQueue]
+    }
+
+    "select an specific mailbox from MailboxSelector " in {
+      val actor = spawn(behavior, MailboxSelector.fromConfig("specific-mailbox"))
+      val mailbox = actor.ask(WhatsYourMailbox(_)).futureValue
+      mailbox shouldBe a[BoundedMessageQueueSemantics]
+      mailbox.asInstanceOf[BoundedNodeMessageQueue].capacity should ===(4)
+    }
+
+    "select an specific mailbox from empty Props " in {
+      val actor = spawn(behavior, Props.empty.withMailboxFromConfig("specific-mailbox"))
+      val mailbox = actor.ask(WhatsYourMailbox(_)).futureValue
+      mailbox shouldBe a[BoundedMessageQueueSemantics]
+      mailbox.asInstanceOf[BoundedNodeMessageQueue].capacity should ===(4)
+    }
+
+    "select an specific mailbox from DispatcherSelector " in {
+      val actor = spawn(behavior, DispatcherSelector.blocking().withMailboxFromConfig("specific-mailbox"))
+      val mailbox = actor.ask(WhatsYourMailbox(_)).futureValue
+      mailbox shouldBe a[BoundedMessageQueueSemantics]
+      mailbox.asInstanceOf[BoundedNodeMessageQueue].capacity should ===(4)
+      val dispatcher = actor.ask(WhatsYourDispatcher(_)).futureValue
+      dispatcher shouldBe Dispatchers.DefaultBlockingDispatcherId
+    }
+
+  }
+
+}

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/MailboxSelectorSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/MailboxSelectorSpec.scala
@@ -19,21 +19,22 @@ package org.apache.pekko.actor.typed.scaladsl
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.apache.pekko.actor.ActorCell
-import org.apache.pekko.actor.testkit.typed.scaladsl.LogCapturing
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import org.apache.pekko.actor.typed.ActorRef
-import org.apache.pekko.actor.typed.Behavior
-import org.apache.pekko.actor.typed.DispatcherSelector
-import org.apache.pekko.actor.typed.MailboxSelector
-import org.apache.pekko.actor.typed.Props
-import org.apache.pekko.actor.typed.internal.adapter.ActorContextAdapter
-import org.apache.pekko.actor.typed.scaladsl.AskPattern._
-import org.apache.pekko.dispatch.BoundedMessageQueueSemantics
-import org.apache.pekko.dispatch.BoundedNodeMessageQueue
-import org.apache.pekko.dispatch.Dispatchers
-import org.apache.pekko.dispatch.MessageQueue
-import org.apache.pekko.dispatch.NodeMessageQueue
+import org.apache.pekko
+import pekko.actor.ActorCell
+import pekko.actor.testkit.typed.scaladsl.LogCapturing
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import pekko.actor.typed.ActorRef
+import pekko.actor.typed.Behavior
+import pekko.actor.typed.DispatcherSelector
+import pekko.actor.typed.MailboxSelector
+import pekko.actor.typed.Props
+import pekko.actor.typed.internal.adapter.ActorContextAdapter
+import pekko.actor.typed.scaladsl.AskPattern._
+import pekko.dispatch.BoundedMessageQueueSemantics
+import pekko.dispatch.BoundedNodeMessageQueue
+import pekko.dispatch.Dispatchers
+import pekko.dispatch.MessageQueue
+import pekko.dispatch.NodeMessageQueue
 import org.scalatest.wordspec.AnyWordSpecLike
 
 object MailboxSelectorSpec {

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/MailboxSelectorSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/MailboxSelectorSpec.scala
@@ -19,6 +19,8 @@ package org.apache.pekko.actor.typed.scaladsl
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
 import org.apache.pekko
 import pekko.actor.ActorCell
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
@@ -35,7 +37,6 @@ import pekko.dispatch.BoundedNodeMessageQueue
 import pekko.dispatch.Dispatchers
 import pekko.dispatch.MessageQueue
 import pekko.dispatch.NodeMessageQueue
-import org.scalatest.wordspec.AnyWordSpecLike
 
 object MailboxSelectorSpec {
   val config = ConfigFactory.parseString(

--- a/actor-typed/src/main/resources/reference.conf
+++ b/actor-typed/src/main/resources/reference.conf
@@ -26,7 +26,7 @@ pekko.actor.typed {
   # buffer. If the capacity is exceed then additional incoming messages are dropped.
   restart-stash-capacity = 1000
 
-  # Typed mailbox defaults to the single consumber mailbox as balancing dispatcher is not supported
+  # Typed mailbox defaults to the single consumer mailbox as balancing dispatcher is not supported
   default-mailbox {
     mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
   }
@@ -73,7 +73,7 @@ pekko.reliable-delivery {
     # To avoid head of line blocking from serialization and transfer
     # of large messages this can be enabled.
     # Large messages are chunked into pieces of the given size in bytes. The
-    # chunked messages are sent separatetely and assembled on the consumer side.
+    # chunked messages are sent separately and assembled on the consumer side.
     # Serialization and deserialization is performed by the ProducerController and
     # ConsumerController respectively instead of in the remote transport layer.
     chunk-large-messages = off

--- a/actor-typed/src/main/resources/reference.conf
+++ b/actor-typed/src/main/resources/reference.conf
@@ -26,7 +26,7 @@ pekko.actor.typed {
   # buffer. If the capacity is exceed then additional incoming messages are dropped.
   restart-stash-capacity = 1000
 
-  # Typed mailbox defaults to the single consumer mailbox as balancing dispatcher is not supported
+  # Typed mailbox defaults to the single consumber mailbox as balancing dispatcher is not supported
   default-mailbox {
     mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
   }
@@ -73,7 +73,7 @@ pekko.reliable-delivery {
     # To avoid head of line blocking from serialization and transfer
     # of large messages this can be enabled.
     # Large messages are chunked into pieces of the given size in bytes. The
-    # chunked messages are sent separately and assembled on the consumer side.
+    # chunked messages are sent separatetely and assembled on the consumer side.
     # Serialization and deserialization is performed by the ProducerController and
     # ConsumerController respectively instead of in the remote transport layer.
     chunk-large-messages = off

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/Props.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/Props.scala
@@ -85,6 +85,7 @@ abstract class Props private[pekko] () extends Product with Serializable {
    * Prepend a selection of the mailbox found at the given Config path to this Props.
    * The path is relative to the configuration root of the [[ActorSystem]] that looks up the
    * mailbox.
+   * @since 1.1.0
    */
   def withMailboxFromConfig(path: String): Props = MailboxFromConfigSelector(path, this)
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/Props.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/Props.scala
@@ -82,6 +82,13 @@ abstract class Props private[pekko] () extends Product with Serializable {
   def withDispatcherFromConfig(path: String): Props = DispatcherFromConfig(path, this)
 
   /**
+   * Prepend a selection of the mailbox found at the given Config path to this Props.
+   * The path is relative to the configuration root of the [[ActorSystem]] that looks up the
+   * mailbox.
+   */
+  def withMailboxFromConfig(path: String): Props = MailboxFromConfigSelector(path, this)
+
+  /**
    * Prepend a selection of the same executor as the parent actor to this Props.
    */
   def withDispatcherSameAsParent: Props = DispatcherSameAsParent(this)

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -323,8 +323,8 @@ pekko {
           # Probability of doing an exploration v.s. optimization.
           chance-of-exploration = 0.4
 
-          # When downsizing after a long streak of under-utilization, the resizer
-          # will downsize the pool to the highest utilization multiplied by a
+          # When downsizing after a long streak of underutilization, the resizer
+          # will downsize the pool to the highest utiliziation multiplied by a
           # a downsize ratio. This downsize ratio determines the new pools size
           # in comparison to the highest utilization.
           # E.g. if the highest utilization is 10, and the down size ratio
@@ -1349,7 +1349,7 @@ pekko {
       # In order to skip this additional delay set as 0
       random-factor = 0.0
 
-      # A allow-list of fqcn of Exceptions that the CircuitBreaker
+      # A allowlist of fqcn of Exceptions that the CircuitBreaker
       # should not consider failures. By default all exceptions are
       # considered failures.
       exception-allowlist = []

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -323,8 +323,8 @@ pekko {
           # Probability of doing an exploration v.s. optimization.
           chance-of-exploration = 0.4
 
-          # When downsizing after a long streak of underutilization, the resizer
-          # will downsize the pool to the highest utiliziation multiplied by a
+          # When downsizing after a long streak of under-utilization, the resizer
+          # will downsize the pool to the highest utilization multiplied by a
           # a downsize ratio. This downsize ratio determines the new pools size
           # in comparison to the highest utilization.
           # E.g. if the highest utilization is 10, and the down size ratio
@@ -1349,7 +1349,7 @@ pekko {
       # In order to skip this additional delay set as 0
       random-factor = 0.0
 
-      # A allowlist of fqcn of Exceptions that the CircuitBreaker
+      # A allow-list of fqcn of Exceptions that the CircuitBreaker
       # should not consider failures. By default all exceptions are
       # considered failures.
       exception-allowlist = []

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -324,7 +324,7 @@ pekko {
           chance-of-exploration = 0.4
 
           # When downsizing after a long streak of under-utilization, the resizer
-          # will downsize the pool to the highest utilization multiplied by a
+          # will downsize the pool to the highest utilization multiplied by
           # a downsize ratio. This downsize ratio determines the new pools size
           # in comparison to the highest utilization.
           # E.g. if the highest utilization is 10, and the down size ratio

--- a/docs/src/main/paradox/typed/dispatchers.md
+++ b/docs/src/main/paradox/typed/dispatchers.md
@@ -55,7 +55,7 @@ A default dispatcher is used for all actors that are spawned without specifying 
 This is suitable for all actors that don't block. Blocking in actors needs to be carefully managed, more
 details @ref:[here](#blocking-needs-careful-management).
 
-To select a dispatcher use `DispatcherSelector` to create a `Props` instance for spawning your actor:
+To select a dispatcher use @apidoc[DispatcherSelector](DispatcherSelector$)  to create a @apidoc[Props](typed.Props) instance for spawning your actor:
 
 Scala
 :  @@snip [DispatcherDocSpec.scala](/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/DispatchersDocSpec.scala) { #spawn-dispatcher }
@@ -73,6 +73,17 @@ The final example shows how to load a custom dispatcher from configuration and r
 
 <!-- Same between Java and Scala -->
 @@snip [DispatcherDocSpec.scala](/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/DispatchersDocSpec.scala) { #config }
+
+### Interoperability with MailboxSelector
+
+The @apidoc[DispatcherSelector](DispatcherSelector$) will create a @apidoc[Props](typed.Props) instance that can be both set up Dispatcher and Mailbox, 
+which means that you can continue to set up Mailbox through chain calls.
+
+Scala
+:  @@snip [DispatcherDocSpec.scala](/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/DispatchersDocSpec.scala) { #interoperability-with-mailbox }
+
+Java
+:  @@snip [DispatcherDocTest.java](/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/DispatchersDocTest.java) { #interoperability-with-mailbox }
 
 ## Types of dispatchers
 

--- a/docs/src/main/paradox/typed/mailboxes.md
+++ b/docs/src/main/paradox/typed/mailboxes.md
@@ -58,6 +58,17 @@ configuration section from the @apidoc[ActorSystem](typed.ActorSystem) configura
 `id` key with the configuration path of the mailbox type and adding a
 fall-back to the default mailbox configuration section.
 
+### Interoperability with DispatcherSelector
+
+The @apidoc[MailboxSelector](MailboxSelector$) will create a @apidoc[Props](typed.Props) instance that can be both set up Dispatcher and Mailbox,
+which means that you can continue to set up Dispatcher through chain calls.
+
+Scala
+:  @@snip [MailboxDocSpec.scala](/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/MailboxDocSpec.scala) { #interoperability-with-dispatcher }
+
+Java
+:  @@snip [MailboxDocTest.java](/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/MailboxDocTest.java) { #interoperability-with-dispatcher }
+
 ## Mailbox Implementations
 
 Pekko ships with a number of mailbox implementations:


### PR DESCRIPTION
## Motivation

I have experience in migrating Classic to Typed. In the process, I found that Typed can't customize Mailbox through Props. We should match the same Classic method on Typed.

<img width="790" alt="截屏2024-02-03 17 03 39" src="https://github.com/apache/incubator-pekko/assets/26020358/dd1bfc1c-4c2b-4926-b54a-3e7129038428">


## TODO list
- [x] Implementation: Reuse existing classes
- [x] Mention in documentation
- [x] Verify via unit test