### PR TITLE
reimplement fix for akka/pekko cluster

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -102,6 +102,53 @@ jobs:
           -Dio.netty.leakDetection.level=PARANOID \
           validatePullRequest
 
+  pekko-classic-remoting-tests:
+    name: Pekko Classic Remoting Tests
+    runs-on: ubuntu-22.04
+    if: github.repository == 'apache/pekko'
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - cluster/test distributed-data/test cluster-tools/test cluster-metrics/test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6
+
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
+      - name: sbt ${{ matrix.command }}
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+        # note that this is not running any multi-jvm tests because multi-in-test=false
+        run: |-
+          sbt \
+          -Djava.security.egd=file:/dev/./urandom \
+          -Dpekko.remote.artery.enabled=off \
+          -Dpekko.test.timefactor=2 \
+          -Dpekko.actor.testkit.typed.timefactor=2 \
+          -Dpekko.test.tags.exclude=gh-exclude,timing \
+          -Dpekko.test.multi-in-test=false \
+          -Dpekko.cluster.assert=on \
+          clean ${{ matrix.command }}
+          
   jdk-21-extra-tests:
     name: Java 21 Extra Tests (including all tests that need Java 9+)
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -3,6 +3,7 @@ name: Nightly Builds
 on:
   schedule:
     - cron: "0 0 * * *"
