### PR TITLE
chore: dependency-submission: skip test scope

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -37,3 +37,5 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v3
+        with:
+          configs-ignore: optional test compile-internal

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,6 @@ object Dependencies {
   // needs to be inline with the aeron version, check
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
   val agronaVersion = "1.22.0"
-  val bouncyCastleVersion = "1.79"
   val nettyVersion = "4.1.116.Final"
   val logbackVersion = "1.3.14"
 
@@ -120,13 +119,8 @@ object Dependencies {
     }
 
     object TestDependencies {
-      val bcprov = "org.bouncycastle" % "bcprov-jdk18on" % bouncyCastleVersion % Test
-      val bcpkix = "org.bouncycastle" % "bcpkix-jdk18on" % bouncyCastleVersion % Test
-      val bcutil = "org.bouncycastle" % "bcutil-jdk18on" % bouncyCastleVersion % Test
       val commonsIo = "commons-io" % "commons-io" % "2.18.0" % Test
       val commonsCodec = "commons-codec" % "commons-codec" % "1.17.1" % Test
-      val commonsCompress = "org.apache.commons" % "commons-compress" % "1.27.1" % Test
-      val guava = "com.google.guava" % "guava" % "33.4.0-jre" % Test
       val junit = "junit" % "junit" % junitVersion % Test
       val junit5 = "org.junit.jupiter" % "junit-jupiter-engine" % junit5Version % Test
       val httpClient = "org.apache.httpcomponents" % "httpclient" % "4.5.14" % Test
@@ -155,16 +149,10 @@ object Dependencies {
       // in-memory filesystem for file related tests
       val jimfs = "com.google.jimfs" % "jimfs" % "1.3.0" % Test
 
-      // the extra dependency overrides for bcprov, commonsCompress and guava should be reviewed - https://github.com/apache/pekko/issues/1317
       val dockerClientVersion = "3.4.1"
       val dockerClient = Seq(
         "com.github.docker-java" % "docker-java-core" % dockerClientVersion % Test,
-        "com.github.docker-java" % "docker-java-transport-httpclient5" % dockerClientVersion % Test,
-        TestDependencies.bcprov,
-        TestDependencies.bcpkix,
-        TestDependencies.bcutil,
-        TestDependencies.commonsCompress,
-        TestDependencies.guava)
+        "com.github.docker-java" % "docker-java-transport-httpclient5" % dockerClientVersion % Test)
 
       val jackson = Seq(
         jacksonCore % Test,


### PR DESCRIPTION
Currently, dependency-submission would submit all dependencies to https://github.com/apache/pekko/security/dependabot , including test dependencies. We then added explicit dependencies to the build to squash warnings about outdated test dependencies (#1181, #1313 and #1344).

With version 3, sbt-dependency-submission now supports ignoring scopes. This PR proposes to ignore the test scope, and remove the explicit dependencies from the build.

Of course, we want our developers to be secure as much as our users. From that perspective you could say we'd want to remove 'insecure' dependencies even from the test scope. In practice, however, I think it's really unlikely that a vulnerability in a test scope dependency would lead to a realistic attack on a developer. For that reason, I think ignoring this scope for dependency-submission and keeping the old dependencies in the build removes some development friction, which balances out the risk of testing with outdated dependencies. If there'd be a 'malicious' dependency out there, I expect we'd learn about it through other channels.

(do we need to request sbt-dependency-submission@v3 to be whitelisted at Infra?)

Closes #1317