### PR TITLE
fix: only setFailed when actor not null (#1399) 

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
@@ -661,8 +661,7 @@ private[pekko] class ActorCell(
         Thread.currentThread().interrupt()
         throw ActorInitializationException(self, "interruption during creation", e)
       case NonFatal(e) =>
-        if (actor == null) setFailed(system.deadLetters)
-        else setFailed(actor.self)
+        if (actor ne null) setFailed(actor.self)
         failActor()
         e match {
           case i: InstantiationException =>


### PR DESCRIPTION
backport to 1.0.x