### PR TITLE
feat: avoid nesting in Behavior Factories

### DIFF
--- a/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/javadsl/ActorCompile.java
+++ b/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/javadsl/ActorCompile.java
@@ -151,6 +151,16 @@ public class ActorCompile {
             });
   }
 
+  {
+    Behavior<MyMsg> b =
+        Behaviors.withTimersSetup(
+            (timers, ctx) -> {
+              timers.startSingleTimer("key", new MyMsgB("tick"), Duration.ofSeconds(1));
+              ctx.scheduleOnce(Duration.ofSeconds(1), ctx.getSelf(), new MyMsgB("tick"));
+              return Behaviors.ignore();
+            });
+  }
+
   static class MyBehavior extends ExtensibleBehavior<MyMsg> {
 
     @Override
@@ -230,6 +240,22 @@ public class ActorCompile {
                     throw new Exception("checked");
                   });
 
+              return Behaviors.empty();
+            });
+  }
+  // stash buffer with setup
+  {
+    Behavior<String> behavior =
+        Behaviors.withStashSetup(
+            5,
+            (stash, ctx) -> {
+              stash.forEach(
+                  msg -> {
+                    // checked is ok
+                    throw new Exception("checked");
+                  });
+
+              ctx.scheduleOnce(Duration.ofSeconds(1), ctx.getSelf(), "tick");
               return Behaviors.empty();
             });
   }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Behaviors.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Behaviors.scala
@@ -366,7 +366,7 @@ object Behaviors {
    */
   def withTimersSetup[T](
       factory: pekko.japi.function.Function2[TimerScheduler[T], ActorContext[T], Behavior[T]]): Behavior[T] =
-    setup(ctx => TimerSchedulerImpl.withTimers(timers => factory.apply(timers, ctx)))
+    setup(ctx => TimerSchedulerImpl.wrapWithTimers(timer => factory.apply(timer, ctx.asJava))(ctx.asScala))
 
   /**
    * Per message MDC (Mapped Diagnostic Context) logging.

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/Behaviors.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/Behaviors.scala
@@ -290,7 +290,7 @@ object Behaviors {
    */
   def withTimersSetup[T](factory: (TimerScheduler[T], ActorContext[T]) => Behavior[T]): Behavior[T] =
     setup(ctx => {
-      TimerSchedulerImpl.withTimers(factory(_, ctx))
+      TimerSchedulerImpl.wrapWithTimers(factory(_, ctx))(ctx)
     })
 
   /**


### PR DESCRIPTION
similar like #1444, but apply to timer and stash:

those nestings are pretty annoying, especially when i using AOSP format.

```diff

-          Behaviors.withTimers(t-> 
-              Behaviors.setup(ctx-> {
-                   // preStart something on here
-                  return new BehaviorXX();
-           }));
+          Behaviors.withTimersSetup((t, ctx) -> {
+             // preStart something on here
+              return new BehaviorXX();
+          });


```