### PR TITLE
reduce use of scala.collection.JavaConverters

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/actor/ActorPath.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorPath.scala
@@ -218,7 +218,7 @@ sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
    */
   @nowarn("msg=deprecated")
   def getElements: java.lang.Iterable[String] =
-    scala.collection.JavaConverters.asJavaIterableConverter(elements).asJava
+    elements.asJava
 
   /**
    * Walk up the tree to obtain and return the RootActorPath.

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
@@ -427,10 +427,8 @@ object ActorSystem {
     final val EnableAdditionalSerializationBindings: Boolean = true
     final val SerializeAllMessages: Boolean = getBoolean("pekko.actor.serialize-messages")
     final val SerializeAllCreators: Boolean = getBoolean("pekko.actor.serialize-creators")
-    final val NoSerializationVerificationNeededClassPrefix: Set[String] = {
-      import pekko.util.ccompat.JavaConverters._
+    final val NoSerializationVerificationNeededClassPrefix: Set[String] =
       getStringList("pekko.actor.no-serialization-verification-needed-class-prefix").asScala.toSet
-    }
 
     final val LogLevel: String = getString("pekko.loglevel")
     final val StdoutLogLevel: String = getString("pekko.stdout-loglevel")

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/Children.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/Children.scala
@@ -42,8 +42,10 @@ private[pekko] trait Children { this: ActorCell =>
 
   final def children: immutable.Iterable[ActorRef] = childrenRefs.children
   @nowarn("msg=deprecated")
-  final def getChildren(): java.lang.Iterable[ActorRef] =
-    scala.collection.JavaConverters.asJavaIterableConverter(children).asJava
+  final def getChildren(): java.lang.Iterable[ActorRef] = {
+    import pekko.util.ccompat.JavaConverters._
+    children.asJava
+  }
 
   final def child(name: String): Option[ActorRef] = Option(getChild(name))
   final def getChild(name: String): ActorRef = childrenRefs.getByName(name) match {

--- a/actor/src/main/scala/org/apache/pekko/util/Index.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/Index.scala
@@ -16,10 +16,7 @@ package org.apache.pekko.util
 import java.util.Comparator
 import java.util.concurrent.{ ConcurrentHashMap, ConcurrentSkipListSet }
 
-import scala.collection.JavaConverters.collectionAsScalaIterableConverter
-
-import annotation.tailrec
-import scala.annotation.nowarn
+import scala.annotation.tailrec
 
 import org.apache.pekko.util.ccompat.JavaConverters._
 
@@ -154,8 +151,7 @@ class Index[K, V](val mapSize: Int, val valueComparator: Comparator[V]) {
     if (set ne null) {
       set.synchronized {
         container.remove(key, set)
-        @nowarn("msg=deprecated")
-        val ret = collectionAsScalaIterableConverter(set.clone()).asScala // Make copy since we need to clear the original
+        val ret = set.clone().asScala // Make copy since we need to clear the original
         set.clear() // Clear the original set to signal to any pending writers that there was a conflict
         Some(ret)
       }

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/ClusterMetricsCollector.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/ClusterMetricsCollector.scala
@@ -107,8 +107,10 @@ final case class ClusterMetricsChanged(nodeMetrics: Set[NodeMetrics]) extends Cl
 
   /** Java API */
   @nowarn("msg=deprecated")
-  def getNodeMetrics: java.lang.Iterable[NodeMetrics] =
-    scala.collection.JavaConverters.asJavaIterableConverter(nodeMetrics).asJava
+  def getNodeMetrics: java.lang.Iterable[NodeMetrics] = {
+    import pekko.util.ccompat.JavaConverters._
+    nodeMetrics.asJava
+  }
 }
 
 /**

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/Metric.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/Metric.scala
@@ -336,8 +336,10 @@ final case class NodeMetrics(address: Address, timestamp: Long, metrics: Set[Met
    * Java API
    */
   @nowarn("msg=deprecated")
-  def getMetrics: java.lang.Iterable[Metric] =
-    scala.collection.JavaConverters.asJavaIterableConverter(metrics).asJava
+  def getMetrics: java.lang.Iterable[Metric] = {
+    import pekko.util.ccompat.JavaConverters._
+    metrics.asJava
+  }
 
   /**
    * Returns true if <code>that</code> address is the same as this

--- a/cluster-tools/src/main/scala/org/apache/pekko/cluster/client/ClusterClient.scala
+++ b/cluster-tools/src/main/scala/org/apache/pekko/cluster/client/ClusterClient.scala
@@ -171,10 +171,8 @@ final class ClusterClientSettings(
   /**
    * Java API
    */
-  def withInitialContacts(initialContacts: java.util.Set[ActorPath]): ClusterClientSettings = {
-    import pekko.util.ccompat.JavaConverters._
+  def withInitialContacts(initialContacts: java.util.Set[ActorPath]): ClusterClientSettings =
     withInitialContacts(initialContacts.asScala.toSet)
-  }
 
   def withEstablishingGetContactsInterval(establishingGetContactsInterval: FiniteDuration): ClusterClientSettings =
     copy(establishingGetContactsInterval = establishingGetContactsInterval)
