### PR TITLE
backport LineNumberSpec fix for Scala3

### DIFF
--- a/actor-tests/src/test/scala-3/org/apache/pekko/util/LineNumberSpec.scala
+++ b/actor-tests/src/test/scala-3/org/apache/pekko/util/LineNumberSpec.scala
@@ -30,7 +30,7 @@ class LineNumberSpec extends PekkoSpec {
 
       "work for larger functions" in {
         val result = LineNumbers(twoline)
-        result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 24, 26))
+        result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 25, 26))
       }
 
       "work for partial functions" in {
@@ -39,7 +39,7 @@ class LineNumberSpec extends PekkoSpec {
 
       "work for `def`" in {
         val result = LineNumbers(method("foo"))
-        result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 34, 36))
+        result should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 35, 36))
       }
 
     }


### PR DESCRIPTION
Causing the nightly tests for 1.0.x to fail wen Scala 3 is used. See https://github.com/apache/pekko/actions/runs/10085818425/job/27887309952

This code is a direct copy of what we have in main branch.
https://github.com/pjfanning/incubator-pekko/blob/39a91c5cebe5f8394216fa7aab6b7b400045b8ed/actor-tests/src/test/scala-3/org/apache/pekko/util/LineNumberSpec.scala

See #683

Partial cherry pick of 15f02d696f0e1d28cdf062cacf8adcd4f83041fe