### PR TITLE
Add alsoTo/alsoToContext to FlowWithContext/SourceWithContext

### DIFF
--- a/docs/src/main/paradox/release-notes/releases-1.1.md
+++ b/docs/src/main/paradox/release-notes/releases-1.1.md
@@ -42,6 +42,7 @@ The Stream API has been updated to add some extra functions.
 * add Source.iterate operator ([PR1244](https://github.com/apache/pekko/pull/1244))
 * added extra retry operators that allow users to provide a predicate to decide whether to retry based on the exception ([PR1269](https://github.com/apache/pekko/pull/1269))
 * add optionalVia/unsafeOptionalDataVia operators ([PR1422](https://github.com/apache/pekko/pull/1422))
+* add alsoTo/alsoToContext operators to `SourceWithContext`/`FlowWithContext` ([PR-1443](https://github.com/apache/pekko/pull/1443))
 
 The Stream Testkit Java DSL has some extra functions.
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/DslFactoriesConsistencySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/DslFactoriesConsistencySpec.scala
@@ -33,6 +33,7 @@ class DslFactoriesConsistencySpec extends AnyWordSpec with Matchers {
       "getClass",
       "shape",
       "identityTraversalBuilder",
+      "contramapImpl",
       // futures in scaladsl vs completion stage in javadsl
       "lazyFutureSource", // lazyCompletionStageSource
       "futureSource", // completionStageSource

--- a/stream/src/main/mima-filters/1.0.x.backwards.excludes/pr-1443-also-alsoTo-source-flow-with-context.backwards.excludes
+++ b/stream/src/main/mima-filters/1.0.x.backwards.excludes/pr-1443-also-alsoTo-source-flow-with-context.backwards.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.stream.scaladsl.FlowWithContextOps.alsoTo")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.stream.scaladsl.FlowWithContextOps.alsoToContext")

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
@@ -138,6 +138,12 @@ final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: Flow[(In
       combine: (Mat, Mat2) => Mat3): FlowWithContext[In, CtxIn, Out2, Ctx2, Mat3] =
     new FlowWithContext(delegate.viaMat(flow)(combine))
 
+  override def alsoTo(that: Graph[SinkShape[Out], _]): Repr[Out, CtxOut] =
+    FlowWithContext.fromTuples(delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, CtxOut)) => in._1)))
+
+  override def alsoToContext(that: Graph[SinkShape[CtxOut], _]): Repr[Out, CtxOut] =
+    FlowWithContext.fromTuples(delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, CtxOut)) => in._2)))
+
   /**
    * Context-preserving variant of [[pekko.stream.scaladsl.Flow.withAttributes]].
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
@@ -89,6 +89,22 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
       combine: (Mat, Mat2) => Mat3): ReprMat[Out2, Ctx2, Mat3]
 
   /**
+   * Data variant of [[pekko.stream.scaladsl.FlowOps.alsoTo]]
+   *
+   * @see [[pekko.stream.scaladsl.FlowOps.alsoTo]]
+   * @since 1.1.0
+   */
+  def alsoTo(that: Graph[SinkShape[Out], _]): Repr[Out, Ctx]
+
+  /**
+   * Context variant of [[pekko.stream.scaladsl.FlowOps.alsoTo]]
+   *
+   * @see [[pekko.stream.scaladsl.FlowOps.alsoTo]]
+   * @since 1.1.0
+   */
+  def alsoToContext(that: Graph[SinkShape[Ctx], _]): Repr[Out, Ctx]
+
+  /**
    * Context-preserving variant of [[pekko.stream.scaladsl.FlowOps.map]].
    *
    * @see [[pekko.stream.scaladsl.FlowOps.map]]

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
@@ -51,7 +51,7 @@ final class Sink[-In, +Mat](override val traversalBuilder: LinearTraversalBuilde
    * '''Cancels when''' original [[Sink]] cancels
    * @since 1.1.0
    */
-  def contramap[In2](f: In2 => In): Sink[In2, Mat] = Flow.fromFunction(f).toMat(this)(Keep.right)
+  def contramap[In2](f: In2 => In): Sink[In2, Mat] = Sink.contramapImpl(this, f)
 
   /**
    * Connect this `Sink` to a `Source` and run it. The returned value is the materialized value
@@ -137,6 +137,10 @@ object Sink {
 
   /** INTERNAL API */
   def shape[T](name: String): SinkShape[T] = SinkShape(Inlet(name + ".in"))
+
+  @InternalApi private[pekko] final def contramapImpl[In, In2, Mat](
+      sink: Graph[SinkShape[In], Mat], f: In2 => In): Sink[In2, Mat] =
+    Flow.fromFunction(f).toMat(sink)(Keep.right)
 
   /**
    * A graph with the shape of a sink logically is a sink, this method makes

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
@@ -155,6 +155,12 @@ final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (delegate: Sourc
   def toMat[Mat2, Mat3](sink: Graph[SinkShape[(Out, Ctx)], Mat2])(combine: (Mat, Mat2) => Mat3): RunnableGraph[Mat3] =
     delegate.toMat(sink)(combine)
 
+  override def alsoTo(that: Graph[SinkShape[Out], _]): Repr[Out, Ctx] =
+    SourceWithContext.fromTuples(delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, Ctx)) => in._1)))
+
+  override def alsoToContext(that: Graph[SinkShape[Ctx], _]): Repr[Out, Ctx] =
+    SourceWithContext.fromTuples(delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, Ctx)) => in._2)))
+
   /**
    * Connect this [[pekko.stream.scaladsl.SourceWithContext]] to a [[pekko.stream.scaladsl.Sink]] and run it.
    * The returned value is the materialized value of the `Sink`.


### PR DESCRIPTION
This PR adds `alsoTo`/`alsoToContext` onto `FlowWithContext`/`SourceWithContext` which just wrap the underlying `delegate` methods, this is analogous to the current `map`/`mapContext` methods that already exist.

Note that `delegate.alsoTo(Flow.fromFunction { in: (Out, Ctx) => in._2 }.toMat(that)(Keep.right))` is copied from the implementation of `contramap`. I would have ideally liked to use `contramap` however the method is not available on a `Graph[SinkShape[_]]`

I didn't add tests due to the sheer triviality of the implementation but can add them if asked.