### PR TITLE
Fix downstream kamon instrumentation

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
@@ -34,7 +34,7 @@ import com.typesafe.config.Config
 
 final case class Envelope private (message: Any, sender: ActorRef) {
 
-  @noinline
+  @noinline // not inlined to permit downstream bytecode instrumentation to attach context information to the Envelope
   def copy(message: Any = message, sender: ActorRef = sender) = {
     Envelope(message, sender)
   }

--- a/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
@@ -34,6 +34,7 @@ import com.typesafe.config.Config
 
 final case class Envelope private (message: Any, sender: ActorRef) {
 
+  @noinline
   def copy(message: Any = message, sender: ActorRef = sender) = {
     Envelope(message, sender)
   }

--- a/actor/src/main/scala/org/apache/pekko/dispatch/ThreadPoolBuilder.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/ThreadPoolBuilder.scala
@@ -85,6 +85,17 @@ final case class ThreadPoolConfig(
     queueFactory: ThreadPoolConfig.QueueFactory = ThreadPoolConfig.linkedBlockingQueue(),
     rejectionPolicy: RejectedExecutionHandler = ThreadPoolConfig.defaultRejectionPolicy)
     extends ExecutorServiceFactoryProvider {
+  @noinline
+  def copy(
+      allowCorePoolTimeout: Boolean = allowCorePoolTimeout,
+      corePoolSize: Int = corePoolSize,
+      maxPoolSize: Int = maxPoolSize,
+      threadTimeout: Duration = threadTimeout,
+      queueFactory: ThreadPoolConfig.QueueFactory = queueFactory,
+      rejectionPolicy: RejectedExecutionHandler = rejectionPolicy
+  ): ThreadPoolConfig =
+    ThreadPoolConfig(allowCorePoolTimeout, corePoolSize, maxPoolSize, threadTimeout, queueFactory, rejectionPolicy)
+
   class ThreadPoolExecutorServiceFactory(val threadFactory: ThreadFactory) extends ExecutorServiceFactory {
     def createExecutorService: ExecutorService = {
       val service: ThreadPoolExecutor = new ThreadPoolExecutor(

--- a/actor/src/main/scala/org/apache/pekko/dispatch/ThreadPoolBuilder.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/ThreadPoolBuilder.scala
@@ -85,6 +85,8 @@ final case class ThreadPoolConfig(
     queueFactory: ThreadPoolConfig.QueueFactory = ThreadPoolConfig.linkedBlockingQueue(),
     rejectionPolicy: RejectedExecutionHandler = ThreadPoolConfig.defaultRejectionPolicy)
     extends ExecutorServiceFactoryProvider {
+  // Written explicitly to permit non-inlined defn; this is necessary for downstream instrumentation that stores extra
+  // context information on the config
   @noinline
   def copy(
       allowCorePoolTimeout: Boolean = allowCorePoolTimeout,

--- a/actor/src/main/scala/org/apache/pekko/util/MessageBuffer.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/MessageBuffer.scala
@@ -160,7 +160,7 @@ final class MessageBuffer private (private var _head: MessageBuffer.Node, privat
 
 object MessageBuffer {
   private final class Node(var next: Node, val message: Any, val ref: ActorRef) {
-    @noinline
+    @noinline // not inlined to permit downstream bytecode instrumentation to apply context information on the Node to the message
     def apply(f: (Any, ActorRef) => Unit): Unit = {
       f(message, ref)
     }

--- a/actor/src/main/scala/org/apache/pekko/util/MessageBuffer.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/MessageBuffer.scala
@@ -160,6 +160,7 @@ final class MessageBuffer private (private var _head: MessageBuffer.Node, privat
 
 object MessageBuffer {
   private final class Node(var next: Node, val message: Any, val ref: ActorRef) {
+    @noinline
     def apply(f: (Any, ActorRef) => Unit): Unit = {
       f(message, ref)
     }


### PR DESCRIPTION
cf https://github.com/apache/pekko/issues/1484 and https://github.com/kamon-io/Kamon/issues/1352

These three sites are enough to fix downstream kamon instrumentation (at least, enough to pass the test suite and negate the need for a recent workaround)