### PR TITLE
build issue in nightly-builds.yml

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -179,7 +179,7 @@ jobs:
           # genjavadoc does not support Scala 3.x
           sbt \
             -Dpekko.genjavadoc.enabled=${{ matrix.scalaVersion != '3.3' }} \
-            "+~ ${{ matrix.scalaVersion }} doc"
+            "++ ${{ matrix.scalaVersion }} doc"
 
       - name: Publish
         # Publish (osgi bundle) not working with JDK 17, issue #31132
@@ -188,7 +188,7 @@ jobs:
           sudo apt-get install graphviz
           sbt \
             -Dpekko.build.scalaVersion=${{ matrix.scalaVersion }} \
-            "+~ ${{ matrix.scalaVersion }} publishLocal publishM2"
+            "++ ${{ matrix.scalaVersion }} publishLocal publishM2"
 
       - name: Install scala-cli
         if: ${{ matrix.javaVersion == 11 }}

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -178,7 +178,7 @@ jobs:
           sudo apt-get install graphviz
           # genjavadoc does not support Scala 3.x
           sbt \
-            -Dpekko.genjavadoc.enabled=${{ matrix.scalaVersion != '3.3' }} \
+            -Dpekko.genjavadoc.enabled=${{ matrix.scalaVersion.startsWith("3") }} \
             "++ ${{ matrix.scalaVersion }} doc"
 
       - name: Publish


### PR DESCRIPTION
relates to https://github.com/apache/pekko/pull/1324

See failures in JDK11 builds in https://github.com/apache/pekko/actions/runs/9104380012/job/25028122890

The affected sbt calls only happen when Java version is 11 due to conditions in the workflow yml.