### PR TITLE
chore: Remove vavr link.

### DIFF
--- a/docs/src/main/paradox/actors.md
+++ b/docs/src/main/paradox/actors.md
@@ -828,7 +828,7 @@ That has benefits such as:
 The @javadoc[Receive](pekko.actor.AbstractActor.Receive) can be implemented in other ways than using the `ReceiveBuilder` since in the
 end, it is just a wrapper around a Scala `PartialFunction`. In Java, you can implement `PartialFunction` by
 extending `AbstractPartialFunction`. For example, one could implement an adapter
-to [Vavr Pattern Matching DSL](https://docs.vavr.io/#_pattern_matching). See the [Akka Vavr sample project](https://github.com/akka/akka-samples/tree/2.5/akka-sample-vavr) for more details.
+to Vavr Pattern Matching DSL. See the [Akka Vavr sample project](https://github.com/akka/akka-samples/tree/2.5/akka-sample-vavr) for more details.
 
 If the validation of the `ReceiveBuilder` match logic turns out to be a bottleneck for some of your
 actors you can consider implementing it at a lower level by extending @javadoc[UntypedAbstractActor](pekko.actor.UntypedAbstractActor) instead

--- a/docs/src/main/paradox/typed/style-guide.md
+++ b/docs/src/main/paradox/typed/style-guide.md
@@ -467,7 +467,7 @@ be good to know that it's optional in case you would prefer a different approach
 * direct processing because there is only one message type
 * if or switch statements
 * annotation processor
-* [Vavr Pattern Matching DSL](https://docs.vavr.io/#_pattern_matching)
+* Vavr Pattern Matching DSL
 * pattern matching since JDK 14 ([JEP 305](https://openjdk.java.net/jeps/305))
 
 In `Behaviors` there are `receive`, `receiveMessage` and `receiveSignal` factory methods that takes functions


### PR DESCRIPTION
Motivation:
The vavr website is down and they don't plan to continue it for now. refs: https://github.com/vavr-io/vavr/issues/2756