+  pull_request:
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -3,7 +3,6 @@ name: Nightly Builds
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull_request:
   workflow_dispatch:
 
 permissions: {}

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterDaemon.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterDaemon.scala
@@ -705,7 +705,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
   def join(address: Address): Unit = {
     if (!acceptedProtocols.contains(address.protocol))
       logWarning(
-        "Trying to join member with wrong protocol, but was ignored, expected any of [{}] but was [{}]",
+        "Trying to join member with wrong protocol, but was ignored, expected any of {} but was [{}]",
         acceptedProtocols,
         address.protocol)
     else if (address.system != selfAddress.system)

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterDaemon.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterDaemon.scala
@@ -705,9 +705,10 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
   def join(address: Address): Unit = {
     if (!acceptedProtocols.contains(address.protocol))
       logWarning(
-        "Trying to join member with wrong protocol, but was ignored, expected any of {} but was [{}]",
+        "Trying to join member with wrong protocol, but was ignored, expected any of {} but was [{}] - selfAddress.protocol={}",
         acceptedProtocols,
-        address.protocol)
+        address.protocol,
+        selfAddress.protocol)
     else if (address.system != selfAddress.system)
       logWarning(
         "Trying to join member with wrong ActorSystem name, but was ignored, expected [{}] but was [{}]",

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterDaemon.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterDaemon.scala
@@ -708,10 +708,9 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
   def join(address: Address): Unit = {
     if (!acceptedProtocols.contains(address.protocol))
       logWarning(
-        "Trying to join member with wrong protocol, but was ignored, expected any of {} but was [{}] - selfAddress.protocol={}",
+        "Trying to join member with wrong protocol, but was ignored, expected any of {} but was [{}]",
         acceptedProtocols,
-        address.protocol,
-        selfAddress.protocol)
+        address.protocol)
     else if (address.system != selfAddress.system)
       logWarning(
         "Trying to join member with wrong ActorSystem name, but was ignored, expected [{}] but was [{}]",

--- a/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.cluster
+
+import com.typesafe.config.{ Config, ConfigFactory }
+
+import org.apache.pekko.testkit.{ LongRunningTest, PekkoSpec }
+
+object MixedProtocolClusterSpec {
+
+  val baseConfig: Config =
+    ConfigFactory.parseString("""
+     pekko.actor.provider = "cluster"
+     pekko.coordinated-shutdown.terminate-actor-system = on
+
+     pekko.remote.classic.netty.tcp.port = 0
+     pekko.remote.artery.canonical.port = 0
+     pekko.remote.artery.advanced.aeron.idle-cpu-level = 3
+     pekko.remote.accept-protocol-names = ["pekko", "akka"]
+
+     pekko.cluster.jmx.multi-mbeans-in-same-jvm = on
+     pekko.cluster.configuration-compatibility-check.enforce-on-join = off
+     """)
+
+  val configWithPekko: Config =
+    ConfigFactory.parseString("""
+      pekko.remote.protocol-name = "pekko"
+    """).withFallback(baseConfig)
+
+  val configWithAkka: Config =
+    ConfigFactory.parseString("""
+      pekko.remote.protocol-name = "akka"
+    """).withFallback(baseConfig)
+}
+
+class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
+
+  import MixedProtocolClusterSpec._
+
+  "A node using the akka protocol" must {
+
+    "be allowed to join a cluster with a node using the pekko protocol" taggedAs LongRunningTest in {
+
+      val clusterTestUtil = new ClusterTestUtil(system.name)
+      // start the first node with the "pekko" protocol
+      clusterTestUtil.newActorSystem(configWithPekko)
+
+      // have a node using the "akka" protocol join
+      val joiningNode = clusterTestUtil.newActorSystem(configWithAkka)
+      clusterTestUtil.formCluster()
+
+      try {
+        awaitCond(clusterTestUtil.isMemberUp(joiningNode), message = "awaiting joining node to be 'Up'")
+      } finally {
+        clusterTestUtil.shutdownAll()
+      }
+    }
+
+    "allow a node using the pekko protocol to join the cluster" taggedAs LongRunningTest in {
+
+      val clusterTestUtil = new ClusterTestUtil(system.name)
+
+      // create the first node with the "akka" protocol
+      clusterTestUtil.newActorSystem(configWithAkka)
+
+      // have a node using the "pekko" protocol join
+      val joiningNode = clusterTestUtil.newActorSystem(configWithPekko)
+      clusterTestUtil.formCluster()
+
+      try {
+        awaitCond(clusterTestUtil.isMemberUp(joiningNode), message = "awaiting joining node to be 'Up'")
+      } finally {
+        clusterTestUtil.shutdownAll()
+      }
+    }
+  }
+}

--- a/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
@@ -95,14 +95,14 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
     "be allowed to join a cluster with a node using the pekko protocol (udp)" taggedAs LongRunningTest ignore {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
-      // start the first node with the "pekko" protocol
-      clusterTestUtil.newActorSystem(configWithPekkoUdp)
-
-      // have a node using the "akka" protocol join
-      val joiningNode = clusterTestUtil.newActorSystem(configWithAkkaUdp)
-      clusterTestUtil.formCluster()
-
       try {
+        // start the first node with the "pekko" protocol
+        clusterTestUtil.newActorSystem(configWithPekkoUdp)
+
+        // have a node using the "akka" protocol join
+        val joiningNode = clusterTestUtil.newActorSystem(configWithAkkaUdp)
+        clusterTestUtil.formCluster()
+
         awaitCond(clusterTestUtil.isMemberUp(joiningNode), message = "awaiting joining node to be 'Up'")
       } finally {
         clusterTestUtil.shutdownAll()
@@ -112,14 +112,14 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
     "be allowed to join a cluster with a node using the pekko protocol (tcp)" taggedAs LongRunningTest in {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
-      // start the first node with the "pekko" protocol
-      clusterTestUtil.newActorSystem(configWithPekkoTcp)
-
-      // have a node using the "akka" protocol join
-      val joiningNode = clusterTestUtil.newActorSystem(configWithAkkaTcp)
-      clusterTestUtil.formCluster()
-
       try {
+        // start the first node with the "pekko" protocol
+        clusterTestUtil.newActorSystem(configWithPekkoTcp)
+
+        // have a node using the "akka" protocol join
+        val joiningNode = clusterTestUtil.newActorSystem(configWithAkkaTcp)
+        clusterTestUtil.formCluster()
+
         awaitCond(clusterTestUtil.isMemberUp(joiningNode), message = "awaiting joining node to be 'Up'")
       } finally {
         clusterTestUtil.shutdownAll()
@@ -129,14 +129,14 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
     "be allowed to join a cluster with a node using the pekko protocol (netty)" taggedAs LongRunningTest in {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
-      // start the first node with the "pekko" protocol
-      clusterTestUtil.newActorSystem(configWithPekkoNetty)
-
-      // have a node using the "akka" protocol join
-      val joiningNode = clusterTestUtil.newActorSystem(configWithAkkaNetty)
-      clusterTestUtil.formCluster()
-
       try {
+        // start the first node with the "pekko" protocol
+        clusterTestUtil.newActorSystem(configWithPekkoNetty)
+
+        // have a node using the "akka" protocol join
+        val joiningNode = clusterTestUtil.newActorSystem(configWithAkkaNetty)
+        clusterTestUtil.formCluster()
+
         awaitCond(clusterTestUtil.isMemberUp(joiningNode), message = "awaiting joining node to be 'Up'")
       } finally {
         clusterTestUtil.shutdownAll()
@@ -146,15 +146,14 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
     "allow a node using the pekko protocol to join the cluster (udp)" taggedAs LongRunningTest ignore {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
-
-      // create the first node with the "akka" protocol
-      clusterTestUtil.newActorSystem(configWithAkkaUdp)
-
-      // have a node using the "pekko" protocol join
-      val joiningNode = clusterTestUtil.newActorSystem(configWithPekkoUdp)
-      clusterTestUtil.formCluster()
-
       try {
+        // create the first node with the "akka" protocol
+        clusterTestUtil.newActorSystem(configWithAkkaUdp)
+
+        // have a node using the "pekko" protocol join
+        val joiningNode = clusterTestUtil.newActorSystem(configWithPekkoUdp)
+        clusterTestUtil.formCluster()
+
         awaitCond(clusterTestUtil.isMemberUp(joiningNode), message = "awaiting joining node to be 'Up'")
       } finally {
         clusterTestUtil.shutdownAll()
@@ -164,15 +163,14 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
     "allow a node using the pekko protocol to join the cluster (tcp)" taggedAs LongRunningTest in {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
-
-      // create the first node with the "akka" protocol
-      clusterTestUtil.newActorSystem(configWithAkkaTcp)
-
-      // have a node using the "pekko" protocol join
-      val joiningNode = clusterTestUtil.newActorSystem(configWithPekkoTcp)
-      clusterTestUtil.formCluster()
-
       try {
+        // create the first node with the "akka" protocol
+        clusterTestUtil.newActorSystem(configWithAkkaTcp)
+
+        // have a node using the "pekko" protocol join
+        val joiningNode = clusterTestUtil.newActorSystem(configWithPekkoTcp)
+        clusterTestUtil.formCluster()
+
         awaitCond(clusterTestUtil.isMemberUp(joiningNode), message = "awaiting joining node to be 'Up'")
       } finally {
         clusterTestUtil.shutdownAll()
@@ -182,15 +180,14 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
     "allow a node using the pekko protocol to join the cluster (netty)" taggedAs LongRunningTest in {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
-
-      // create the first node with the "akka" protocol
-      clusterTestUtil.newActorSystem(configWithAkkaNetty)
-
-      // have a node using the "pekko" protocol join
-      val joiningNode = clusterTestUtil.newActorSystem(configWithPekkoNetty)
-      clusterTestUtil.formCluster()
-
       try {
+        // create the first node with the "akka" protocol
+        clusterTestUtil.newActorSystem(configWithAkkaNetty)
+
+        // have a node using the "pekko" protocol join
+        val joiningNode = clusterTestUtil.newActorSystem(configWithPekkoNetty)
+        clusterTestUtil.formCluster()
+
         awaitCond(clusterTestUtil.isMemberUp(joiningNode), message = "awaiting joining node to be 'Up'")
       } finally {
         clusterTestUtil.shutdownAll()

--- a/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
@@ -87,7 +87,7 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
 
   "A node using the akka protocol" must {
 
-    "be allowed to join a cluster with a node using the pekko protocol (udp)" taggedAs LongRunningTest ignore {
+    "be allowed to join a cluster with a node using the pekko protocol (udp)" taggedAs LongRunningTest in {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
       try {
@@ -138,7 +138,7 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
       }
     }
 
-    "allow a node using the pekko protocol to join the cluster (udp)" taggedAs LongRunningTest ignore {
+    "allow a node using the pekko protocol to join the cluster (udp)" taggedAs LongRunningTest in {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
       try {

--- a/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
@@ -29,6 +29,7 @@ object MixedProtocolClusterSpec {
      pekko.coordinated-shutdown.terminate-actor-system = on
 
      pekko.remote.artery.canonical.port = 0
+     pekko.remote.classic.netty.tcp.port = 0
      pekko.remote.artery.advanced.aeron.idle-cpu-level = 3
      pekko.remote.accept-protocol-names = ["pekko", "akka"]
 
@@ -51,27 +52,21 @@ object MixedProtocolClusterSpec {
       pekko.remote.protocol-name = "akka"
     """).withFallback(configWithUdp)
 
-  val configWithTcp: Config =
-    ConfigFactory.parseString("""
-      pekko.remote.artery.canonical.port = 0
-    """).withFallback(baseConfig)
-
   val configWithPekkoTcp: Config =
     ConfigFactory.parseString("""
       pekko.remote.protocol-name = "pekko"
-    """).withFallback(configWithTcp)
+    """).withFallback(baseConfig)
 
   val configWithAkkaTcp: Config =
     ConfigFactory.parseString("""
       pekko.remote.protocol-name = "akka"
-    """).withFallback(configWithTcp)
+    """).withFallback(baseConfig)
 
   val configWithNetty: Config =
     ConfigFactory.parseString("""
       pekko.remote.artery.enabled = false
       pekko.remote.classic {
         enabled-transports = ["pekko.remote.classic.netty.tcp"]
-        netty.tcp.port = 0
       }
     """).withFallback(baseConfig)
 

--- a/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/MixedProtocolClusterSpec.scala
@@ -92,7 +92,7 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
 
   "A node using the akka protocol" must {
 
-    "be allowed to join a cluster with a node using the pekko protocol (udp)" taggedAs LongRunningTest in {
+    "be allowed to join a cluster with a node using the pekko protocol (udp)" taggedAs LongRunningTest ignore {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
       // start the first node with the "pekko" protocol
@@ -143,7 +143,7 @@ class MixedProtocolClusterSpec extends PekkoSpec with ClusterTestKit {
       }
     }
 
-    "allow a node using the pekko protocol to join the cluster (udp)" taggedAs LongRunningTest in {
+    "allow a node using the pekko protocol to join the cluster (udp)" taggedAs LongRunningTest ignore {
 
       val clusterTestUtil = new ClusterTestUtil(system.name)
 


### PR DESCRIPTION
Run I the tests locally they pass but the nightly tests were failing until I removed this change.

see #1590

```
sbt \
            -Dpekko.cluster.assert=on \
            -Dpekko.log.timestamps=true \
            -Dpekko.test.timefactor=2 \
            -Dpekko.actor.testkit.typed.timefactor=2 \
            -Dpekko.test.tags.exclude=gh-exclude,timing \
            -Dpekko.test.multi-in-test=false \
"cluster/testOnly *JoinConfigCompatCheckerRollingUpdateSpec"
```