### PR TITLE
publish 1.0.3 docs

### DIFF
--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -57,20 +57,20 @@ jobs:
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |-
-          sbt -Dpekko.genjavadoc.enabled=true -Dpekko.genlicensereport.enabled=true "set ThisBuild / version := \"1.0.2\"; docs/paradox; unidoc"
+          sbt -Dpekko.genjavadoc.enabled=true -Dpekko.genlicensereport.enabled=true "set ThisBuild / version := \"1.0.3\"; docs/paradox; unidoc"
 
       # Create directory structure upfront since rsync does not create intermediate directories otherwise
       - name: Create directory structure
         run: |-
-          mkdir -p target/nightly-docs/docs/pekko/1.0.2/
+          mkdir -p target/nightly-docs/docs/pekko/1.0.3/
           mkdir -p target/nightly-docs/docs/pekko/1.0/
-          cp -r docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0.2/docs
+          cp -r docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0.3/docs
           cp -r docs/target/paradox/site/main/ target/nightly-docs/docs/pekko/1.0/docs
           rm -r docs/target/paradox/site/main/
-          cp -r target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0.2/api
+          cp -r target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0.3/api
           cp -r target/scala-2.13/unidoc target/nightly-docs/docs/pekko/1.0/api
           rm -r target/scala-2.13/unidoc
-          cp -r target/javaunidoc target/nightly-docs/docs/pekko/1.0.2/japi
+          cp -r target/javaunidoc target/nightly-docs/docs/pekko/1.0.3/japi
           cp -r target/javaunidoc target/nightly-docs/docs/pekko/1.0/japi
           rm -r target/javaunidoc
 
@@ -79,7 +79,7 @@ jobs:
         with:
           upload: true
           switches: --archive --compress --update --delete --progress --relative
-          local_path: target/nightly-docs/./docs/pekko/1.0.2 # The intermediate dot is to show `--relative` which paths to operate on
+          local_path: target/nightly-docs/./docs/pekko/1.0.3 # The intermediate dot is to show `--relative` which paths to operate on
           remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
           remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}


### PR DESCRIPTION
I forgot to do when we released v1.0.3. This is now causing a problem after I merged https://github.com/apache/pekko-site/pull/123 because that redirects 'current' docs to the non-existent 1.0.3 docs.