### PR TITLE
Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -16,6 +16,8 @@ jobs:
     if: github.repository == 'apache/pekko'
     strategy:
       fail-fast: false
+    env:
+      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -14,6 +14,8 @@ jobs:
   check-code-style:
     name: Check / Code Style
     runs-on: ubuntu-22.04
+    env:
+      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,6 +43,8 @@ jobs:
   pull-request-validation:
     name: Check / Tests
     runs-on: ubuntu-20.04
+    env:
+      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/generate-doc-check.yml
+++ b/.github/workflows/generate-doc-check.yml
@@ -49,4 +49,6 @@ jobs:
           sudo apt-get install graphviz
 
       - name: Compile testClass&docs for all Scala versions
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         run: sbt ";+TestJdk9 / compile ; +compile:doc"

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -23,6 +23,8 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Check headers
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt \
           -Dsbt.override.build.repos=false \

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -35,6 +35,8 @@ jobs:
         uses: coursier/setup-action@v1
 
       - name: Create the Pekko site
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           cp .jvmopts-ci .jvmopts
           sbt -Dpekko.genjavadoc.enabled=true -Dpekko.genlicensereport.enabled=true "Javaunidoc/doc; Compile/unidoc; docs/paradox"

--- a/.github/workflows/nightly-1.0-builds.yml
+++ b/.github/workflows/nightly-1.0-builds.yml
@@ -33,6 +33,8 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: sbt cluster-metrics/test
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \
@@ -82,6 +84,8 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: sbt ${{ matrix.command }}
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
@@ -127,6 +131,8 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: Compile and Test
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \

--- a/.github/workflows/nightly-builds-aeron.yml
+++ b/.github/workflows/nightly-builds-aeron.yml
@@ -40,6 +40,8 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: sbt ${{ matrix.command }}
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -32,6 +32,8 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: sbt cluster-metrics/test
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \
@@ -90,6 +92,8 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: sbt ${{ matrix.command }}
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
@@ -114,6 +118,8 @@ jobs:
         # full version from it.
         scalaVersion: ["2.12", "2.13", "3.3"]
         javaVersion: [8, 11, 17, 21]
+    env:
+      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -54,6 +54,8 @@ jobs:
 
       # TODO come up with a better way to control the version, possibly based on git tags
       - name: Build Documentation
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt -Dpekko.genjavadoc.enabled=true -Dpekko.genlicensereport.enabled=true "set ThisBuild / version := \"1.0.2\"; docs/paradox; unidoc"
 

--- a/.github/workflows/publish-1.0-nightly.yml
+++ b/.github/workflows/publish-1.0-nightly.yml
@@ -32,6 +32,8 @@ jobs:
     name: Publish 1.0 nightly
     runs-on: ubuntu-20.04
     if: github.repository == 'apache/pekko'
+    env:
+      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -32,6 +32,8 @@ jobs:
     name: Publish nightly
     runs-on: ubuntu-20.04
     if: github.repository == 'apache/pekko'
+    env:
+      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -52,6 +52,8 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: Compile and run tests on Scala 3
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false
         run: |
           sbt \

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -50,6 +50,8 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: Compile on Scala 3
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           sbt \
           "+~ 3 ${{ matrix.command }}"

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -34,6 +34,8 @@ jobs:
         run: cp .jvmopts-ci .jvmopts
 
       - name: sbt test
+        env:
+          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \

