### PR TITLE
Fix mustBeAbleToUseMapWithAutoCloseableResource broken test

### DIFF
--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
@@ -239,7 +239,7 @@ public class FlowTest extends StreamTest {
   }
 
   @Test
-  public void mustBeAbleToUseMapWithAutoCloseableResource() {
+  public void mustBeAbleToUseMapWithAutoCloseableResource() throws Exception {
     final TestKit probe = new TestKit(system);
     final AtomicInteger closed = new AtomicInteger();
     Source.from(Arrays.asList("1", "2", "3"))
@@ -247,7 +247,9 @@ public class FlowTest extends StreamTest {
             Flow.of(String.class)
                 .mapWithResource(
                     () -> (AutoCloseable) closed::incrementAndGet, (resource, elem) -> elem))
-        .runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), system);
+        .runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), system)
+        .toCompletableFuture()
+        .get(3, TimeUnit.SECONDS);
 
     probe.expectMsgAllOf("1", "2", "3");
     Assert.assertEquals(closed.get(), 1);

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -817,12 +817,14 @@ public class SourceTest extends StreamTest {
   }
 
   @Test
-  public void mustBeAbleToUseMapWithAutoCloseableResource() {
+  public void mustBeAbleToUseMapWithAutoCloseableResource() throws Exception {
     final TestKit probe = new TestKit(system);
     final AtomicInteger closed = new AtomicInteger();
     Source.from(Arrays.asList("1", "2", "3"))
         .mapWithResource(() -> (AutoCloseable) closed::incrementAndGet, (resource, elem) -> elem)
-        .runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), system);
+        .runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), system)
+        .toCompletableFuture()
+        .get(3, TimeUnit.SECONDS);
 
     probe.expectMsgAllOf("1", "2", "3");
     Assert.assertEquals(closed.get(), 1);


### PR DESCRIPTION
Closes #1229.

```java
  @Test
  public void mustBeAbleToUseMapWithAutoCloseableResource() {
    final TestKit probe = new TestKit(system);
    final AtomicInteger closed = new AtomicInteger();
    Source.from(Arrays.asList("1", "2", "3"))
        .via(
            Flow.of(String.class)
                .mapWithResource(
                    () -> (AutoCloseable) closed::incrementAndGet, (resource, elem) -> elem))
        .runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), system);

    probe.expectMsgAllOf("1", "2", "3");

    // FAILED: AssertionError: expected:<0> but was:<1>
    Assert.assertEquals(closed.get(), 1); // 👈👈 clean-up may not be processed yet here!
  }
```
I found that `AutoCloseable resource.close();` can be not invoked yet on above code so fix it~!