### PR TITLE
chore: Avoid copy the whole iterable for mapconcat oprerator in Javadsl.

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -744,9 +744,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    */
   def mapConcat[T](f: function.Function[Out, java.lang.Iterable[T]]): javadsl.Flow[In, T, Mat] =
-    new Flow(delegate.mapConcat { elem =>
-      Util.immutableSeq(f(elem))
-    })
+    new Flow(delegate.mapConcat(f(_).asScala))
 
   /**
    * Transform each stream element with the help of a state.
@@ -900,7 +898,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
       f: function.Creator[function.Function[Out, java.lang.Iterable[T]]]): javadsl.Flow[In, T, Mat] =
     new Flow(delegate.statefulMapConcat { () =>
       val fun = f.create()
-      elem => Util.immutableSeq(fun(elem))
+      elem => fun(elem).asScala
     })
 
   /**


### PR DESCRIPTION
Motivation:
Currently, it's using the `Util.immutableSeq` which will copy the whole value in the Java iterable and convert it to a vector.
Because in the MapConcat/StatefulMapConcat ops, only the underlying `iterator` is being used,  so I think we can use the JIteratorWrapper instead.

Result:
Avoid the copy