### PR TITLE
Disable Develocity local build cache

### DIFF
--- a/project/PekkoDevelocityPlugin.scala
+++ b/project/PekkoDevelocityPlugin.scala
@@ -53,6 +53,11 @@ object PekkoDevelocityPlugin extends AutoPlugin {
               .withObfuscation(
                 original.buildScan.obfuscation
                   .withIpAddresses(_.map(_ => ObfuscatedIPv4Address))))
+          .withBuildCache(
+            original.buildCache
+              .withLocal(
+                original.buildCache.local
+                  .withEnabled(false)))
       if (isInsideCI) {
         apacheDevelocityConfiguration
           .withTestRetryConfiguration(
@@ -71,7 +76,6 @@ object PekkoDevelocityJdk9TestSettingsPlugin extends AutoPlugin {
   override lazy val trigger: PluginTrigger = allRequirements
   override lazy val requires: Plugins = DevelocityPlugin && Jdk9
 
-  // See https://docs.gradle.com/develocity/sbt-plugin/#capturing_test_data_in_a_custom_configuration
-  override lazy val projectSettings =
-    inConfig(Jdk9.TestJdk9)(DevelocityPlugin.testSettings)
+  // See https://docs.gradle.com/develocity/sbt-plugin/#enabling_build_cache_in_a_custom_sbt_configuration
+  override lazy val projectSettings = DevelocityPlugin.develocitySettings(Jdk9.TestJdk9)
 }


### PR DESCRIPTION
sbt-develocity v1.1 ships with local and remote build cache support for the `compile` and `test` tasks (see
https://gradle.com/develocity/releases/2024.2#build-caching-for-sbt).

The local build cache is enabled by default, while the remote cache requires configuring the nodes that are allowed to upload artifacts to the build cache (see
https://docs.gradle.com/develocity/sbt-build-cache/#rolling_out_the_cache_in_your_organization).

It's important to confirm that a project's build is ready to use the build cache (local or remote) to avoid unexpected behaviors. Specifically, one should make sure that all relevant inputs to the `compile` or `test` task are captured, as otherwise the generated build cache key will be incorrect (this can lead to erractic behavior, as entries from the cache will be reused when they shouldn't). Refer to
https://docs.gradle.com/enterprise/sbt-plugin/#caching_the_compile_task to know what are the build cache inputs captured for the `compile` task and https://docs.gradle.com/enterprise/sbt-plugin/#caching_the_test_testonly_and_testquick_tasks for the `test` task.

This commits disables the local build cache so that a proper rollout can be planned (see
https://docs.gradle.com/develocity/sbt-build-cache/#rolling_out_the_cache_in_your_organization).