### PR TITLE
chore: Fix ByteIterator indexWhere method

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -923,6 +923,11 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
           likeVector(a) { _.indexWhere(_ == b) }
         }
       }
+      "calling indexWhere(p, idx)" in {
+        check { (a: ByteString, b: Byte, idx: Int) =>
+          likeVector(a) { _.indexWhere(_ == b, math.max(0, idx)) }
+        }
+      }
       "calling indexOf" in {
         check { (a: ByteString, b: Byte) =>
           likeVector(a) { _.indexOf(b) }

--- a/actor/src/main/scala-2.12/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-2.12/org/apache/pekko/util/ByteIterator.scala
@@ -470,7 +470,7 @@ abstract class ByteIterator extends BufferedIterator[Byte] {
   override def indexWhere(p: Byte => Boolean): Int = indexWhere(p, 0)
   override def indexWhere(p: Byte => Boolean, from: Int): Int = {
     var index = 0
-    while (index < from) {
+    while (index < from && hasNext) {
       next()
       index += 1
     }

--- a/actor/src/main/scala-2.13/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-2.13/org/apache/pekko/util/ByteIterator.scala
@@ -486,7 +486,7 @@ abstract class ByteIterator extends BufferedIterator[Byte] {
 
   override def indexWhere(p: Byte => Boolean, from: Int = 0): Int = {
     var index = 0
-    while (index < from) {
+    while (index < from && hasNext) {
       next()
       index += 1
     }

--- a/actor/src/main/scala-3/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/ByteIterator.scala
@@ -482,7 +482,7 @@ abstract class ByteIterator extends BufferedIterator[Byte] {
 
   override def indexWhere(p: Byte => Boolean, from: Int = 0): Int = {
     var index = 0
-    while (index < from) {
+    while (index < from && hasNext) {
       next()
       index += 1
     }


### PR DESCRIPTION
`ByteIterator#indexWhere` was misbehaving when from was larger than the underlying iterator. This method was also called by `ByteIterator#indexOf` and `ByteString#indexWhere`, so those were all wrong.

~~This PR also changes the comparison order in `ByteIterator#indexOf` to match the implementation of stdlib collections. This way objects that override `equals` will work as expected.~~