### PR TITLE
chore: Skip genjavadoc on Scala 3.3

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Docs
         # Docs generation requires JDK 11.
-        if: ${{ matrix.javaVersion == 11 }}
+        if: ${{ matrix.javaVersion == 11 && matrix.scalaVersion != '3.3'}}
         run: |-
           sudo apt-get install graphviz
           sbt \


### PR DESCRIPTION
Motivation:
The genjavadoc doesn't support Scala 3.3 for now.

Result:
Sucess nightly build on Scala 3.3 && JDK 11