### PR TITLE
Update pins in .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,6 +11,10 @@ updates.pin = [
   { groupId = "com.google.protobuf", artifactId = "protobuf-java", version = "3." }
   # aeron 1.46 requires Java 17
   { groupId = "io.aeron", version = "1.45." }
+  # agrona 1.23 requires Java 17
+  { groupId = "org.agrona", artifactId = "agrona" version = "1.22." }
+  # bndlib 7 requires Java 17
+  { groupId = "biz.aQute.bnd", artifactId = "biz.aQute.bndlib" version = "6." }
 ]
 
 updates.ignore = [
@@ -22,9 +26,8 @@ updates.ignore = [
   { groupId = "com.fasterxml.jackson.dataformat" }
   { groupId = "com.fasterxml.jackson.datatype" }
   { groupId = "com.fasterxml.jackson.jaxrs" }
+  # other ignored updates
   { groupId = "com.typesafe", artifactId = "ssl-config-core" }
-  { groupId = "org.agrona", artifactId = "agrona" }
-  { groupId = "org.mockito", artifactId = "mockito-core" }
   { groupId = "com.lightbend.sbt", artifactId = "sbt-java-formatter" }
 ]
 


### PR DESCRIPTION
* Mockito seems to be a transitive dependency so we probably don't need to pin it.
* see #1582 also
* also allow for patch version updates on agrona