### PR TITLE
Support primitives in Flow#collectType

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCollectTypeSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCollectTypeSpec.scala
@@ -25,7 +25,7 @@ class FlowCollectTypeSpec extends StreamSpec {
 
   "A CollectType" must {
 
-    "collectType" in {
+    "collectType with references" in {
       val fruit = Source(List(Orange, Apple, Apple, Orange))
 
       val apples = fruit.collectType[Apple].runWith(Sink.seq).futureValue
@@ -34,6 +34,17 @@ class FlowCollectTypeSpec extends StreamSpec {
       oranges should equal(List(Orange, Orange))
       val all = fruit.collectType[Fruit].runWith(Sink.seq).futureValue
       all should equal(List(Orange, Apple, Apple, Orange))
+    }
+
+    "collectType with primitives" in {
+      val numbers = Source(List[Int](1, 2, 3) ++ List[Double](1.5))
+
+      val integers = numbers.collectType[Int].runWith(Sink.seq).futureValue
+      integers should equal(List(1, 2, 3))
+      val doubles = numbers.collectType[Double].runWith(Sink.seq).futureValue
+      doubles should equal(List(1.5))
+      val all = numbers.collectType[Any].runWith(Sink.seq).futureValue
+      all should equal(List(1, 2, 3, 1.5))
     }
 
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1686,7 +1686,7 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream cancels
    */
   def collectType[T](implicit tag: ClassTag[T]): Repr[T] =
-    collect { case c if tag.runtimeClass.isInstance(c) => c.asInstanceOf[T] }
+    collect { case tag(c) => c }
 
   /**
    * Chunk up this stream into groups of the given size, with the last group


### PR DESCRIPTION
`Flow#collectType` was not working as expected for primitives. This PR replaces the use of `ClassTag#runtimeClass#instanceOf` with `ClassTag#unapply`.

While the default implementation of `ClassTag#unapply` simply defers to `ClassTag#runtimeClass#instanceOf`, this is not the case for the `ClassTag`s of primitives, which only override `unapply`.

See the `IntManifest` for an example:

https://github.com/scala/scala/blob/v2.13.14/src/library/scala/reflect/Manifest.scala#L223-L236