### PR TITLE
we are not ignoring enough jackson modules (scala-steward)

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -10,13 +10,11 @@ updates.pin = [
 updates.ignore = [
   // these will get updated along with jackson-core, so no need to update them
   // separately
-  { groupId = "com.fasterxml.jackson.module", artifactId = "jackson-module-parameter-names" }
-  { groupId = "com.fasterxml.jackson.module", artifactId = "jackson-module-scala" }
   { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-annotations" }
   { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind" }
-  { groupId = "com.fasterxml.jackson.dataformat", artifactId = "jackson-dataformat-cbor" }
-  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jsr310" }
-  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" }
+  { groupId = "com.fasterxml.jackson.module" }
+  { groupId = "com.fasterxml.jackson.dataformat" }
+  { groupId = "com.fasterxml.jackson.datatype" }
   { groupId = "com.google.protobuf", artifactId = "protobuf-java" }
   { groupId = "com.typesafe", artifactId = "ssl-config-core" }
   { groupId = "org.agrona", artifactId = "agrona" }


### PR DESCRIPTION
Jackson 2.17.0 has some issues.

the current setup tries to focus on jackson-core and ignores updates on other jackson modules - there is one jacksonVersion param and ScalaSteward does not recognise that it creates lots of PRs to update the same value (one for each Jackson module)