### PR TITLE
feat: add QueueClosed singleton instance for Java API

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/QueueOfferResult.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/QueueOfferResult.scala
@@ -76,4 +76,9 @@ object QueueOfferResult {
   case object QueueClosed extends QueueCompletionResult {
     override def isEnqueued: Boolean = false
   }
+
+  /**
+   * Java API: The `QueueClosed` singleton instance
+   */
+  def closed: QueueOfferResult = QueueClosed
 }


### PR DESCRIPTION
## Motivation

new API for Java users, used to detect queue completion.

```java
QueueOfferResult offerResult = queue.offer(params);

if (offerResult == QueueOfferResult.enqueued()) {
    // logic...
} else if (offerResult == QueueOfferResult.dropped()) {
    // logic...
} else if (offerResult instanceof QueueOfferResult.Failure) {
    // logic...
} else if (offerResult == QueueOfferResult.closed()) {
    // logic...
} else {
    // logic...
}
```


![截屏2024-06-25 10 08 44](https://github.com/apache/pekko/assets/26020358/f8c6c906-0e08-4f6f-80dc-1d1d8c2b0354)

https://github.com/apache/pekko/blob/3fabc04acfc472777c85a1bef09bc7f2f777f2e0/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/BoundedSourceQueueSpec.scala#L98-L106
