### PR TITLE
[DO NOT MERGE] upgrade aeron and agrona (1.0.x)

### DIFF
--- a/.github/workflows/nightly-builds-aeron.yml
+++ b/.github/workflows/nightly-builds-aeron.yml
@@ -1,6 +1,8 @@
 name: Nightly Aeron Tests
 
 on:
+  # hack to run these tests for this PR
+  pull_request:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,10 +24,10 @@ object Dependencies {
   val junitVersion = "4.13.2"
   val slf4jVersion = "1.7.36"
   // check agrona version when updating this
-  val aeronVersion = "1.38.1"
+  val aeronVersion = "1.44.1"
   // needs to be inline with the aeron version, check
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
-  val agronaVersion = "1.15.1"
+  val agronaVersion = "1.21.1"
   val nettyVersion = "3.10.6.Final"
   val protobufJavaVersion = "3.16.3"
   val logbackVersion = "1.2.11"


### PR DESCRIPTION
Try build with latest Aeron and Agrona libs.

Aeron 1.46.0 needs Java 17.