### PR TITLE
Fix Address ordering bug

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/AddressSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/AddressSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.actor
+
+import org.apache.pekko.testkit.PekkoSpec
+
+class AddressSpec extends PekkoSpec {
+  "Address ordering" must {
+
+    "work correctly with multiple mixed protocols" in {
+      val pekkoAddress1 = Address("pekko", "system", "host1", 1000)
+      val pekkoAddress2 = Address("pekko", "system", "host2", 1000)
+      val akkaAddress1 = Address("akka", "system", "host1", 1000)
+      val akkaAddress2 = Address("akka", "system", "host2", 1000)
+
+      val addresses = Seq(pekkoAddress1, pekkoAddress2, akkaAddress1, akkaAddress2)
+      val sortedAddresses = addresses.sorted
+
+      sortedAddresses should ===(Seq(akkaAddress1, akkaAddress2, pekkoAddress1, pekkoAddress2))
+    }
+  }
+}

--- a/actor/src/main/scala/org/apache/pekko/actor/Address.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Address.scala
@@ -136,7 +136,7 @@ object Address {
    */
   implicit val addressOrdering: Ordering[Address] = Ordering.fromLessThan[Address] { (a, b) =>
     if (a eq b) false
-    else if (a.protocol != b.protocol) a.system.compareTo(b.protocol) < 0
+    else if (a.protocol != b.protocol) a.protocol.compareTo(b.protocol) < 0
     else if (a.system != b.system) a.system.compareTo(b.system) < 0
     else if (a.host != b.host) a.host.getOrElse("").compareTo(b.host.getOrElse("")) < 0
     else if (a.port != b.port) a.port.getOrElse(0) < b.port.getOrElse(0)


### PR DESCRIPTION
This bug causes major issues when a cluster contains nodes using both "akka" and "pekko". It can be a significant obstacle when migrating from Akka to Pekko through a rolling upgrade, especially if the migration requires the cluster to run with mixed protocols for an extended period.

Due to this bug, the DistributedPubSubMediator fails to send messages to some registered nodes. In the DistributedPubSubMediator, node addresses are stored in a [set](https://code.amazon.com/packages/PekkoClusterTools/blobs/697135892e22f31922167fd1faa102b9fbb49c56/--/src/main/scala/org/apache/pekko/cluster/pubsub/DistributedPubSubMediator.scala#L598). However, when [set membership ](https://github.com/scala/scala/blob/a5270194b6eec9678a79e2f88a83d83aa6b92de1/src/library/scala/collection/immutable/RedBlackTree.scala#L47C1-L59C4) relies on the faulty addressOrdering method, set.contains returns false for some addresses that are actually in the set.