@@ -282,7 +280,6 @@ case object GetContactPoints extends GetContactPoints {
  * @param contactPoints The presently known list of contact points.
  */
 final case class ContactPoints(contactPoints: Set[ActorPath]) {
-  import pekko.util.ccompat.JavaConverters._
 
   /**
    * Java API
@@ -865,7 +862,6 @@ case object GetClusterClients extends GetClusterClients {
  * @param clusterClients The presently known list of cluster clients.
  */
 final case class ClusterClients(clusterClients: Set[ActorRef]) {
-  import pekko.util.ccompat.JavaConverters._
 
   /**
    * Java API

--- a/cluster/src/main/scala/org/apache/pekko/cluster/Cluster.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/Cluster.scala
@@ -111,8 +111,10 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    * Java API: roles that this member has
    */
   @nowarn("msg=deprecated")
-  def getSelfRoles: java.util.Set[String] =
-    scala.collection.JavaConverters.setAsJavaSetConverter(selfRoles).asJava
+  def getSelfRoles: java.util.Set[String] = {
+    import pekko.util.ccompat.JavaConverters._
+    selfRoles.asJava
+  }
 
   private val _isTerminated = new AtomicBoolean(false)
   private val log = Logging.withMarker(system, ClusterLogClass.ClusterCore)

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterEvent.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterEvent.scala
@@ -30,6 +30,7 @@ import pekko.cluster.MemberStatus._
 import pekko.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import pekko.event.EventStream
 import pekko.util.ccompat._
+import pekko.util.ccompat.JavaConverters._
 
 /**
  * Domain events published to the event bus.
@@ -138,31 +139,29 @@ object ClusterEvent {
     /**
      * Java API: get current member list.
      */
-    def getMembers: java.lang.Iterable[Member] = {
-      import pekko.util.ccompat.JavaConverters._
+    def getMembers: java.lang.Iterable[Member] =
       members.asJava
-    }
 
     /**
      * Java API: get current unreachable set.
      */
     @nowarn("msg=deprecated")
     def getUnreachable: java.util.Set[Member] =
-      scala.collection.JavaConverters.setAsJavaSetConverter(unreachable).asJava
+      unreachable.asJava
 
     /**
      * Java API: All data centers in the cluster
      */
     @nowarn("msg=deprecated")
     def getUnreachableDataCenters: java.util.Set[String] =
-      scala.collection.JavaConverters.setAsJavaSetConverter(unreachableDataCenters).asJava
+      unreachableDataCenters.asJava
 
     /**
      * Java API: get current “seen-by” set.
      */
     @nowarn("msg=deprecated")
     def getSeenBy: java.util.Set[Address] =
-      scala.collection.JavaConverters.setAsJavaSetConverter(seenBy).asJava
+      seenBy.asJava
 
     /**
      * Java API: get address of current data center leader, or null if none
@@ -190,7 +189,7 @@ object ClusterEvent {
      */
     @nowarn("msg=deprecated")
     def getAllRoles: java.util.Set[String] =
-      scala.collection.JavaConverters.setAsJavaSetConverter(allRoles).asJava
+      allRoles.asJava
 
     /**
      * All data centers in the cluster
@@ -202,7 +201,7 @@ object ClusterEvent {
      */
     @nowarn("msg=deprecated")
     def getAllDataCenters: java.util.Set[String] =
-      scala.collection.JavaConverters.setAsJavaSetConverter(allDataCenters).asJava
+      allDataCenters.asJava
 
     /**
      * Replace the set of unreachable datacenters with the given set

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ConfigUtil.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ConfigUtil.scala
@@ -25,7 +25,7 @@ private[cluster] object ConfigUtil {
 
   @nowarn("msg=deprecated")
   def addAkkaConfig(cfg: Config, akkaVersion: String): Config = {
-    import scala.collection.JavaConverters._
+    import org.apache.pekko.util.ccompat.JavaConverters._
     val innerSet = cfg.entrySet().asScala
       .filter(e => e.getKey.startsWith("pekko.") && e.getValue.valueType() != ConfigValueType.OBJECT)
       .map { entry =>

--- a/cluster/src/main/scala/org/apache/pekko/cluster/Member.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/Member.scala
@@ -62,8 +62,10 @@ class Member private[cluster] (
    * Java API
    */
   @nowarn("msg=deprecated")
-  def getRoles: java.util.Set[String] =
-    scala.collection.JavaConverters.setAsJavaSetConverter(roles).asJava
+  def getRoles: java.util.Set[String] = {
+    import pekko.util.ccompat.JavaConverters._
+    roles.asJava
+  }
 
   /**
    * Is this member older, has been part of cluster longer, than another

--- a/remote/src/main/scala/org/apache/pekko/remote/RemotingLifecycleEvent.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemotingLifecycleEvent.scala
@@ -78,8 +78,10 @@ final case class AssociationErrorEvent(
 @SerialVersionUID(1L)
 @nowarn("msg=deprecated")
 final case class RemotingListenEvent(listenAddresses: Set[Address]) extends RemotingLifecycleEvent {
-  def getListenAddresses: java.util.Set[Address] =
-    scala.collection.JavaConverters.setAsJavaSetConverter(listenAddresses).asJava
+  def getListenAddresses: java.util.Set[Address] = {
+    import pekko.util.ccompat.JavaConverters._
+    listenAddresses.asJava
+  }
   override def logLevel: Logging.LogLevel = Logging.InfoLevel
   override def toString: String = "Remoting now listens on addresses: " + listenAddresses.mkString("[", ", ", "]")
 }


### PR DESCRIPTION
also tidies up some stray instances where the Pekko converters are imported unnecessarily