### PR TITLE
Fix determining log class by stack on JDK21

### DIFF
--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/LoggerClass.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/LoggerClass.scala
@@ -64,7 +64,7 @@ private[pekko] object LoggerClass {
           val lambdaClsOwner = for {
             nextCaller <- trace.lift(idx)
             nextName = nextCaller.getName()
-            lambdaNameIdx = nextName.indexOf("$$Lambda$")
+            lambdaNameIdx = nextName.indexOf("$$Lambda")
             if nextName.startsWith(cls.getName()) && lambdaNameIdx > 0
             lambdaClsOwner = nextName.substring(0, lambdaNameIdx)
           } yield Class.forName(lambdaClsOwner)


### PR DESCRIPTION
Fixes #1521

It appears on JDK21 the lambda class is called e.g. `class org.apache.pekko.persistence.typed.EventSourcedBehaviorLoggingSpec$ChattyEventSourcingBehavior$$$Lambda/0x00007f1aa03e53b0` instead of e.g. `class org.apache.pekko.persistence.typed.EventSourcedBehaviorLoggingSpec$ChattyEventSourcingBehavior$$$Lambda$523/0x000000080053e040`