### PR TITLE
fix: resolves and addition tests for child preStart supervise

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
@@ -643,7 +643,6 @@ private[pekko] class ActorCell(
     def failActor(): Unit =
       if (_actor != null) {
         clearActorFields(actor, recreate = false)
-        setFailedFatally()
         _actor = null // ensure that we know that we failed during creation
       }
 
@@ -657,10 +656,12 @@ private[pekko] class ActorCell(
         publish(Debug(self.path.toString, clazz(created), "started (" + created + ")"))
     } catch {
       case e: InterruptedException =>
+        setFailedFatally()
         failActor()
         Thread.currentThread().interrupt()
         throw ActorInitializationException(self, "interruption during creation", e)
       case NonFatal(e) =>
+        setFailed(actor.self)
         failActor()
         e match {
           case i: InstantiationException =>

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
@@ -643,6 +643,7 @@ private[pekko] class ActorCell(
     def failActor(): Unit =
       if (_actor != null) {
         clearActorFields(actor, recreate = false)
+        setFailedFatally()
         _actor = null // ensure that we know that we failed during creation
       }
 
@@ -657,7 +658,6 @@ private[pekko] class ActorCell(
     } catch {
       case e: InterruptedException =>
         failActor()
-        setFailedFatally()
         Thread.currentThread().interrupt()
         throw ActorInitializationException(self, "interruption during creation", e)
       case NonFatal(e) =>
@@ -717,8 +717,6 @@ private[pekko] class ActorCell(
   final protected def clearActorFields(actorInstance: Actor, recreate: Boolean): Unit = {
     currentMessage = null
     behaviorStack = emptyBehaviorStack
-    if (recreate) setFailed(actorInstance.self)
-    else setFailed(system.deadLetters)
   }
   final protected def clearFieldsForTermination(): Unit = {
     unstashAll()

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
@@ -643,7 +643,7 @@ private[pekko] class ActorCell(
     def failActor(): Unit =
       if (_actor != null) {
         clearActorFields(actor, recreate = false)
-        setFailedFatally()
+        setFailed(actor.self)
         _actor = null // ensure that we know that we failed during creation
       }
 

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
@@ -661,7 +661,8 @@ private[pekko] class ActorCell(
         Thread.currentThread().interrupt()
         throw ActorInitializationException(self, "interruption during creation", e)
       case NonFatal(e) =>
-        setFailed(actor.self)
+        if (actor == null) setFailed(system.deadLetters)
+        else setFailed(actor.self)
         failActor()
         e match {
           case i: InstantiationException =>

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
@@ -296,8 +296,8 @@ private[pekko] trait FaultHandling { this: ActorCell =>
             publish(Error(e, self.path.toString, clazz(freshActor), "restarting " + child))
           })
     } catch handleNonFatalOrInterruptedException { e =>
-        setFailedFatally()
         clearActorFields(actor, recreate = false) // in order to prevent preRestart() from happening again
+        setFailedFatally()
         handleInvokeFailure(survivors, PostRestartException(self, e, cause))
       }
   }

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
@@ -70,8 +70,8 @@ private[pekko] trait FaultHandling { this: ActorCell =>
    * might well be replaced by ref to a Cancellable in the future (see #2299)
    */
   private var _failed: FailedInfo = NoFailedInfo
-  private def isFailedFatally: Boolean = _failed eq FailedFatally
   private def isFailed: Boolean = _failed.isInstanceOf[FailedRef]
+  private def isFailedFatally: Boolean = _failed eq FailedFatally
   private def perpetrator: ActorRef = _failed match {
     case FailedRef(ref) => ref
     case _              => null

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
@@ -76,7 +76,7 @@ private[pekko] trait FaultHandling { this: ActorCell =>
     case FailedRef(ref) => ref
     case _              => null
   }
-  protected def setFailed(perpetrator: ActorRef): Unit = _failed = _failed match {
+  private def setFailed(perpetrator: ActorRef): Unit = _failed = _failed match {
     case FailedFatally => FailedFatally
     case _             => FailedRef(perpetrator)
   }
@@ -296,8 +296,8 @@ private[pekko] trait FaultHandling { this: ActorCell =>
             publish(Error(e, self.path.toString, clazz(freshActor), "restarting " + child))
           })
     } catch handleNonFatalOrInterruptedException { e =>
-        clearActorFields(actor, recreate = false) // in order to prevent preRestart() from happening again
         setFailedFatally()
+        clearActorFields(actor, recreate = false) // in order to prevent preRestart() from happening again
         handleInvokeFailure(survivors, PostRestartException(self, e, cause))
       }
   }

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
@@ -70,13 +70,12 @@ private[pekko] trait FaultHandling { this: ActorCell =>
    * might well be replaced by ref to a Cancellable in the future (see #2299)
    */
   private var _failed: FailedInfo = NoFailedInfo
-  private def isFailed: Boolean = _failed.isInstanceOf[FailedRef]
   private def isFailedFatally: Boolean = _failed eq FailedFatally
   private def perpetrator: ActorRef = _failed match {
     case FailedRef(ref) => ref
     case _              => null
   }
-  private def setFailed(perpetrator: ActorRef): Unit = _failed = _failed match {
+  protected def setFailed(perpetrator: ActorRef): Unit = _failed = _failed match {
     case FailedFatally => FailedFatally
     case _             => FailedRef(perpetrator)
   }
@@ -214,34 +213,33 @@ private[pekko] trait FaultHandling { this: ActorCell =>
   @InternalStableApi
   final def handleInvokeFailure(childrenNotToSuspend: immutable.Iterable[ActorRef], t: Throwable): Unit = {
     // prevent any further messages to be processed until the actor has been restarted
-    if (!isFailed)
-      try {
-        suspendNonRecursive()
-        // suspend children
-        val skip: Set[ActorRef] = currentMessage match {
-          case Envelope(Failed(_, _, _), child) => setFailed(child); Set(child)
-          case _                                => setFailed(self); Set.empty
-        }
-        suspendChildren(exceptFor = skip ++ childrenNotToSuspend)
-        t match {
-          // tell supervisor
-          case _: InterruptedException =>
-            // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-            parent.sendSystemMessage(Failed(self, new ActorInterruptedException(t), uid))
-          case _ =>
-            // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-            parent.sendSystemMessage(Failed(self, t, uid))
-        }
-      } catch handleNonFatalOrInterruptedException { e =>
-          publish(
-            Error(
-              e,
-              self.path.toString,
-              clazz(actor),
-              "emergency stop: exception in failure handling for " + t.getClass + Logging.stackTraceFor(t)))
-          try children.foreach(stop)
-          finally finishTerminate()
-        }
+    try {
+      suspendNonRecursive()
+      // suspend children
+      val skip: Set[ActorRef] = currentMessage match {
+        case Envelope(Failed(_, _, _), child) => setFailed(child); Set(child)
+        case _                                => setFailed(self); Set.empty
+      }
+      suspendChildren(exceptFor = skip ++ childrenNotToSuspend)
+      t match {
+        // tell supervisor
+        case _: InterruptedException =>
+          // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
+          parent.sendSystemMessage(Failed(self, new ActorInterruptedException(t), uid))
+        case _ =>
+          // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
+          parent.sendSystemMessage(Failed(self, t, uid))
+      }
+    } catch handleNonFatalOrInterruptedException { e =>
+        publish(
+          Error(
+            e,
+            self.path.toString,
+            clazz(actor),
+            "emergency stop: exception in failure handling for " + t.getClass + Logging.stackTraceFor(t)))
+        try children.foreach(stop)
+        finally finishTerminate()
+      }
   }
 
   private def finishTerminate(): Unit = {

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/FaultHandling.scala
@@ -76,7 +76,7 @@ private[pekko] trait FaultHandling { this: ActorCell =>
     case FailedRef(ref) => ref
     case _              => null
   }
-  private def setFailed(perpetrator: ActorRef): Unit = _failed = _failed match {
+  protected def setFailed(perpetrator: ActorRef): Unit = _failed = _failed match {
     case FailedFatally => FailedFatally
     case _             => FailedRef(perpetrator)
   }


### PR DESCRIPTION
Related with #1384 and resolves #1384, some of code contributed by @sadekmunawar 

if PR can reproducer this issue, the ci checks will be unable to successd: https://github.com/apache/pekko/actions/runs/9770536752/job/26971887726?pr=1385