### PR TITLE
mark stop() method as noinline

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/Dispatch.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/Dispatch.scala
@@ -159,7 +159,7 @@ private[pekko] trait Dispatch { this: ActorCell =>
     catch handleException
 
   // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
-  final def stop(): Unit =
+  @noinline final def stop(): Unit =
     try dispatcher.systemDispatch(this, Terminate())
     catch handleException
 

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/Dispatch.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/Dispatch.scala
@@ -159,6 +159,8 @@ private[pekko] trait Dispatch { this: ActorCell =>
     catch handleException
 
   // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
+  // this function is marked `noinline` because Kamon and other metrics libraries
+  // instrument this function
   @noinline final def stop(): Unit =
     try dispatcher.systemDispatch(this, Terminate())
     catch handleException


### PR DESCRIPTION
relates to #1484 

I have similar issues in https://github.com/pjfanning/micrometer-pekko and this change fixes the broken test I ran into there when upgrading to Pekko 1.1.

I have tested this locally and it fixes the issue in micrometer-pekko.

More changes will be needed for Kamon but I'm raising this to show a path forward and to see if this acceptable for Pekko 1.1.2. We can add more changes in more PRs.

I won't merge this until a few people have reviewed it and there are no objections.

fyi @hughsimpson