### PR TITLE
chore: enable test.multi-node test during pr and nightly build.

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -81,7 +81,7 @@ jobs:
           -Dpekko.test.tags.exclude=gh-exclude,timing \
           -Dpekko.cluster.assert=on \
           -Dsbt.override.build.repos=false \
-          -Dpekko.test.multi-node=false \
+          -Dpekko.test.multi-node=true \
           -Dsbt.log.noformat=false \
           -Dpekko.log.timestamps=true \
           validateCompile

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -160,7 +160,7 @@ jobs:
             -Dpekko.test.timefactor=2 \
             -Dpekko.actor.testkit.typed.timefactor=2 \
             -Dpekko.test.tags.exclude=gh-exclude,timing \
-            -Dpekko.test.multi-in-test=false \
+            -Dpekko.test.multi-in-test=true \
             clean "++ ${{ matrix.scalaVersion }} test" checkTestsHaveRun
 
 # comment out test report until an apache or GitHub published action (action-surefire-report) can be found or added allowlist from INFRA


### PR DESCRIPTION
Motivation:
refs: https://github.com/apache/pekko/issues/1591

Need to make sure `MultiJvm/test` pass.

I was running  `MultiJvm/test`  code locally.