### PR TITLE
fix alignment in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule.interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule.interval: "daily"


### PR DESCRIPTION
* see https://github.com/apache/pekko/runs/32596468063
* appears to complain that there is no 'schedule'
* compare this to https://github.com/pjfanning/excel-streaming-reader/blob/main/.github/dependabot.yml
* note the different indent
* this is a bit of guesswork because some of the yaml issues can be tricky and it is hard to know if GitHUB CI wokflows are valid until you merge them

