### PR TITLE
Fix CollectionUtil `toSeq` methods

### DIFF
--- a/stream/src/main/scala-2.13/org/apache/pekko/stream/javadsl/CollectionUtil.scala
+++ b/stream/src/main/scala-2.13/org/apache/pekko/stream/javadsl/CollectionUtil.scala
@@ -21,6 +21,7 @@ package javadsl
 import scala.collection.immutable
 
 import org.apache.pekko
+import pekko.annotation.InternalApi
 import pekko.util.ccompat.JavaConverters._
 
 /**
@@ -28,6 +29,7 @@ import pekko.util.ccompat.JavaConverters._
  *
  * Utility methods for converting Java collections to Scala collections.
  */
+@InternalApi
 private[javadsl] object CollectionUtil {
   @inline def toSeq[T](jlist: java.util.List[T]): immutable.Seq[T] =
     jlist.asScala.toSeq

--- a/stream/src/main/scala-3/org/apache/pekko/stream/javadsl/CollectionUtil.scala
+++ b/stream/src/main/scala-3/org/apache/pekko/stream/javadsl/CollectionUtil.scala
@@ -22,7 +22,7 @@ import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.japi.Util.immutableSeq
+import pekko.util.ccompat.JavaConverters._
 
 /**
  * INTERNAL API
@@ -31,9 +31,9 @@ import pekko.japi.Util.immutableSeq
  */
 @InternalApi
 private[javadsl] object CollectionUtil {
-  @inline def toSeq[T](jlist: java.util.List[T]): immutable.Seq[T] =
-    immutableSeq(jlist)
+  inline def toSeq[T](jlist: java.util.List[T]): immutable.Seq[T] =
+    jlist.asScala.toSeq
 
-  @inline def toSeq[T](jiterable: java.lang.Iterable[T]): immutable.Seq[T] =
-    immutableSeq(jiterable)
+  inline def toSeq[T](jiterable: java.lang.Iterable[T]): immutable.Seq[T] =
+    jiterable.asScala.toSeq
 }


### PR DESCRIPTION
This PR fixes the the newly added `.toSeq` methods, more specifically

* Adds the pekko  `@InternalApi` annotation
* Moves the `scala-2.13+` to just `scala-2.13` and adds an implementation bespoke to `scala-3`. This is because `@inline` doesn't do anything in Scala 3, instead you have to use the new `inline` keyword.