### PR TITLE
Remove ignore-opts-files arg in scala steward

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -20,4 +20,3 @@ jobs:
           github-app-installation-id: ${{ secrets.SCALA_STEWARD_INSTALLATION_ID }}
           github-app-key: ${{ secrets.SCALA_STEWARD_PRIVATE_KEY }}
           github-app-auth-only: true
-          ignore-opts-files: false


### PR DESCRIPTION
This is no longer needed since we are using `JAVA_OPTS`