### PR TITLE
feat: Add `isCompleted` method to BoundedSourceQueue

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/BoundedSourceQueueSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/BoundedSourceQueueSpec.scala
@@ -45,6 +45,7 @@ class BoundedSourceQueueSpec extends StreamSpec("""pekko.loglevel = debug
       }
 
       queue.complete()
+      queue.isCompleted shouldBe true
 
       val subIt = Iterator.continually(sub.requestNext())
       subIt.zip(elements.iterator).foreach {
@@ -81,6 +82,7 @@ class BoundedSourceQueueSpec extends StreamSpec("""pekko.loglevel = debug
       val queue =
         Source.queue[Int](1).toMat(Sink.fromSubscriber(sub))(Keep.left).run()
       queue.complete()
+      queue.isCompleted shouldBe true
       assertThrows[IllegalStateException](queue.complete())
     }
 
@@ -89,6 +91,7 @@ class BoundedSourceQueueSpec extends StreamSpec("""pekko.loglevel = debug
       val queue =
         Source.queue[Int](1).toMat(Sink.fromSubscriber(sub))(Keep.left).run()
       queue.fail(ex)
+      queue.isCompleted shouldBe true
       assertThrows[IllegalStateException](queue.fail(ex))
     }
 
@@ -98,6 +101,7 @@ class BoundedSourceQueueSpec extends StreamSpec("""pekko.loglevel = debug
         Source.queue[Int](10).toMat(Sink.fromSubscriber(sub))(Keep.left).run()
 
       queue.complete()
+      queue.isCompleted shouldBe true
       queue.offer(1) should be(QueueOfferResult.QueueClosed)
       sub.expectSubscriptionAndComplete()
     }
@@ -108,6 +112,7 @@ class BoundedSourceQueueSpec extends StreamSpec("""pekko.loglevel = debug
         Source.queue[Int](10).toMat(Sink.fromSubscriber(sub))(Keep.left).run()
 
       queue.fail(ex)
+      queue.isCompleted shouldBe true
       queue.offer(1) should be(QueueOfferResult.Failure(ex))
       sub.request(1)
       sub.expectError(ex)
@@ -180,6 +185,7 @@ class BoundedSourceQueueSpec extends StreamSpec("""pekko.loglevel = debug
       // where enqueueing an element concurrently with Done reaching the stage can lead to Enqueued being returned
       // but the element dropped (no guarantee of entering stream as documented in BoundedSourceQueue.offer
       queue.complete()
+      queue.isCompleted shouldBe true
 
       result.futureValue should be(counter.get())
     }

--- a/stream/src/main/mima-filters/1.0.x.backwards.excludes/pr-1374-boundedsourcequeue-iscompleted-classes.backwards.excludes
+++ b/stream/src/main/mima-filters/1.0.x.backwards.excludes/pr-1374-boundedsourcequeue-iscompleted-classes.backwards.excludes
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Add BoundedSourceQueue.isCompleted method
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.stream.BoundedSourceQueue.isCompleted")

--- a/stream/src/main/scala/org/apache/pekko/stream/BoundedSourceQueue.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/BoundedSourceQueue.scala
@@ -39,6 +39,13 @@ trait BoundedSourceQueue[T] {
   def complete(): Unit
 
   /**
+   * Returns true if the stream has been completed, either normally or with failure.
+   *
+   * @since 1.1.0
+   */
+  def isCompleted: Boolean
+
+  /**
    * Completes the stream with a failure.
    */
   def fail(ex: Throwable): Unit


### PR DESCRIPTION
Motivation:
refs: https://github.com/apache/pekko/issues/1356

Result:
Better user interface to work with, and can call `complete` without handling the maybe exception.