### PR TITLE
Enable deserialization of old Akka cluster messages (mixed pekko/akka cluster)

### DIFF
--- a/cluster/src/main/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializer.scala
@@ -125,35 +125,43 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
       throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass} in [${getClass.getName}]")
   }
 
-  def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
-    case HeartbeatManifest         => deserializeHeartBeat(bytes)
-    case HeartbeatRspManifest      => deserializeHeartBeatResponse(bytes)
-    case GossipStatusManifest      => deserializeGossipStatus(bytes)
-    case GossipEnvelopeManifest    => deserializeGossipEnvelope(bytes)
-    case InitJoinManifest          => deserializeInitJoin(bytes)
-    case InitJoinAckManifest       => deserializeInitJoinAck(bytes)
-    case InitJoinNackManifest      => deserializeInitJoinNack(bytes)
-    case JoinManifest              => deserializeJoin(bytes)
-    case WelcomeManifest           => deserializeWelcome(bytes)
-    case LeaveManifest             => deserializeLeave(bytes)
-    case DownManifest              => deserializeDown(bytes)
-    case ExitingConfirmedManifest  => deserializeExitingConfirmed(bytes)
-    case ClusterRouterPoolManifest => deserializeClusterRouterPool(bytes)
-    // needs to stay in Akka 2.6.5 to be able to talk to an Akka 2.5.{3,4} node during rolling upgrade
-    case HeartBeatManifestPre2523     => deserializeHeartBeatAsAddress(bytes)
-    case HeartBeatRspManifest2523     => deserializeHeartBeatRspAsUniqueAddress(bytes)
-    case OldGossipStatusManifest      => deserializeGossipStatus(bytes)
-    case OldGossipEnvelopeManifest    => deserializeGossipEnvelope(bytes)
-    case OldInitJoinManifest          => deserializeInitJoin(bytes)
-    case OldInitJoinAckManifest       => deserializeInitJoinAck(bytes)
-    case OldInitJoinNackManifest      => deserializeInitJoinNack(bytes)
-    case OldJoinManifest              => deserializeJoin(bytes)
-    case OldWelcomeManifest           => deserializeWelcome(bytes)
-    case OldLeaveManifest             => deserializeLeave(bytes)
-    case OldDownManifest              => deserializeDown(bytes)
-    case OldExitingConfirmedManifest  => deserializeExitingConfirmed(bytes)
-    case OldClusterRouterPoolManifest => deserializeClusterRouterPool(bytes)
-    case _                            => throw new IllegalArgumentException(s"Unknown manifest [$manifest]")
+  def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+    val updatedManifest = {
+      if (manifest.startsWith("akka"))
+        manifest.replaceFirst("akka", "org.apache.pekko")
+      else manifest
+    }
+
+    updatedManifest match {
+      case HeartbeatManifest         => deserializeHeartBeat(bytes)
+      case HeartbeatRspManifest      => deserializeHeartBeatResponse(bytes)
+      case GossipStatusManifest      => deserializeGossipStatus(bytes)
+      case GossipEnvelopeManifest    => deserializeGossipEnvelope(bytes)
+      case InitJoinManifest          => deserializeInitJoin(bytes)
+      case InitJoinAckManifest       => deserializeInitJoinAck(bytes)
+      case InitJoinNackManifest      => deserializeInitJoinNack(bytes)
+      case JoinManifest              => deserializeJoin(bytes)
+      case WelcomeManifest           => deserializeWelcome(bytes)
+      case LeaveManifest             => deserializeLeave(bytes)
+      case DownManifest              => deserializeDown(bytes)
+      case ExitingConfirmedManifest  => deserializeExitingConfirmed(bytes)
+      case ClusterRouterPoolManifest => deserializeClusterRouterPool(bytes)
+      // needs to stay in Akka 2.6.5 to be able to talk to an Akka 2.5.{3,4} node during rolling upgrade
+      case HeartBeatManifestPre2523     => deserializeHeartBeatAsAddress(bytes)
+      case HeartBeatRspManifest2523     => deserializeHeartBeatRspAsUniqueAddress(bytes)
+      case OldGossipStatusManifest      => deserializeGossipStatus(bytes)
+      case OldGossipEnvelopeManifest    => deserializeGossipEnvelope(bytes)
+      case OldInitJoinManifest          => deserializeInitJoin(bytes)
+      case OldInitJoinAckManifest       => deserializeInitJoinAck(bytes)
+      case OldInitJoinNackManifest      => deserializeInitJoinNack(bytes)
+      case OldJoinManifest              => deserializeJoin(bytes)
+      case OldWelcomeManifest           => deserializeWelcome(bytes)
+      case OldLeaveManifest             => deserializeLeave(bytes)
+      case OldDownManifest              => deserializeDown(bytes)
+      case OldExitingConfirmedManifest  => deserializeExitingConfirmed(bytes)
+      case OldClusterRouterPoolManifest => deserializeClusterRouterPool(bytes)
+      case _                            => throw new IllegalArgumentException(s"Unknown manifest [$manifest]")
+    }
   }
 
   def compress(msg: MessageLite): Array[Byte] = {

--- a/cluster/src/test/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -177,6 +177,14 @@ class ClusterMessageSerializerSpec extends PekkoSpec("pekko.actor.provider = clu
         ClusterMessageSerializer.OldWelcomeManifest)
     }
 
+    "be de-serializable with class manifests from Akka nodes" in {
+      val oldAkkaJoinAckManifest = s"org.apache.pekko.cluster.InternalClusterAction$$InitJoinAck"
+      val address = Address("akka", "system", "some.host.org", 4711)
+      checkDeserializationWithManifest(
+        InternalClusterAction.InitJoinAck(address, CompatibleConfig(ConfigFactory.empty)),
+        oldAkkaJoinAckManifest)
+    }
+
     "add a default data center role to gossip if none is present" in {
       val env = roundtrip(GossipEnvelope(a1.uniqueAddress, d1.uniqueAddress, Gossip(SortedSet(a1, d1))))
       env.gossip.members.head.roles should be(Set(ClusterSettings.DcRolePrefix + "default"))


### PR DESCRIPTION
Forming a cluster with Akka nodes requires the deserialization of cluster messages sent by the Akka. This commit fixes the following exception that occurs during deserialization.

```
[akka://HybridCluster@127.0.0.1:2551] with serializer id [5] and manifest [akka.cluster.InternalClusterAction$InitJoinAck].
java.lang.IllegalArgumentException: Unknown manifest [akka.cluster.InternalClusterAction$InitJoinAck]
    at org.apache.pekko.cluster.protobuf.ClusterMessageSerializer.fromBinary(ClusterMessageSerializer.scala:156)
```