### PR TITLE
chore: Separate commands with `;` in nightly-builds.yml

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -188,7 +188,7 @@ jobs:
           sudo apt-get install graphviz
           sbt \
             -Dpekko.build.scalaVersion=${{ matrix.scalaVersion }} \
-            "++ ${{ matrix.scalaVersion }} publishLocal publishM2"
+            "++ ${{ matrix.scalaVersion }} ;publishLocal;publishM2"
 
       - name: Install scala-cli
         if: ${{ matrix.javaVersion == 11 }}


### PR DESCRIPTION
Motivation:
Fix nightly publish
https://github.com/apache/pekko/actions/runs/9126537049/job/25095015352