### PR TITLE
Avoid unnecessary shard updates while shutting down (#1342)

### DIFF
--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
@@ -1003,8 +1003,9 @@ private[pekko] class ShardRegion(
       shardsByRef = shardsByRef - ref
       shards = shards - shardId
       startingShards -= shardId
-      if (settings.passivationStrategy != ClusterShardingSettings.NoPassivationStrategy) {
-        shards.values.foreach(_ ! ShardsUpdated(shards.size))
+      if (settings.passivationStrategy != ClusterShardingSettings.NoPassivationStrategy && !gracefulShutdownInProgress) {
+        val update = ShardsUpdated(shards.size)
+        shards.values.foreach(_ ! update)
       }
       if (handingOff.contains(ref)) {
         handingOff = handingOff - ref
@@ -1348,7 +1349,8 @@ private[pekko] class ShardRegion(
             shards = shards.updated(id, shard)
             startingShards += id
             if (settings.passivationStrategy != ClusterShardingSettings.NoPassivationStrategy) {
-              shards.values.foreach(_ ! ShardsUpdated(shards.size))
+              val update = ShardsUpdated(shards.size)
+              shards.values.foreach(_ ! update)
             }
             None
           case Some(_) =>


### PR DESCRIPTION
* Avoid unnecessary shard updates while shutting down
* Avoid re-creating the same message for each shard

cherry pick 92b38e72d6a2701da06f483e8cd27953e403240e