### PR TITLE
remove unnecessary scalafix setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,6 @@
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
-ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
-
 scalaVersion := Dependencies.allScalaVersions.head
 
 ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)


### PR DESCRIPTION
/code/incubator-pekko/build.sbt:12: warning: value scalafixScalaBinaryVersion in object autoImport is deprecated (since 0.12.1): scalafixScalaBinaryVersion now follows scalaBinaryVersion by default
ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value