### PR TITLE
fix: dependency-graph permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -10,10 +10,10 @@ jobs:
   dependency-graph:
     name: Update Dependency Graph
     runs-on: ubuntu-latest
+    permissions:
+      # The API requires write permission on the repository
+      # to submit dependencies
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: scalacenter/sbt-dependency-submission@v2
-        permissions:
-          # The API requires write permission on the repository
-          # to submit dependencies
-          contents: write


### PR DESCRIPTION
apparently permissions must be at the job level, not the step level.

Follow-up on #1371