### PR TITLE
fix some typos

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LoggingTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LoggingTestKit.scala
@@ -173,7 +173,7 @@ object LoggingTestKit {
     messageContains(messageIncludes).withLogLevel(Level.WARN)
 
   /**
-   * Create a filter for WARN level events with a an included
+   * Create a filter for WARN level events with an included
    * `throwable` that is a class or subclass of the given
    * * `Throwable` class.
    *
@@ -192,7 +192,7 @@ object LoggingTestKit {
     messageContains(messageIncludes).withLogLevel(Level.ERROR)
 
   /**
-   * Create a filter for ERROR level events with a an included
+   * Create a filter for ERROR level events with an included
    * `throwable` that is a class or subclass of the given
    * * `Throwable` class.
    *

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LoggingTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LoggingTestKit.scala
@@ -182,7 +182,7 @@ object LoggingTestKit {
     messageContains(messageIncludes).withLogLevel(Level.WARN)
 
   /**
-   * Create a filter for WARN level events with a an included
+   * Create a filter for WARN level events with an included
    * `throwable` that is a class or subclass of the given
    * `Throwable` `ClassTag`.
    *
@@ -201,7 +201,7 @@ object LoggingTestKit {
     messageContains(messageIncludes).withLogLevel(Level.ERROR)
 
   /**
-   * Create a filter for WARN level events with a an included
+   * Create a filter for WARN level events with an included
    * `throwable` that is a class or subclass of the given
    * `Throwable` `ClassTag`.
    *

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/ActorRefIgnoreSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/ActorRefIgnoreSpec.scala
@@ -47,7 +47,7 @@ class ActorRefIgnoreSpec extends ScalaTestWithActorTestKit() with AnyWordSpecLik
   }
 
   /**
-   * This actor sends a ask to 'askMeRef' at bootstrap and forward the answer to the probe.
+   * This actor sends an ask to 'askMeRef' at bootstrap and forward the answer to the probe.
    * We will use it through out this test.
    */
   def behavior(askMeRef: ActorRef[Request], probe: TestProbe[Int]) = Behaviors.setup[Int] { context =>

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -204,7 +204,7 @@ class ExternalShardAllocationStrategy(systemProvider: ClassicActorSystemProvider
 
     val currentAllocationByAddress: Map[Address, immutable.IndexedSeq[ShardId]] = currentShardAllocations.map {
       case (ref: ActorRefScope, value) if ref.isLocal =>
-        (cluster.selfAddress, value) // so it can be compared to a address with host and port
+        (cluster.selfAddress, value) // so it can be compared to an address with host and port
       case (key, value) => (key.path.address, value)
     }
 

--- a/docs/src/main/paradox/typed/guide/tutorial_1.md
+++ b/docs/src/main/paradox/typed/guide/tutorial_1.md
@@ -35,7 +35,7 @@ In fact, before your first actor is started, Pekko has already created two actor
  
 The easiest way to see the actor hierarchy in action is to print @apidoc[actor.typed.ActorRef] instances. In this small experiment, we create an actor, print its reference, create a child of this actor, and print the child's reference. 
 
-In a new project, create a `com.example` package and with a @scala[a new Scala file called `ActorHierarchyExperiments.scala` here. Copy and paste the code from the snippet below to this new source file]@java[a Java file for each of the classes in the snippet below and copy the respective contents]. Save your @scala[file and run `sbt "runMain com.example.ActorHierarchyExperiments"`]@java[files and run `com.example.ActorHierarchyExperiments` from your build tool or IDE] to observe the output.
+In a new project, create a `com.example` package and with a @scala[new Scala file called `ActorHierarchyExperiments.scala` here. Copy and paste the code from the snippet below to this new source file]@java[Java file for each of the classes in the snippet below and copy the respective contents]. Save your @scala[file and run `sbt "runMain com.example.ActorHierarchyExperiments"`]@java[files and run `com.example.ActorHierarchyExperiments` from your build tool or IDE] to observe the output.
 
 Scala
 :   @@snip [ActorHierarchyExperiments.scala](/docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala) { #print-refs }

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/LeveldbIdMapping.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/LeveldbIdMapping.scala
@@ -36,7 +36,7 @@ private[persistence] trait LeveldbIdMapping extends Actor { this: LeveldbStore =
    * Get the mapped numeric id for the specified persistent actor `id`. Creates and
    * stores a new mapping if necessary.
    *
-   * This method is thread safe and it is allowed to call it from a another
+   * This method is thread safe and it is allowed to call it from another
    * thread than the actor's thread. That is necessary for Future composition,
    * e.g. `asyncReadHighestSequenceNr` followed by `asyncReplayMessages`.
    */

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -1359,7 +1359,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.scan(zero)(f.apply))
 
   /**
-   * Similar to `scan` but with a asynchronous function,
+   * Similar to `scan` but with an asynchronous function,
    * emits its current value which starts at `zero` and then
    * applies the current and next value to the given function `f`,
    * emitting a `Future` that resolves to the next current value.

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
@@ -278,7 +278,7 @@ object Sink {
     new Sink(scaladsl.Sink.lastOption[In].mapMaterializedValue(_.map(_.toJava)(ExecutionContexts.parasitic).asJava))
 
   /**
-   * A `Sink` that materializes into a a `CompletionStage` of `List<In>` containing the last `n` collected elements.
+   * A `Sink` that materializes into a `CompletionStage` of `List<In>` containing the last `n` collected elements.
    *
    * If the stream completes before signaling at least n elements, the `CompletionStage` will complete with all elements seen so far.
    * If the stream never completes the `CompletionStage` will never complete.

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -3102,7 +3102,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     new Source(delegate.scan(zero)(f.apply))
 
   /**
-   * Similar to `scan` but with a asynchronous function,
+   * Similar to `scan` but with an asynchronous function,
    * emits its current value which starts at `zero` and then
    * applies the current and next value to the given function `f`,
    * emitting a `Future` that resolves to the next current value.

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -739,7 +739,7 @@ class SubFlow[In, Out, Mat](
     new SubFlow(delegate.scan(zero)(f.apply))
 
   /**
-   * Similar to `scan` but with a asynchronous function,
+   * Similar to `scan` but with an asynchronous function,
    * emits its current value which starts at `zero` and then
    * applies the current and next value to the given function `f`,
    * emitting a `Future` that resolves to the next current value.

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -730,7 +730,7 @@ class SubSource[Out, Mat](
     new SubSource(delegate.scan(zero)(f.apply))
 
   /**
-   * Similar to `scan` but with a asynchronous function,
+   * Similar to `scan` but with an asynchronous function,
    * emits its current value which starts at `zero` and then
    * applies the current and next value to the given function `f`,
    * emitting a `Future` that resolves to the next current value.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
@@ -248,7 +248,7 @@ object Sink {
   }
 
   /**
-   * A `Sink` that materializes into a a `Future` of `immutable.Seq[T]` containing the last `n` collected elements.
+   * A `Sink` that materializes into a `Future` of `immutable.Seq[T]` containing the last `n` collected elements.
    *
    * If the stream completes before signaling at least n elements, the `Future` will complete with all elements seen so far.
    * If the stream never completes, the `Future` will never complete.


### PR DESCRIPTION
* see #1357 
* also cases where 'a' is used but 'an' is better