### PR TITLE
Fix Develocity access key environment variable name

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check / Code Style
     runs-on: ubuntu-22.04
     env:
-      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
     name: Check / Tests
     runs-on: ubuntu-20.04
     env:
-      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/generate-doc-check.yml
+++ b/.github/workflows/generate-doc-check.yml
@@ -50,5 +50,5 @@ jobs:
 
       - name: Compile testClass&docs for all Scala versions
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: sbt ";+TestJdk9 / compile ; +compile:doc"

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Check headers
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt \
           -Dsbt.override.build.repos=false \

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create the Pekko site
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           cp .jvmopts-ci .jvmopts
           sbt -Dpekko.genjavadoc.enabled=true -Dpekko.genlicensereport.enabled=true "Javaunidoc/doc; Compile/unidoc; docs/paradox"

--- a/.github/workflows/nightly-1.0-builds.yml
+++ b/.github/workflows/nightly-1.0-builds.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: sbt cluster-metrics/test
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \
@@ -85,7 +85,7 @@ jobs:
 
       - name: sbt ${{ matrix.command }}
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
@@ -132,7 +132,7 @@ jobs:
 
       - name: Compile and Test
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \

--- a/.github/workflows/nightly-builds-aeron.yml
+++ b/.github/workflows/nightly-builds-aeron.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: sbt ${{ matrix.command }}
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: sbt cluster-metrics/test
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \
@@ -93,7 +93,7 @@ jobs:
 
       - name: sbt ${{ matrix.command }}
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
@@ -119,7 +119,7 @@ jobs:
         scalaVersion: ["2.12", "2.13", "3.3"]
         javaVersion: [8, 11, 17, 21]
     env:
-      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -55,7 +55,7 @@ jobs:
       # TODO come up with a better way to control the version, possibly based on git tags
       - name: Build Documentation
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt -Dpekko.genjavadoc.enabled=true -Dpekko.genlicensereport.enabled=true "set ThisBuild / version := \"1.0.2\"; docs/paradox; unidoc"
 

--- a/.github/workflows/publish-1.0-nightly.yml
+++ b/.github/workflows/publish-1.0-nightly.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'apache/pekko'
     env:
-      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'apache/pekko'
     env:
-      DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Compile and run tests on Scala 3
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false
         run: |
           sbt \

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Compile on Scala 3
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           sbt \
           "+~ 3 ${{ matrix.command }}"

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: sbt test
         env:
-          DEVELOCITY_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \


### PR DESCRIPTION
Follow up PR for the change that was done in https://github.com/apache/pekko/pull/1288, where the wrong variable name was used. Due to the wrong name the Build Scan was not published. 

Develocity docs about environment variable can be found [here](https://docs.gradle.com/develocity/sbt-plugin/#via_environment_variable)