### PR TITLE
update scaladoc for QueueOfferResult.scala

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/QueueOfferResult.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/QueueOfferResult.scala
@@ -79,6 +79,8 @@ object QueueOfferResult {
 
   /**
    * Java API: The `QueueClosed` singleton instance
+   *
+   * @since 1.1.0   
    */
   def closed: QueueOfferResult = QueueClosed
 }


### PR DESCRIPTION
missing `@since` for #1377