### PR TITLE
feat: Java API for ExternalShardAllocationStrategy

### DIFF
--- a/cluster-sharding-typed/src/test/java/jdocs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
+++ b/cluster-sharding-typed/src/test/java/jdocs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
@@ -18,12 +18,14 @@ import org.apache.pekko.actor.Address;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.ActorSystem;
 import org.apache.pekko.cluster.sharding.external.ExternalShardAllocation;
+import org.apache.pekko.cluster.sharding.external.ExternalShardAllocationStrategy;
 import org.apache.pekko.cluster.sharding.external.javadsl.ExternalShardAllocationClient;
 import org.apache.pekko.cluster.sharding.typed.ShardingEnvelope;
 import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
 import org.apache.pekko.cluster.sharding.typed.javadsl.Entity;
 import org.apache.pekko.cluster.sharding.typed.javadsl.EntityTypeKey;
 
+import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 
 import static jdocs.org.apache.pekko.cluster.sharding.typed.ShardingCompileOnlyTest.Counter;
@@ -39,7 +41,11 @@ public class ExternalShardAllocationCompileOnlyTest {
     EntityTypeKey<Counter.Command> typeKey = EntityTypeKey.create(Counter.Command.class, "Counter");
 
     ActorRef<ShardingEnvelope<Counter.Command>> shardRegion =
-        sharding.init(Entity.of(typeKey, ctx -> Counter.create(ctx.getEntityId())));
+        sharding.init(
+            Entity.of(typeKey, ctx -> Counter.create(ctx.getEntityId()))
+                .withAllocationStrategy(
+                    ExternalShardAllocationStrategy.create(
+                        system, typeKey.name(), Duration.ofSeconds(5))));
     // #entity
 
     // #client

--- a/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlySpec.scala
+++ b/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlySpec.scala
@@ -38,7 +38,7 @@ class ExternalShardAllocationCompileOnlySpec {
   val TypeKey = EntityTypeKey[Counter.Command]("Counter")
 
   val entity = Entity(TypeKey)(createBehavior = entityContext => Counter(entityContext.entityId))
-    .withAllocationStrategy(new ExternalShardAllocationStrategy(system, TypeKey.name))
+    .withAllocationStrategy(ExternalShardAllocationStrategy(system, TypeKey.name))
   // #entity
 
   val shardRegion: ActorRef[ShardingEnvelope[Counter.Command]] =

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -119,7 +119,7 @@ object ExternalShardAllocationStrategy {
 
 class ExternalShardAllocationStrategy(systemProvider: ClassicActorSystemProvider, typeName: String)(
     // local only ask
-    implicit val timeout: Timeout)
+    implicit val timeout: Timeout = Timeout(5.seconds))
     extends ShardCoordinator.StartableAllocationStrategy {
 
   private val system = systemProvider.classicSystem

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.cluster.sharding.external
 
-import scala.annotation.varargs
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -47,11 +46,18 @@ object ExternalShardAllocationStrategy {
   type ShardRegion = ActorRef
 
   /**
-   * Scala API: Create an [[ExternalShardAllocationStrategy]]
+   * Create an [[ExternalShardAllocationStrategy]]
    */
-  def apply(systemProvider: ClassicActorSystemProvider, typeName: String)(
-      implicit timeout: Timeout = 5.seconds): ExternalShardAllocationStrategy =
+  def apply(
+      systemProvider: ClassicActorSystemProvider, typeName: String, timeout: Timeout): ExternalShardAllocationStrategy =
     new ExternalShardAllocationStrategy(systemProvider, typeName)(timeout)
+
+  /**
+   * Scala API: Create an [[ExternalShardAllocationStrategy]] with default timeout value.
+   */
+  def apply(systemProvider: ClassicActorSystemProvider, typeName: String)(implicit timeout: Timeout =
+        Timeout(5.seconds)): ExternalShardAllocationStrategy =
+    new ExternalShardAllocationStrategy(systemProvider, typeName)
 
   /**
    * Java API: Create an [[ExternalShardAllocationStrategy]]

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -40,6 +40,7 @@ import pekko.cluster.sharding.ShardRegion.ShardId
 import pekko.event.Logging
 import pekko.pattern.AskTimeoutException
 import pekko.util.Timeout
+import pekko.util.JavaDurationConverters._
 
 object ExternalShardAllocationStrategy {
 
@@ -55,10 +56,9 @@ object ExternalShardAllocationStrategy {
   /**
    * Java API: Create an [[ExternalShardAllocationStrategy]]
    */
-  @varargs
   def create(systemProvider: ClassicActorSystemProvider, typeName: String, duration: java.time.Duration)
       : ExternalShardAllocationStrategy =
-    this.apply(systemProvider, typeName)(Timeout.create(duration))
+    this.apply(systemProvider, typeName)(duration.asScala)
 
   // local only messages
   private[pekko] final case class GetShardLocation(shard: ShardId)

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -56,7 +56,8 @@ object ExternalShardAllocationStrategy {
   /**
    * Scala API: Create an [[ExternalShardAllocationStrategy]]
    */
-  def apply(systemProvider: ClassicActorSystemProvider, typeName: String, timeout: FiniteDuration): ExternalShardAllocationStrategy = {
+  def apply(systemProvider: ClassicActorSystemProvider, typeName: String, timeout: FiniteDuration)
+      : ExternalShardAllocationStrategy = {
     new ExternalShardAllocationStrategy(systemProvider, typeName)(timeout)
   }
 

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -48,23 +48,24 @@ object ExternalShardAllocationStrategy {
   /**
    * Create an [[ExternalShardAllocationStrategy]]
    */
-  def apply(
-      systemProvider: ClassicActorSystemProvider, typeName: String, timeout: Timeout): ExternalShardAllocationStrategy =
-    new ExternalShardAllocationStrategy(systemProvider, typeName)(timeout)
+  def apply(systemProvider: ClassicActorSystemProvider, typeName: String): ExternalShardAllocationStrategy = {
+    implicit val timeout: Timeout = 5.seconds
+    new ExternalShardAllocationStrategy(systemProvider, typeName)
+  }
 
   /**
-   * Scala API: Create an [[ExternalShardAllocationStrategy]] with default timeout value.
+   * Scala API: Create an [[ExternalShardAllocationStrategy]]
    */
-  def apply(systemProvider: ClassicActorSystemProvider, typeName: String)(implicit timeout: Timeout =
-        Timeout(5.seconds)): ExternalShardAllocationStrategy =
-    new ExternalShardAllocationStrategy(systemProvider, typeName)
+  def apply(systemProvider: ClassicActorSystemProvider, typeName: String, timeout: FiniteDuration): ExternalShardAllocationStrategy = {
+    new ExternalShardAllocationStrategy(systemProvider, typeName)(timeout)
+  }
 
   /**
    * Java API: Create an [[ExternalShardAllocationStrategy]]
    */
-  def create(systemProvider: ClassicActorSystemProvider, typeName: String, duration: java.time.Duration)
+  def create(systemProvider: ClassicActorSystemProvider, typeName: String, timeout: java.time.Duration)
       : ExternalShardAllocationStrategy =
-    this.apply(systemProvider, typeName)(duration.asScala)
+    this.apply(systemProvider, typeName, timeout.asScala)
 
   // local only messages
   private[pekko] final case class GetShardLocation(shard: ShardId)
@@ -117,7 +118,7 @@ object ExternalShardAllocationStrategy {
 
 class ExternalShardAllocationStrategy(systemProvider: ClassicActorSystemProvider, typeName: String)(
     // local only ask
-    implicit val timeout: Timeout = Timeout(5.seconds))
+    implicit val timeout: Timeout)
     extends ShardCoordinator.StartableAllocationStrategy {
 
   private val system = systemProvider.classicSystem

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -13,6 +13,7 @@
 
 package org.apache.pekko.cluster.sharding.external
 
+import scala.annotation.varargs
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -43,6 +44,21 @@ import pekko.util.Timeout
 object ExternalShardAllocationStrategy {
 
   type ShardRegion = ActorRef
+
+  /**
+   * Scala API: Create an [[ExternalShardAllocationStrategy]]
+   */
+  def apply(systemProvider: ClassicActorSystemProvider, typeName: String)(
+      implicit timeout: Timeout = 5.seconds): ExternalShardAllocationStrategy =
+    new ExternalShardAllocationStrategy(systemProvider, typeName)(timeout)
+
+  /**
+   * Java API: Create an [[ExternalShardAllocationStrategy]]
+   */
+  @varargs
+  def create(systemProvider: ClassicActorSystemProvider, typeName: String, duration: java.time.Duration)
+      : ExternalShardAllocationStrategy =
+    this.apply(systemProvider, typeName)(Timeout.create(duration))
 
   // local only messages
   private[pekko] final case class GetShardLocation(shard: ShardId)

--- a/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/ExternalShardAllocationSpec.scala
+++ b/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/ExternalShardAllocationSpec.scala
@@ -105,7 +105,7 @@ abstract class ExternalShardAllocationSpec
       entityProps = Props[GiveMeYourHome](),
       extractEntityId = extractEntityId,
       extractShardId = extractShardId,
-      allocationStrategy = new ExternalShardAllocationStrategy(system, typeName))
+      allocationStrategy = ExternalShardAllocationStrategy(system, typeName))
 
     "start cluster sharding" in {
       shardRegion


### PR DESCRIPTION
# Motivation

`ExternalShardAllocationStrategy` doesn't have a Java API, users have to use `pekko.util.TimeUnit ` rather than `java.time.Duration`

And the documentation also has an issue that doesn't specific AllocateStrategy, see: https://pekko.apache.org/docs/pekko/current/typed/cluster-sharding.html#external-shard-allocation



<img width="769" alt="截屏2024-04-01 15 49 39" src="https://github.com/apache/pekko/assets/26020358/01a15d70-d52b-4275-af0e-72a37ecc5a96">


