### PR TITLE
reduce use of org.apache.pekko.dispatch.Futures

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
@@ -127,7 +127,7 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void mustBeAbleToForeachAFuture() throws Throwable {
     final CountDownLatch latch = new CountDownLatch(1);
-    Promise<String> cf = new Promise<String>()g>();
+    Promise<String> cf = new Promise<String>();
     Future<String> f = cf.future();
     f.foreach(
         new Foreach<String>() {

--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
@@ -13,10 +13,12 @@
 
 package org.apache.pekko.dispatch;
 
-import org.apache.pekko.testkit.PekkoJUnitActorSystemResource;
 import org.apache.pekko.actor.ActorSystem;
-
 import org.apache.pekko.japi.*;
+import org.apache.pekko.testkit.PekkoJUnitActorSystemResource;
+import org.apache.pekko.testkit.PekkoSpec;
+import static org.apache.pekko.japi.Util.classTag;
+
 import org.junit.ClassRule;
 import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
@@ -32,9 +34,6 @@ import java.util.LinkedList;
 import java.lang.Iterable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import static org.apache.pekko.japi.Util.classTag;
-
-import org.apache.pekko.testkit.PekkoSpec;
 
 public class JavaFutureTests extends JUnitSuite {
 
@@ -72,7 +71,7 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void mustBeAbleToExecuteAnOnResultCallback() throws Throwable {
     final CountDownLatch latch = new CountDownLatch(1);
-    Promise<String> cf = Futures.promise();
+    Promise<String> cf = new Promise<String>();
     Future<String> f = cf.future();
     f.onComplete(
         new OnComplete<String>() {
@@ -90,7 +89,7 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void mustBeAbleToExecuteAnOnExceptionCallback() throws Throwable {
     final CountDownLatch latch = new CountDownLatch(1);
-    Promise<String> cf = Futures.promise();
+    Promise<String> cf = new Promise<String>();
     Future<String> f = cf.future();
     f.onComplete(
         new OnComplete<String>() {
@@ -110,7 +109,7 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void mustBeAbleToExecuteAnOnCompleteCallback() throws Throwable {
     final CountDownLatch latch = new CountDownLatch(1);
-    Promise<String> cf = Futures.promise();
+    Promise<String> cf = new Promise<String>();
     Future<String> f = cf.future();
     f.onComplete(
         new OnComplete<String>() {
@@ -128,7 +127,7 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void mustBeAbleToForeachAFuture() throws Throwable {
     final CountDownLatch latch = new CountDownLatch(1);
-    Promise<String> cf = Futures.promise();
+    Promise<String> cf = new Promise<String>()g>();
     Future<String> f = cf.future();
     f.foreach(
         new Foreach<String>() {
@@ -146,7 +145,7 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void mustBeAbleToFlatMapAFuture() throws Throwable {
     final CountDownLatch latch = new CountDownLatch(1);
-    Promise<String> cf = Futures.promise();
+    Promise<String> cf = new Promise<String>();
     cf.success("1000");
     Future<String> f = cf.future();
     Future<Integer> r =
@@ -155,7 +154,7 @@ public class JavaFutureTests extends JUnitSuite {
               public Future<Integer> checkedApply(String r) throws Throwable {
                 if (false) throw new IOException("Just here to make sure this compiles.");
                 latch.countDown();
-                Promise<Integer> cf = Futures.promise();
+                Promise<Integer> cf = new Promise<Integer>();
                 cf.success(Integer.parseInt(r));
                 return cf.future();
               }
@@ -170,7 +169,7 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void mustBeAbleToFilterAFuture() throws Throwable {
     final CountDownLatch latch = new CountDownLatch(1);
-    Promise<String> cf = Futures.promise();
+    Promise<String> cf = new Promise<String>();
     Future<String> f = cf.future();
     Future<String> r =
         f.filter(
@@ -333,7 +332,7 @@ public class JavaFutureTests extends JUnitSuite {
 
   @Test
   public void blockMustBeCallable() throws Exception {
-    Promise<String> p = Futures.promise();
+    Promise<String> p = new Promise<String>();
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.success("foo");
     Await.ready(p.future(), d);
@@ -342,7 +341,7 @@ public class JavaFutureTests extends JUnitSuite {
 
   @Test
   public void mapToMustBeCallable() throws Exception {
-    Promise<Object> p = Futures.promise();
+    Promise<Object> p = new Promise<Object>();
     Future<String> f = p.future().mapTo(classTag(String.class));
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.success("foo");
@@ -353,7 +352,7 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void recoverToMustBeCallable() throws Exception {
     final IllegalStateException fail = new IllegalStateException("OHNOES");
-    Promise<Object> p = Futures.promise();
+    Promise<Object> p = new Promise<Object>();
     Future<Object> f =
         p.future()
             .recover(
@@ -372,13 +371,13 @@ public class JavaFutureTests extends JUnitSuite {
   @Test
   public void recoverWithToMustBeCallable() throws Exception {
     final IllegalStateException fail = new IllegalStateException("OHNOES");
-    Promise<Object> p = Futures.promise();
+    Promise<Object> p = new Promise<Object>();
     Future<Object> f =
         p.future()
             .recoverWith(
                 new Recover<Future<Object>>() {
                   public Future<Object> recover(Throwable t) throws Throwable {
-                    if (t == fail) return Futures.successful("foo");
+                    if (t == fail) return Future.successful("foo");
                     else throw t;
                   }
                 },

--- a/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
@@ -219,7 +219,7 @@ public class PatternsTest extends JUnitSuite {
   @Test
   public void usePipe() throws Exception {
     TestProbe probe = new TestProbe(system);
-    pipe(Futures.successful("ho!"), system.dispatcher()).to(probe.ref());
+    pipe(Future.successful("ho!"), system.dispatcher()).to(probe.ref());
     probe.expectMsg("ho!");
   }
 
@@ -227,7 +227,7 @@ public class PatternsTest extends JUnitSuite {
   public void usePipeWithActorSelection() throws Exception {
     TestProbe probe = new TestProbe(system);
     ActorSelection selection = system.actorSelection(probe.ref().path());
-    pipe(Futures.successful("hi!"), system.dispatcher()).to(selection);
+    pipe(Future.successful("hi!"), system.dispatcher()).to(selection);
     probe.expectMsg("hi!");
   }
 
@@ -293,7 +293,7 @@ public class PatternsTest extends JUnitSuite {
 
     Future<String> retriedFuture =
         Patterns.retry(
-            () -> Futures.successful(expected),
+            () -> Future.successful(expected),
             3,
             scala.concurrent.duration.Duration.apply(200, "millis"),
             system.scheduler(),
@@ -319,7 +319,7 @@ public class PatternsTest extends JUnitSuite {
   @Test(expected = IllegalStateException.class)
   public void testAfterFailedCallable() throws Exception {
     Callable<Future<String>> failedCallable =
-        () -> Futures.failed(new IllegalStateException("Illegal!"));
+        () -> Future.failed(new IllegalStateException("Illegal!"));
 
     Future<String> delayedFuture =
         Patterns.after(
@@ -340,7 +340,7 @@ public class PatternsTest extends JUnitSuite {
             scala.concurrent.duration.Duration.create(200, "millis"),
             system.scheduler(),
             ec,
-            () -> Futures.failed(new IllegalStateException("Illegal!")));
+            () -> Future.failed(new IllegalStateException("Illegal!")));
 
     Future<String> resultFuture = Futures.firstCompletedOf(Arrays.asList(delayedFuture), ec);
     Await.result(resultFuture, FiniteDuration.apply(3, SECONDS));
@@ -355,7 +355,7 @@ public class PatternsTest extends JUnitSuite {
             scala.concurrent.duration.Duration.create(200, "millis"),
             system.scheduler(),
             ec,
-            () -> Futures.successful(expected));
+            () -> Future.successful(expected));
 
     Future<String> resultFuture = Futures.firstCompletedOf(Arrays.asList(delayedFuture), ec);
     final String actual = Await.result(resultFuture, FiniteDuration.apply(3, SECONDS));
@@ -372,7 +372,7 @@ public class PatternsTest extends JUnitSuite {
             scala.concurrent.duration.Duration.create(200, "millis"),
             system.scheduler(),
             ec,
-            () -> Futures.successful(expected));
+            () -> Future.successful(expected));
 
     Future<String> resultFuture = Futures.firstCompletedOf(Arrays.asList(delayedFuture), ec);
 
@@ -389,7 +389,7 @@ public class PatternsTest extends JUnitSuite {
             scala.concurrent.duration.Duration.create(200, "millis"),
             system.scheduler(),
             ec,
-            () -> Futures.successful("world"));
+            () -> Future.successful("world"));
 
     Future<String> immediateFuture = Futures.future(() -> expected, ec);
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -137,16 +137,19 @@ object Futures {
    *
    * @return         the newly created `Promise` object
    */
-  def promise[T](): Promise[T] = Promise[T]()
+   @deprecated("Use the Scala Promise API directly", "1.1.0")
+   def promise[T](): Promise[T] = Promise[T]()
 
   /**
    * creates an already completed Promise with the specified exception
    */
+  @deprecated("Use the Scala Future.failed API directly", "1.1.0")
   def failed[T](exception: Throwable): Future[T] = Future.failed(exception)
 
   /**
    * Creates an already completed Promise with the specified result
    */
+  @deprecated("Use the Scala Future.successful APIs directly", "1.1.0")
   def successful[T](result: T): Future[T] = Future.successful(result)
 
   /**

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -137,8 +137,8 @@ object Futures {
    *
    * @return         the newly created `Promise` object
    */
-   @deprecated("Use the Scala Promise API directly", "1.1.0")
-   def promise[T](): Promise[T] = Promise[T]()
+  @deprecated("Use the Scala Promise API directly", "1.1.0")
+  def promise[T](): Promise[T] = Promise[T]()
 
   /**
    * creates an already completed Promise with the specified exception

--- a/docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
+++ b/docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
@@ -14,7 +14,6 @@
 package jdocs.persistence;
 
 // #plugin-imports
-import org.apache.pekko.dispatch.Futures;
 import org.apache.pekko.persistence.*;
 import org.apache.pekko.persistence.journal.japi.*;
 import org.apache.pekko.persistence.snapshot.japi.*;
@@ -93,12 +92,12 @@ public class LambdaPersistencePluginDocTest {
 
     @Override
     public Future<Void> doDeleteAsync(SnapshotMetadata metadata) {
-      return Futures.successful(null);
+      return Future.successful(null);
     }
 
     @Override
     public Future<Void> doDeleteAsync(String persistenceId, SnapshotSelectionCriteria criteria) {
-      return Futures.successful(null);
+      return Future.successful(null);
     }
   }
 
@@ -111,9 +110,9 @@ public class LambdaPersistencePluginDocTest {
         Iterable<Optional<Exception>> result = new ArrayList<Optional<Exception>>();
         // blocking call here...
         // result.add(..)
-        return Futures.successful(result);
+        return Future.successful(result);
       } catch (Exception e) {
-        return Futures.failed(e);
+        return Future.failed(e);
       }
     }
     // #sync-journal-plugin-api

--- a/docs/src/test/java/jdocs/stream/FlowDocTest.java
+++ b/docs/src/test/java/jdocs/stream/FlowDocTest.java
@@ -19,7 +19,6 @@ import org.apache.pekko.actor.AbstractActor;
 import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.Cancellable;
-import org.apache.pekko.dispatch.Futures;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.*;
 import org.apache.pekko.stream.javadsl.*;
@@ -159,7 +158,7 @@ public class FlowDocTest extends AbstractJavaTest {
     Source.from(list);
 
     // Create a source form a Future
-    Source.future(Futures.successful("Hello Streams!"));
+    Source.future(Future.successful("Hello Streams!"));
 
     // Create a source from a single element
     Source.single("only one element");

--- a/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
+++ b/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
@@ -111,7 +111,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
   public void shutdownStream() throws Exception {
     new TestKit(system) {
       {
-        Promise<Done> shutdown = Futures.promise();
+        Promise<Done> shutdown = new Promise<Done>();
         TestSubscriber.Probe<String> probe =
             adhocSource(
                     Source.repeat("a")
@@ -134,7 +134,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
   public void notShutDownStream() throws Exception {
     new TestKit(system) {
       {
-        Promise<Done> shutdown = Futures.promise();
+        Promise<Done> shutdown = new Promise<Done>();
         TestSubscriber.Probe<String> probe =
             adhocSource(
                     Source.repeat("a")
@@ -166,7 +166,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
   public void restartUponDemand() throws Exception {
     new TestKit(system) {
       {
-        Promise<Done> shutdown = Futures.promise();
+        Promise<Done> shutdown = new Promise<Done>();
         AtomicInteger startedCount = new AtomicInteger(0);
 
         Source<String, ?> source =
@@ -196,7 +196,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
   public void restartUptoMaxRetries() throws Exception {
     new TestKit(system) {
       {
-        Promise<Done> shutdown = Futures.promise();
+        Promise<Done> shutdown = new Promise<Done>();
         AtomicInteger startedCount = new AtomicInteger(0);
 
         Source<String, ?> source =


### PR DESCRIPTION
see #1417 

Some of the methods in org.apache.pekko.dispatch.Futures don't have simple equivalents but these methods are not needed:
* promise
* failed
* successful