### PR TITLE
Add overridden duration timeout to StreamTestKit

### DIFF
--- a/stream-testkit/src/main/mima-filters/1.1.1.backwards.excludes/pr-1468-override-timeout-stream-testkit.backwards.excludes
+++ b/stream-testkit/src/main/mima-filters/1.1.1.backwards.excludes/pr-1468-override-timeout-stream-testkit.backwards.excludes
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Add overridden duration timeout to StreamTestKit
+# StreamTestKit.assertNoChildren is an internal API and can be changed
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.testkit.scaladsl.StreamTestKit.assertNoChildren")

--- a/stream-testkit/src/main/mima-filters/1.1.1.backwards.excludes/pr-1468-override-timeout-stream-testkit.backwards.excludes
+++ b/stream-testkit/src/main/mima-filters/1.1.1.backwards.excludes/pr-1468-override-timeout-stream-testkit.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.testkit.scaladsl.StreamTestKit.assertNoChildren")

--- a/stream-testkit/src/main/mima-filters/1.1.1.backwards.excludes/pr-1468-override-timeout-stream-testkit.backwards.excludes
+++ b/stream-testkit/src/main/mima-filters/1.1.1.backwards.excludes/pr-1468-override-timeout-stream-testkit.backwards.excludes
@@ -1,1 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Add overridden duration timeout to StreamTestKit
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.testkit.scaladsl.StreamTestKit.assertNoChildren")

--- a/stream-testkit/src/main/scala/org/apache/pekko/stream/testkit/javadsl/StreamTestKit.scala
+++ b/stream-testkit/src/main/scala/org/apache/pekko/stream/testkit/javadsl/StreamTestKit.scala
@@ -19,6 +19,10 @@ import pekko.stream.{ Materializer, SystemMaterializer }
 import pekko.stream.impl.PhasedFusingActorMaterializer
 import pekko.stream.testkit.scaladsl
 
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+
 object StreamTestKit {
 
   /**
@@ -29,7 +33,21 @@ object StreamTestKit {
   def assertAllStagesStopped(mat: Materializer): Unit =
     mat match {
       case impl: PhasedFusingActorMaterializer =>
-        scaladsl.StreamTestKit.assertNoChildren(impl.system, impl.supervisor)
+        scaladsl.StreamTestKit.assertNoChildren(impl.system, impl.supervisor, None)
+      case _ =>
+    }
+
+  /**
+   * Assert that there are no stages running under a given materializer.
+   * Usually this assertion is run after a test-case to check that all of the
+   * stages have terminated successfully with an overridden duration that ignores
+   * `stream.testkit.all-stages-stopped-timeout`.
+   */
+  def assertAllStagesStopped(mat: Materializer, overrideTimeout: Duration): Unit =
+    mat match {
+      case impl: PhasedFusingActorMaterializer =>
+        scaladsl.StreamTestKit.assertNoChildren(impl.system, impl.supervisor,
+          Some(FiniteDuration(overrideTimeout.toMillis, TimeUnit.MILLISECONDS)))
       case _ =>
     }
 

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamConfiguration.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamConfiguration.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.testkit
+
+import org.apache.pekko.testkit.TestKitBase
+import org.scalatest.time.{ Millis, Span }
+
+import java.util.concurrent.TimeUnit
+
+trait StreamConfiguration extends TestKitBase {
+  case class StreamConfig(allStagesStoppedTimeout: Span = Span({
+          val c = system.settings.config.getConfig("pekko.stream.testkit")
+          c.getDuration("all-stages-stopped-timeout", TimeUnit.MILLISECONDS)
+        }, Millis))
+
+  private val defaultStreamConfig = StreamConfig()
+
+  /**
+   * The default `StreamConfig` which is derived from the Actor System's `pekko.stream.testkit.all-stages-stopped-timeout`
+   * configuration value. If you want to provide a different StreamConfig for specific tests without having to re-specify
+   * `pekko.stream.testkit.all-stages-stopped-timeout` then you can override this value.
+   */
+  implicit def streamConfig: StreamConfig = defaultStreamConfig
+
+}

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamSpec.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamSpec.scala
@@ -30,7 +30,10 @@ import org.scalatest.Failed
 
 import com.typesafe.config.{ Config, ConfigFactory }
 
-abstract class StreamSpec(_system: ActorSystem) extends PekkoSpec(_system) {
+import java.util.concurrent.TimeUnit
+
+abstract class StreamSpec(_system: ActorSystem) extends PekkoSpec(_system) with StreamConfiguration {
+
   def this(config: Config) =
     this(
       ActorSystem(
@@ -73,7 +76,8 @@ abstract class StreamSpec(_system: ActorSystem) extends PekkoSpec(_system) {
           case impl: PhasedFusingActorMaterializer =>
             stopAllChildren(impl.system, impl.supervisor)
             val result = test.apply()
-            assertNoChildren(impl.system, impl.supervisor)
+            assertNoChildren(impl.system, impl.supervisor,
+              Some(FiniteDuration(streamConfig.allStagesStoppedTimeout.millisPart, TimeUnit.MILLISECONDS)))
             result
           case _ => other
         }


### PR DESCRIPTION
The context of this change is https://github.com/apache/pekko-http/pull/590#pullrequestreview-2281514043. It turns out its extremely cumbersome to manually override the duration so I am adding this public method

@raboof @jrudolph Let me know if this line of thinking is on the right lines.