### PR TITLE
chore: drop custom `+~` version switching

### DIFF
--- a/.github/workflows/nightly-1.0-builds.yml
+++ b/.github/workflows/nightly-1.0-builds.yml
@@ -108,7 +108,7 @@ jobs:
         # No need to specify the full Scala version. Only the Scala
         # binary version is required and Pekko build will set the right
         # full version from it.
-        scalaVersion: ["2.12", "2.13", "3.3"]
+        scalaVersion: ["2.12.x", "2.13.x", "3.3.x"]
         javaVersion: [8, 11, 17, 21]
     steps:
       - name: Checkout
@@ -142,4 +142,4 @@ jobs:
             -Dpekko.actor.testkit.typed.timefactor=2 \
             -Dpekko.test.tags.exclude=gh-exclude,timing \
             -Dpekko.test.multi-in-test=false \
-            clean "+~ ${{ matrix.scalaVersion }} test" checkTestsHaveRun
+            clean "++ ${{ matrix.scalaVersion }} test" checkTestsHaveRun

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -116,7 +116,7 @@ jobs:
         # No need to specify the full Scala version. Only the Scala
         # binary version is required and Pekko build will set the right
         # full version from it.
-        scalaVersion: ["2.12", "2.13", "3.3"]
+        scalaVersion: ["2.12.x", "2.13.x", "3.3.x"]
         javaVersion: [8, 11, 17, 21]
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
@@ -152,7 +152,7 @@ jobs:
             -Dpekko.actor.testkit.typed.timefactor=2 \
             -Dpekko.test.tags.exclude=gh-exclude,timing \
             -Dpekko.test.multi-in-test=false \
-            clean "+~ ${{ matrix.scalaVersion }} test" checkTestsHaveRun
+            clean "++ ${{ matrix.scalaVersion }} test" checkTestsHaveRun
 
 # comment out test report until an apache or GitHub published action (action-surefire-report) can be found or added allowlist from INFRA
 #      - name: Test Reports

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -66,7 +66,7 @@ jobs:
           -Dmultinode.Xms256M \
           -Dmultinode.Xmx256M \
           -Dmultinode.XX:+AlwaysActAsServerClassMachine \
-          "+~ 3 ${{ matrix.command }}"
+          "++ 3.x ${{ matrix.command }}"
 
       # comment out email actions until we have an email address to use (and we need to get INFRA to whitelist dawidd6/action-send-mail)
       #- name: Email on failure

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -54,4 +54,4 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           sbt \
-          "+~ 3 ${{ matrix.command }}"
+          "++ 3.x ${{ matrix.command }}"


### PR DESCRIPTION
as this feature is in sbt since https://github.com/sbt/sbt/pull/6894 and https://github.com/sbt/sbt/pull/6936