### PR TITLE
feat: Support adjust the scheduler's tick-duration.

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/config/ConfigSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/config/ConfigSpec.scala
@@ -50,6 +50,7 @@ class ConfigSpec extends PekkoSpec(ConfigFactory.defaultReference(ActorSystem.fi
 
         getInt("pekko.scheduler.ticks-per-wheel") should ===(512)
         getDuration("pekko.scheduler.tick-duration", TimeUnit.MILLISECONDS) should ===(10L)
+        getBoolean("pekko.scheduler.error-on-tick-duration-verification-failed") should ===(true)
         getString("pekko.scheduler.implementation") should ===("org.apache.pekko.actor.LightArrayRevolverScheduler")
 
         getBoolean("pekko.daemonic") should ===(false)

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -829,7 +829,16 @@ pekko {
     # Note that it might take up to 1 tick to stop the Timer, so setting the
     # tick-duration to a high value will make shutting down the actor system
     # take longer.
+    #
+    # Requirements:
+    # 1. The minimum supported tick-duration on Windows is 10ms,
+    # 2. The minimum supported tick-duration is 1ms
     tick-duration = 10ms
+
+    # An error will be throw when the tick-duration does not meet the requirements.
+    # When this is set to off, the tick-duration will be adjusted to meet the requirements
+    # and a warning will be logged.
+    error-on-tick-duration-verification-failed = on
 
     # The timer uses a circular wheel of buckets to store the timer tasks.
     # This should be set such that the majority of scheduled timeouts (for high


### PR DESCRIPTION
Motivation:
refs: https://github.com/apache/pekko/issues/1364

Modification:
Add another config `pekko.scheduler.error-on-tick-duration-verification-failed = on` by default and can be changed to `off` when needed.

Result:
Better experience 