### PR TITLE
chore: Fix typo for Source.fromIterator operator.

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -102,7 +102,7 @@ object Source {
    * Source.from(() -> data.iterator());
    * }}}
    *
-   * Start a new `Source` from the given Iterator. The produced stream of elements
+   * Start a new `Source` from the given function that produces an Iterator. The produced stream of elements
    * will continue until the iterator runs empty or fails during evaluation of
    * the `next()` method. Elements are pulled out of the iterator
    * in accordance with the demand coming from the downstream transformation

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
@@ -272,7 +272,7 @@ object Source {
    * Helper to create [[Source]] from `Iterator`.
    * Example usage: `Source.fromIterator(() => Iterator.from(0))`
    *
-   * Start a new `Source` from the given function that produces anIterator.
+   * Start a new `Source` from the given function that produces an Iterator.
    * The produced stream of elements will continue until the iterator runs empty
    * or fails during evaluation of the `next()` method.
    * Elements are pulled out of the iterator in accordance with the demand coming


### PR DESCRIPTION
Motivation:
Fix typo in `Source.fromIterator`