### PR TITLE
Configure `TestJdk9` for Develocity

### DIFF
--- a/project/PekkoDevelocityPlugin.scala
+++ b/project/PekkoDevelocityPlugin.scala
@@ -22,7 +22,7 @@ import com.gradle.develocity.agent.sbt.DevelocityPlugin.autoImport.{
   ProjectId,
   Publishing
 }
-import sbt.{ url, AutoPlugin, Def, PluginTrigger, Plugins, Setting }
+import sbt.{ inConfig, url, AutoPlugin, Def, PluginTrigger, Plugins, Setting }
 import sbt.Keys.insideCI
 
 object PekkoDevelocityPlugin extends AutoPlugin {
@@ -62,4 +62,16 @@ object PekkoDevelocityPlugin extends AutoPlugin {
           )
       } else apacheDevelocityConfiguration
     })
+}
+
+/**
+ * An AutoPlugin to add Develocity test configuration to the TestJdk9 configuration.
+ */
+object PekkoDevelocityJdk9TestSettingsPlugin extends AutoPlugin {
+  override lazy val trigger: PluginTrigger = allRequirements
+  override lazy val requires: Plugins = DevelocityPlugin && Jdk9
+
+  // See https://docs.gradle.com/develocity/sbt-plugin/#capturing_test_data_in_a_custom_configuration
+  override lazy val projectSettings =
+    inConfig(Jdk9.TestJdk9)(DevelocityPlugin.testSettings)
 }


### PR DESCRIPTION
Prevously, the tests that are run in the `TestJdk9` configuration were not captured by Develocity: the results of these tests would not appear in the Develocity test report and dashboard, and failed tests would not be retried.

Because TestJdk9 is a custom configuration, Develocity cannot configure it automatically and we need to manually add the Develocity test settings in that configuration. This is done through an auto plugin that is enabled only on projects where both the Develocity and Jdk9 plugins are enabled.