--- a/project/PekkoDevelocityPlugin.scala
+++ b/project/PekkoDevelocityPlugin.scala
@@ -36,7 +36,7 @@ object PekkoDevelocityPlugin extends AutoPlugin {
 
   override lazy val buildSettings: Seq[Setting[_]] = Def.settings(
     develocityConfiguration := {
-      val isInsideCi = insideCI.value
+      val isInsideCI = insideCI.value
 
       val original = develocityConfiguration.value
       val apacheDevelocityConfiguration =
@@ -49,11 +49,11 @@ object PekkoDevelocityPlugin extends AutoPlugin {
           .withBuildScan(
             original.buildScan
               .withPublishing(Publishing.onlyIf(_.authenticated))
-              .withBackgroundUpload(!isInsideCi)
+              .withBackgroundUpload(!isInsideCI)
               .withObfuscation(
                 original.buildScan.obfuscation
                   .withIpAddresses(_.map(_ => ObfuscatedIPv4Address))))
-      if (isInsideCi) {
+      if (isInsideCI) {
         apacheDevelocityConfiguration
           .withTestRetryConfiguration(
             original.testRetryConfiguration

--- a/project/PekkoDevelocityPlugin.scala
+++ b/project/PekkoDevelocityPlugin.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.gradle.develocity.agent.sbt.DevelocityPlugin
+import com.gradle.develocity.agent.sbt.DevelocityPlugin.autoImport.{
+  develocityConfiguration,
+  FlakyTestPolicy,
+  ProjectId,
+  Publishing
+}
+import sbt.{ url, AutoPlugin, Def, PluginTrigger, Plugins, Setting }
+import sbt.Keys.insideCI
+
+object PekkoDevelocityPlugin extends AutoPlugin {
+
+  private val ApacheDevelocityUrl = url("https://ge.apache.org")
+  private val PekkoProjectId = ProjectId("pekko")
+  private val ObfuscatedIPv4Address = "0.0.0.0"
+
+  override lazy val trigger: PluginTrigger = allRequirements
+  override lazy val requires: Plugins = DevelocityPlugin
+
+  override lazy val buildSettings: Seq[Setting[_]] = Def.settings(
+    develocityConfiguration := {
+      val isCI = insideCI.value
+
+      val original = develocityConfiguration.value
+      val apacheDevelocityConfiguration =
+        original
+          .withProjectId(PekkoProjectId)
+          .withServer(
+            original.server
+              .withUrl(Some(ApacheDevelocityUrl))
+              .withAllowUntrusted(false))
+          .withBuildScan(
+            original.buildScan
+              .withPublishing(Publishing.onlyIf(_.authenticated))
+              .withBackgroundUpload(!isCI)
+              .withObfuscation(
+                original.buildScan.obfuscation
+                  .withIpAddresses(_.map(_ => ObfuscatedIPv4Address))))
+      if (isCI) {
+        apacheDevelocityConfiguration
+          .withTestRetryConfiguration(
+            original.testRetryConfiguration
+              .withMaxRetries(1)
+              .withFlakyTestPolicy(FlakyTestPolicy.Fail) // preserve the original build outcome in case of flaky tests
+          )
+      } else apacheDevelocityConfiguration
+    })
+}

--- a/project/PekkoDevelocityPlugin.scala
+++ b/project/PekkoDevelocityPlugin.scala
@@ -36,7 +36,7 @@ object PekkoDevelocityPlugin extends AutoPlugin {
 
   override lazy val buildSettings: Seq[Setting[_]] = Def.settings(
     develocityConfiguration := {
-      val isCI = insideCI.value
+      val isInsideCi = insideCI.value
 
       val original = develocityConfiguration.value
       val apacheDevelocityConfiguration =
@@ -49,11 +49,11 @@ object PekkoDevelocityPlugin extends AutoPlugin {
           .withBuildScan(
             original.buildScan
               .withPublishing(Publishing.onlyIf(_.authenticated))
-              .withBackgroundUpload(!isCI)
+              .withBackgroundUpload(!isInsideCi)
               .withObfuscation(
                 original.buildScan.obfuscation
                   .withIpAddresses(_.map(_ => ObfuscatedIPv4Address))))
-      if (isCI) {
+      if (isInsideCi) {
         apacheDevelocityConfiguration
           .withTestRetryConfiguration(
             original.testRetryConfiguration

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -32,3 +32,5 @@ addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 addSbtPlugin("io.github.roiocam" % "sbt-depend-walker" % "0.1.1")
 
 addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1")
+
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.0.1")


### PR DESCRIPTION
This PR adds a new auto-plugin that configures publishing of a build scan for every CI build on GitHub Actions. Build scans from local builds can be published by authenticated Apache committer only by explicitly opting in. The build will not fail if publishing fails.

The build scans of the Apache Pekko projects are published to the Develocity instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle through a [Platinum Targeted Sponsorship](https://news.apache.org/foundation/entry/the-apache-software-foundation-announces-gradle-as-a-platinum-targeted-sponsor). This Develocity instance has all features and extensions enabled and is freely available for use by the Apache Pekko projects and all other Apache projects.

On this Develocity instance, Apache Pekko will have access not only to all of the published build scans but other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance trends over time
* Build failure analytics for enhanced investigation and diagnosis of build failures
* Test failure analytics to better understand trends and causes around slow, failing, and flaky tests
 
Develocity is already used by other Apache projects such as [Beam](https://ge.apache.org/scans?search.rootProjectNames=beam&search.timeZoneId=America%2FChicago), [Kafka](https://ge.apache.org/scans?search.rootProjectNames=kafka&search.timeZoneId=America%2FChicago), [IoTDB](https://ge.apache.org/scans?search.rootProjectNames=Apache%20IoTDB%20Project%20Parent%20POM&search.timeZoneId=America%2FChicago), [Pulsar](https://ge.apache.org/scans?search.rootProjectNames=pulsar&search.timeZoneId=America%2FChicago), and more. Develocity is also used by a number of other [OSS projects](https://gradle.com/enterprise-customers/oss-projects/) for which we sponsor instances of Develocity.

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.