### PR TITLE
chore: Add since 1.1.0 for `foldWhile` operator

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -1437,6 +1437,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    *
    * See also [[FlowOps.fold]]
+   *
+   * @since 1.1.0
    */
   def foldWhile[T](zero: T, p: function.Predicate[T], f: function.Function2[T, Out, T]): javadsl.Flow[In, T, Mat] =
     new Flow(delegate.foldWhile(zero)(p.test)(f.apply))

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
@@ -57,6 +57,8 @@ object Sink {
    * The returned [[java.util.concurrent.CompletionStage]] will be completed with value of the final
    * function evaluation when the input stream ends, predicate `p` returns false, or completed with `Failure`
    * if there is a failure is signaled in the stream.
+   *
+   * @since 1.1.0
    */
   def foldWhile[U, In](
       zero: U, p: function.Predicate[U], f: function.Function2[U, In, U]): javadsl.Sink[In, CompletionStage[U]] =

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -817,6 +817,8 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    *
    * See also [[FlowOps.fold]]
+   *
+   * @since 1.1.0
    */
   def foldWhile[T](zero: T, p: function.Predicate[T], f: function.Function2[T, Out, T]): SubFlow[In, T, Mat] =
     new SubFlow(delegate.foldWhile(zero)(p.test)(f.apply))

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1844,6 +1844,8 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream cancels
    *
    * See also [[FlowOps.fold]]
+   *
+   * @since 1.1.0
    */
   def foldWhile[T](zero: T)(p: T => Boolean)(f: (T, Out) => T): Repr[T] = via(
     Fold[Out, T](zero, p, f).withAttributes(DefaultAttributes.foldWhile))

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
@@ -424,6 +424,8 @@ object Sink {
    * if there is a failure signaled in the stream.
    *
    * @see [[#fold]]
+   *
+   * @since 1.1.0
    */
   def foldWhile[U, T](zero: U)(p: U => Boolean)(f: (U, T) => U): Sink[T, Future[U]] =
     Flow[T].foldWhile(zero)(p)(f).toMat(Sink.head)(Keep.right).named("foldWhileSink")


### PR DESCRIPTION
Motivation:
Add the missing 1.1.0 annotation

Result:
@since 1.1.0 added for foldWhile.