### PR TITLE
revert zipWithIndex changes

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowZipWithIndexSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowZipWithIndexSpec.scala
@@ -69,7 +69,8 @@ class FlowZipWithIndexSpec extends StreamSpec {
         UniformFanInShape(zip2.out, zip1.in0, zip1.in1, zip2.in1)
       }
 
-      val resultSink = Sink.foreach(println)
+      val probe = TestSubscriber.manualProbe[(Int, AnyVal)]()
+      val resultSink = Sink.fromSubscriber(probe)
 
       val g = RunnableGraph.fromGraph(GraphDSL.createGraph(resultSink) { implicit b => sink =>
         // importing the partial graph will return its shape (inlets & outlets)
@@ -83,6 +84,11 @@ class FlowZipWithIndexSpec extends StreamSpec {
       })
 
       g.run()
+
+      val subscription = probe.expectSubscription()
+      subscription.request(1)
+      probe.expectNext((3, 0))
+      probe.expectComplete()
     }
 
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowZipWithIndexSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowZipWithIndexSpec.scala
@@ -60,9 +60,8 @@ class FlowZipWithIndexSpec extends StreamSpec {
     "support junction output ports" in {
       // https://github.com/apache/pekko/issues/1525
       import GraphDSL.Implicits._
-  
-      val pickMaxOfThree = GraphDSL.create() { implicit b =>
 
+      val pickMaxOfThree = GraphDSL.create() { implicit b =>
         val zip1 = b.add(ZipWith[Int, Int, Int](math.max _))
         val zip2 = b.add(ZipWith[Int, Int, Int](math.max _))
         zip1.out ~> zip2.in0
@@ -73,13 +72,12 @@ class FlowZipWithIndexSpec extends StreamSpec {
       val resultSink = Sink.foreach(println)
 
       val g = RunnableGraph.fromGraph(GraphDSL.createGraph(resultSink) { implicit b => sink =>
-
         // importing the partial graph will return its shape (inlets & outlets)
         val pm3 = b.add(pickMaxOfThree)
 
-        Source.single(1) ~> pm3.in(0)
-        Source.single(2) ~> pm3.in(1)
-        Source.single(3) ~> pm3.in(2)
+        Source.single(1)     ~> pm3.in(0)
+        Source.single(2)     ~> pm3.in(1)
+        Source.single(3)     ~> pm3.in(2)
         pm3.out.zipWithIndex ~> sink.in
         ClosedShape
       })

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -3304,10 +3304,16 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipWithIndex: Repr[(Out, Long)] =
-    statefulMap(() => 0L)((index, out) =>
-        (index + 1L, (out, index)), _ => None)
-      .withAttributes(DefaultAttributes.zipWithIndex)
+  def zipWithIndex: Repr[(Out, Long)] = {
+    statefulMapConcat[(Out, Long)] { () =>
+      var index: Long = 0L
+      elem => {
+        val zipped = (elem, index)
+        index += 1
+        immutable.Iterable[(Out, Long)](zipped)
+      }
+    }
+  }
 
   /**
    * Interleave is a deterministic merge of the given [[Source]] with elements of this [[Flow]].


### PR DESCRIPTION
relates to #1525 

I have validated that the test fails without the zipWithIndex change.