### PR TITLE
jackson 2.18 with max-token-count support

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,6 @@
 updates.pin = [
-  { groupId = "com.fasterxml.jackson.core", version = "2.17." }
+  # Jackson upgrades can be complicated to coordinate across modules - it is better to upgrade manually
+  { groupId = "com.fasterxml.jackson.core", version = "2.18." }
   # Pin logback to v1.3.x because v1.4.x needs JDK11
   { groupId = "ch.qos.logback", version="1.3." }
   # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
   val nettyVersion = "4.1.114.Final"
   val logbackVersion = "1.3.14"
 
-  val jacksonCoreVersion = "2.17.3"
+  val jacksonCoreVersion = "2.18.1"
   val jacksonDatabindVersion = jacksonCoreVersion
 
   val scala212Version = "2.12.20"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
   val nettyVersion = "4.1.114.Final"
   val logbackVersion = "1.3.14"
 
-  val jacksonCoreVersion = "2.18.1"
+  val jacksonCoreVersion = "2.18.2"
   val jacksonDatabindVersion = jacksonCoreVersion
 
   val scala212Version = "2.12.20"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -106,7 +106,8 @@ object Dependencies {
     val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
     val jacksonJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonCoreVersion
     val jacksonJsr310 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonCoreVersion
-    val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonCoreVersion
+    val jacksonScala = ("com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonCoreVersion)
+      .excludeAll(ExclusionRule(organization = "org.scala-lang"))
     val jacksonParameterNames = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonCoreVersion
     val jacksonCbor = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCoreVersion
     val lz4Java = "org.lz4" % "lz4-java" % "1.8.0"

--- a/serialization-jackson/src/main/resources/reference.conf
+++ b/serialization-jackson/src/main/resources/reference.conf
@@ -59,6 +59,8 @@ pekko.serialization.jackson {
     max-name-length = 50000
     # max-document-length of -1 means unlimited
     max-document-length = -1
+    # max-token-count of -1 means unlimited
+    max-token-count = -1
   }
 
   write {

--- a/serialization-jackson/src/main/resources/reference.conf
+++ b/serialization-jackson/src/main/resources/reference.conf
@@ -39,7 +39,7 @@ pekko.serialization.jackson {
   # https://javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.18.1/com/fasterxml/jackson/core/util/JsonRecyclerPools.html
   # The default is "thread-local" which is the same as the default in Jackson 2.18.
   buffer-recycler {
-    # the supported values are "thread-local", "concurrent-deque", "shared-concurrent-deque", "bounded"
+    # the supported values are "thread-local", "concurrent-deque", "shared-concurrent-deque", "bounded", "non-recycling"
     pool-instance = "thread-local"
     # the maximum size of bounded recycler pools - must be >=1 or an IllegalArgumentException will occur
     # only applies to pool-instance type "bounded"

--- a/serialization-jackson/src/main/resources/reference.conf
+++ b/serialization-jackson/src/main/resources/reference.conf
@@ -36,11 +36,10 @@ pekko.serialization.jackson {
   }
 
   # Controls the Buffer Recycler Pool implementation used by Jackson.
-  # https://javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.17.1/com/fasterxml/jackson/core/util/JsonRecyclerPools.html
-  # The default is "thread-local" which is the same as the default in Jackson 2.16.
+  # https://javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.18.1/com/fasterxml/jackson/core/util/JsonRecyclerPools.html
+  # The default is "thread-local" which is the same as the default in Jackson 2.18.
   buffer-recycler {
-    # the supported values are "thread-local", "lock-free", "shared-lock-free", "concurrent-deque",
-    # "shared-concurrent-deque", "bounded"
+    # the supported values are "thread-local", "concurrent-deque", "shared-concurrent-deque", "bounded"
     pool-instance = "thread-local"
     # the maximum size of bounded recycler pools - must be >=1 or an IllegalArgumentException will occur
     # only applies to pool-instance type "bounded"

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -160,8 +160,6 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
   private def getBufferRecyclerPool(cfg: Config): RecyclerPool[BufferRecycler] = {
     cfg.getString("buffer-recycler.pool-instance") match {
       case "thread-local"            => JsonRecyclerPools.threadLocalPool()
-      case "lock-free"               => JsonRecyclerPools.newLockFreePool()
-      case "shared-lock-free"        => JsonRecyclerPools.sharedLockFreePool()
       case "concurrent-deque"        => JsonRecyclerPools.newConcurrentDequePool()
       case "shared-concurrent-deque" => JsonRecyclerPools.sharedConcurrentDequePool()
       case "bounded"                 => JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"))

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -90,6 +90,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       .maxStringLength(config.getInt("read.max-string-length"))
       .maxNameLength(config.getInt("read.max-name-length"))
       .maxDocumentLength(config.getLong("read.max-document-length"))
+      .maxTokenCount(config.getLong("read.max-token-count"))
       .build()
 
     val streamWriteConstraints = StreamWriteConstraints.builder()

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -163,6 +163,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       case "concurrent-deque"        => JsonRecyclerPools.newConcurrentDequePool()
       case "shared-concurrent-deque" => JsonRecyclerPools.sharedConcurrentDequePool()
       case "bounded"                 => JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"))
+      case "non-recycling"           => JsonRecyclerPools.nonRecyclingPool()
       case other                     => throw new IllegalArgumentException(s"Unknown recycler-pool: $other")
     }
   }

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
@@ -45,11 +45,13 @@ class JacksonFactorySpec extends TestKit(ActorSystem("JacksonFactorySpec"))
       val maxStringLen = 1234567
       val maxDocLen = 123456789L
       val maxNestingDepth = 5
+      val maxTokenCount = 9876543210L
       val config = ConfigFactory.parseString(
         s"""pekko.serialization.jackson.read.max-number-length=$maxNumLen
              |pekko.serialization.jackson.read.max-string-length=$maxStringLen
              |pekko.serialization.jackson.read.max-document-length=$maxDocLen
              |pekko.serialization.jackson.read.max-nesting-depth=$maxNestingDepth
+             |pekko.serialization.jackson.read.max-token-count=$maxTokenCount
              |""".stripMargin)
         .withFallback(defaultConfig)
       val jacksonConfig = JacksonObjectMapperProvider.configForBinding(bindingName, config)
@@ -60,6 +62,7 @@ class JacksonFactorySpec extends TestKit(ActorSystem("JacksonFactorySpec"))
       streamReadConstraints.getMaxStringLength shouldEqual maxStringLen
       streamReadConstraints.getMaxDocumentLength shouldEqual maxDocLen
       streamReadConstraints.getMaxNestingDepth shouldEqual maxNestingDepth
+      streamReadConstraints.getMaxTokenCount shouldEqual maxTokenCount
     }
 
     "support StreamWriteConstraints" in {


### PR DESCRIPTION
* supports https://github.com/FasterXML/jackson-core/pull/1296
* Jackson lock-free buffer recyclers turned out to have major trouble and have been deprecated - https://github.com/trinodb/trino/issues/21356