### PR TITLE
fix: link to GitHub for Hyperic Sigar

### DIFF
--- a/docs/src/main/paradox/cluster-metrics.md
+++ b/docs/src/main/paradox/cluster-metrics.md
@@ -82,7 +82,7 @@ ClusterMetricsExtension.get(system).subscribe(metricsListenerActor);
 
 ## Hyperic Sigar Provisioning
 
-Both user-provided and built-in metrics collectors can optionally use [Hyperic Sigar](http://www.hyperic.com/products/sigar)
+Both user-provided and built-in metrics collectors can optionally use [Hyperic Sigar](https://github.com/hyperic/sigar)
 for a wider and more accurate range of metrics compared to what can be retrieved from ordinary JMX MBeans.
 
 Sigar is using a native o/s library, and requires library provisioning, i.e.


### PR DESCRIPTION
sigar seems dormant: the website is not on 'https', and has become entirely unreachable recently. The repo hasn't seen an update since 9 years.

Perhaps we should consider whether it's responsible to still link to it at all - but for now let's at least link to the GitHub repo instead of the defunct website.