### PR TITLE
Fix OSGi metadata

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -141,7 +141,7 @@ object OSGi {
       "!scala.util.parsing.*",
       scalaImport(scalaVersion),
       "*")
-  def pekkoImport(packageName: String = "org.apache.pekko.*") = versionedImport(packageName, "1.0", "1.1")
+  def pekkoImport(packageName: String = "org.apache.pekko.*") = versionedImport(packageName, "1.1", "1.2")
   def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.4.0", "1.5.0")
   def scalaImport(version: String) = {
     val packageName = "scala.*"


### PR DESCRIPTION
Set the correct version range for `Import-Package` declarations to `org.apache.pekko` packages.

Fixes #1479.