### PR TITLE
chore: clean code in ClusterSharding

### DIFF
--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -194,12 +194,9 @@ import pekko.util.JavaDurationConverters._
             typeKey.name,
             new java.util.function.Function[String, ActorRef[scaladsl.ClusterSharding.ShardCommand]] {
               override def apply(t: String): ActorRef[scaladsl.ClusterSharding.ShardCommand] = {
-                // using classic.systemActorOf to avoid the Future[ActorRef]
-                system.toClassic
-                  .asInstanceOf[ExtendedActorSystem]
-                  .systemActorOf(
-                    PropsAdapter(ShardCommandActor.behavior(stopMessage.getOrElse(PoisonPill))),
-                    URLEncoder.encode(typeKey.name, ByteString.UTF_8) + "ShardCommandDelegator")
+                system.systemActorOf(
+                  ShardCommandActor.behavior(stopMessage.getOrElse(PoisonPill)),
+                  URLEncoder.encode(typeKey.name, ByteString.UTF_8) + "ShardCommandDelegator")
               }
             })
 
@@ -307,11 +304,8 @@ import pekko.util.JavaDurationConverters._
     }
   }
 
-  override lazy val shardState: ActorRef[ClusterShardingQuery] = {
-    import pekko.actor.typed.scaladsl.adapter._
-    val behavior = ShardingState.behavior(classicSharding)
-    classicSystem.systemActorOf(PropsAdapter(behavior), "typedShardState")
-  }
+  override lazy val shardState: ActorRef[ClusterShardingQuery] =
+    system.systemActorOf(ShardingState.behavior(classicSharding), "typedShardState")
 
 }
 


### PR DESCRIPTION
Make code cleaner, it is basically the same.

## Before using

https://github.com/apache/pekko/blob/b5eb6ff01a8d5c5f50b5d1b54280c0dcb075a59a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/adapter/PropsAdapter.scala#L31-L36

## After

https://github.com/apache/pekko/blob/b5eb6ff01a8d5c5f50b5d1b54280c0dcb075a59a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorSystemAdapter.scala#L125-L133