### PR TITLE
feat: Add required reflection/resource metadata for native image generation

### DIFF
--- a/actor-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-actor-typed/native-image.properties
+++ b/actor-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-actor-typed/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-monitoring=jfr

--- a/actor-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-actor-typed/reflect-config.json
+++ b/actor-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-actor-typed/reflect-config.json
@@ -1,0 +1,105 @@
+[
+  {
+    "name": "org.apache.pekko.actor.typed.internal.adapter.ActorSystemAdapter$LoadTypedExtensions$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.receptionist.LocalReceptionist$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.adapter.ActorSystemAdapter$AdapterExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.adapter.ActorSystemAdapter$LoadTypedExtensions$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.adapter.AdapterExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.MiscMessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.receptionist.ServiceKeySerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.ActorRef"
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.adapter.ActorRefAdapter"
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.receptionist.DefaultServiceKey"
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.ActorRefResolver$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.EventStreamExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.pubsub.PubSub$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.receptionist.Receptionist$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  }
+]

--- a/actor/src/main/resources/META-INF/native-image/com.typesafe/config/resource-config.json
+++ b/actor/src/main/resources/META-INF/native-image/com.typesafe/config/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources":{
+    "includes":[{
+      "pattern":".*\\.conf"
+    }]
+  },
+  "bundles":[]
+}

--- a/actor/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-actor/reflect-config.json
+++ b/actor/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-actor/reflect-config.json
@@ -1,0 +1,1055 @@
+[
+  {
+    "name": "sun.misc.Unsafe",
+    "methods": [
+      {
+        "name": "arrayBaseOff",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "arrayIndexScale",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "copyMemory",
+        "parameterTypes": [
+          "long",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "copyMemory",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "getAndAddLong",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "getAndSetObject",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "getBoolean",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getByte",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "getByte",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getDouble",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getFloat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getInt",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "getInt",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getLong",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "getLong",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getObject",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "invokeCleaner",
+        "parameterTypes": [
+          "java.nio.ByteBuffer"
+        ]
+      },
+      {
+        "name": "objectFieldOffset",
+        "parameterTypes": [
+          "java.lang.reflect.Field"
+        ]
+      },
+      {
+        "name": "putBoolean",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "boolean"
+        ]
+      },
+      {
+        "name": "putByte",
+        "parameterTypes": [
+          "long",
+          "byte"
+        ]
+      },
+      {
+        "name": "putByte",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "byte"
+        ]
+      },
+      {
+        "name": "putDouble",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "double"
+        ]
+      },
+      {
+        "name": "putFloat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "float"
+        ]
+      },
+      {
+        "name": "putInt",
+        "parameterTypes": [
+          "long",
+          "int"
+        ]
+      },
+      {
+        "name": "putInt",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "int"
+        ]
+      },
+      {
+        "name": "putLong",
+        "parameterTypes": [
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "putLong",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "putObject",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "storeFence"
+      }
+    ],
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.apache.pekko.actor.ActorCell",
+    "fields": [
+      {
+        "name": "org$apache$pekko$actor$dungeon$Children$$_childrenRefsDoNotCallMeDirectly"
+      },
+      {
+        "name": "org$apache$pekko$actor$dungeon$Children$$_functionRefsDoNotCallMeDirectly"
+      },
+      {
+        "name": "org$apache$pekko$actor$dungeon$Children$$_nextNameDoNotCallMeDirectly"
+      },
+      {
+        "name": "org$apache$pekko$actor$dungeon$Dispatch$$_mailboxDoNotCallMeDirectly"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.RepointableRef",
+    "fields": [
+      {
+        "name": "_cellDoNotCallMeDirectly"
+      },
+      {
+        "name": "_lookupDoNotCallMeDirectly"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.pattern.CircuitBreaker",
+    "fields": [
+      {
+        "name": "_currentResetTimeoutDoNotCallMeDirectly"
+      },
+      {
+        "name": "_currentStateDoNotCallMeDirectly"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.pattern.PromiseActorRef",
+    "fields": [
+      {
+        "name": "_stateDoNotCallMeDirectly"
+      },
+      {
+        "name": "_watchedByDoNotCallMeDirectly"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.LightArrayRevolverScheduler$TaskHolder",
+    "fields": [
+      {
+        "name": "task"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.LocalActorRefProvider$Guardian",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.SupervisorStrategy"
+        ]
+      }
+    ],
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.pekko.actor.LocalActorRefProvider$SystemGuardian",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.SupervisorStrategy",
+          "org.apache.pekko.actor.ActorRef"
+        ]
+      }
+    ],
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.pekko.actor.LocalActorRefProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "org.apache.pekko.event.EventStream",
+          "org.apache.pekko.actor.DynamicAccess"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.Props$EmptyActor",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.affinity.ThrowOnOverflowRejectionHandler",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.affinity.FairDistributionHashCache",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.event.Logging$DefaultLogger",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.event.DefaultLoggingFilter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "org.apache.pekko.event.EventStream"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.io.InetAddressDnsProvider",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.io.SimpleDnsManager",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.io.DnsExt"
+        ]
+      }
+    ],
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.pekko.io.dns.internal.AsyncDnsProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.io.DnsExt"
+        ]
+      }
+    ],
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.pekko.io.InetAddressDnsResolver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.io.SimpleDnsCache",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ],
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.pekko.io.dns.internal.AsyncDnsResolver",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.io.SimpleDnsCache",
+          "com.typesafe.config.Config",
+          "scala.Function2<org.apache.pekko.actor.ActorRefFactory,scala.collection.immutable.List<java.net.InetSocketAddress>,scala.collection.immutable.List<org.apache.pekko.actor.ActorRef>>"
+        ]
+      }
+    ],
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.pekko.io.SimpleDnsManager",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.io.DnsExt"
+        ]
+      }
+    ],
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.pekko.io.dns.internal.AsyncDnsManager",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.io.DnsExt"
+        ]
+      }
+    ],
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.pekko.routing.RoutedActorCell$RouterActorCreator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.routing.RouterConfig"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "jdk.jfr.Recording",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.BoundedControlAwareMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.BoundedDequeBasedMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.BoundedMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.BoundedPriorityMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.BoundedStablePriorityMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.NonBlockingBoundedMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.UnboundedControlAwareMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.UnboundedDequeBasedMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.UnboundedMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.UnboundedPriorityMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.dispatch.UnboundedStablePriorityMailbox",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.event.LoggerMailboxType",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.CoordinatedShutdown$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.event.AddressTerminatedTopic$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.event.Logging$LogExt$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.io.Dns$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.io.Tcp$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.io.Udp$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.io.UdpConnected$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.pattern.CircuitBreakersRegistry$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.SerializationExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.util.Clock$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.util.ManifestInfo$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.BooleanSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.ByteArraySerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.ByteStringSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.DisabledJavaSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.IntSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.JavaSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.LongSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.NullSerializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.NullSerializer$",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.StringSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "scala.Int"
+  },
+  {
+    "name": "java.io.Serializable"
+  },
+  {
+    "name": "org.apache.pekko.util.ByteString$ByteString1C"
+  },
+  {
+    "name": "scala.Long"
+  },
+  {
+    "name": "java.lang.String"
+  },
+  {
+    "name": "scala.Boolean"
+  },
+  {
+    "name": "java.lang.Boolean"
+  },
+  {
+    "name": "org.apache.pekko.util.ByteString$ByteString1"
+  },
+  {
+    "name": "java.lang.Long"
+  },
+  {
+    "name": "[B"
+  },
+  {
+    "name": "java.lang.Integer"
+  },
+  {
+    "name": "org.apache.pekko.util.ByteString$ByteStrings"
+  },
+  {
+    "name": "org.apache.pekko.actor.LightArrayRevolverScheduler",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config",
+          "org.apache.pekko.event.LoggingAdapter",
+          "java.util.concurrent.ThreadFactory"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.BalancingPool",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.BroadcastGroup",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.BroadcastPool",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.ConsistentHashingGroup",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.ConsistentHashingPool",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.FromConfig"
+  },
+  {
+    "name": "org.apache.pekko.routing.FromConfig$"
+  },
+  {
+    "name": "org.apache.pekko.routing.NoRouter$"
+  },
+  {
+    "name": "org.apache.pekko.routing.RandomGroup",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.RandomPool",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.RoundRobinGroup",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.RoundRobinPool",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.ScatterGatherFirstCompletedGroup",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.ScatterGatherFirstCompletedPool",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.SmallestMailboxPool",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.TailChoppingGroup",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.routing.TailChoppingPool",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.event.DefaultLoggingFilter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "org.apache.pekko.event.EventStream"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.event.LoggingFilterWithMarkerWrapper",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "org.apache.pekko.event.EventStream"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.event.jul.JavaLoggingFilter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "org.apache.pekko.event.EventStream"
+        ]
+      }
+    ]
+  }
+]

--- a/cluster-metrics/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-metrics/reflect-config.json
+++ b/cluster-metrics/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-metrics/reflect-config.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "org.apache.pekko.cluster.metrics.ClusterMetricsStrategy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.ClusterMetricsExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.protobuf.MessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.MixMetricsSelector"
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.CpuMetricsSelector$"
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.SystemLoadAverageMetricsSelector$"
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.HeapMetricsSelector$"
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.AdaptiveLoadBalancingPool"
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.ClusterMetricsMessage"
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.AdaptiveLoadBalancingGroup",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config",
+          "org.apache.pekko.actor.DynamicAccess"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.metrics.AdaptiveLoadBalancingPool",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config",
+          "org.apache.pekko.actor.DynamicAccess"
+        ]
+      }
+    ]
+  }
+]

--- a/cluster-sharding-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-sharding-typed/reflect-config.json
+++ b/cluster-sharding-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-sharding-typed/reflect-config.json
@@ -1,0 +1,48 @@
+[
+  {
+    "name": "org.apache.pekko.cluster.sharding.typed.internal.ShardingSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.typed.internal.ClusterShardingTypedSerializable"
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.typed.internal.JoinConfigCompatCheckerClusterSharding",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.typed.ReplicatedShardingExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.typed.scaladsl.ClusterSharding$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.typed.scaladsl.ShardedDaemonProcess$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  }
+]

--- a/cluster-sharding/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-sharding/native-image.properties
+++ b/cluster-sharding/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-sharding/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-monitoring=jfr

--- a/cluster-sharding/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-sharding/reflect-config.json
+++ b/cluster-sharding/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-sharding/reflect-config.json
@@ -1,0 +1,51 @@
+[
+  {
+    "name": "org.apache.pekko.cluster.sharding.ClusterShardingHealthCheck",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.ClusterSharding$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.external.ExternalShardAllocation$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.protobuf.ClusterShardingMessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.ClusterShardingSerializable"
+  },
+  {
+    "name": "org.apache.pekko.cluster.sharding.JoinConfigCompatCheckSharding",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  }
+]

--- a/cluster-tools/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-tools/reflect-config.json
+++ b/cluster-tools/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-tools/reflect-config.json
@@ -1,0 +1,41 @@
+[
+  {
+    "name": "org.apache.pekko.cluster.pubsub.DistributedPubSub$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.pubsub.protobuf.DistributedPubSubMessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.singleton.protobuf.ClusterSingletonMessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.singleton.ClusterSingletonMessage"
+  },
+  {
+    "name": "org.apache.pekko.cluster.pubsub.DistributedPubSubMediator$Internal$SendToOneSubscriber"
+  },
+  {
+    "name": "org.apache.pekko.cluster.pubsub.DistributedPubSubMessage"
+  }
+]

--- a/cluster-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-typed/reflect-config.json
+++ b/cluster-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster-typed/reflect-config.json
@@ -1,0 +1,81 @@
+[
+  {
+    "name": "org.apache.pekko.cluster.typed.internal.receptionist.ClusterReceptionist$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.typed.internal.AkkaClusterTypedSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.typed.internal.delivery.ReliableDeliverySerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.typed.internal.receptionist.ClusterReceptionist$Entry"
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.internal.pubsub.TopicImpl$MessagePublished"
+  },
+  {
+    "name": "org.apache.pekko.actor.typed.delivery.internal.DeliverySerializable"
+  },
+  {
+    "name": "org.apache.pekko.cluster.typed.internal.receptionist.ClusterReceptionistConfigCompatChecker",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.ddata.typed.javadsl.DistributedData$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.ddata.typed.scaladsl.DistributedData$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.typed.Cluster$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.typed.ClusterSingleton$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  }
+]

--- a/cluster/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster/reflect-config.json
+++ b/cluster/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-cluster/reflect-config.json
@@ -1,0 +1,98 @@
+[
+  {
+    "name": "org.apache.pekko.cluster.sbr.SplitBrainResolverProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.ClusterActorRefProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "org.apache.pekko.event.EventStream",
+          "org.apache.pekko.actor.DynamicAccess"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.NoDowning",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.Cluster$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.protobuf.ClusterMessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.routing.ClusterRouterPool"
+  },
+  {
+    "name": "org.apache.pekko.cluster.ClusterMessage"
+  },
+  {
+    "name": "org.apache.pekko.cluster.Cluster$$anon$1",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config",
+          "org.apache.pekko.event.LoggingAdapter",
+          "java.util.concurrent.ThreadFactory"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.routing.ClusterRouterGroup"
+  },
+  {
+    "name": "org.apache.pekko.cluster.routing.ClusterRouterPool"
+  },
+  {
+    "name": "org.apache.pekko.cluster.JoinConfigCompatCheckCluster",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.JoinConfigCompatChecker$CompositeChecker",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  }
+]

--- a/coordination/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-coordination/reflect-config.json
+++ b/coordination/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-coordination/reflect-config.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "org.apache.pekko.coordination.lease.javadsl.LeaseProvider$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.coordination.lease.scaladsl.LeaseProvider$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  }
+]

--- a/discovery/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-discovery/reflect-config.json
+++ b/discovery/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-discovery/reflect-config.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "org.apache.pekko.discovery.config.ConfigServiceDiscovery",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.discovery.aggregate.AggregateServiceDiscovery",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.discovery.dns.DnsServiceDiscovery",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.discovery.Discovery$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  }
+]

--- a/distributed-data/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-distributed-data/reflect-config.json
+++ b/distributed-data/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-distributed-data/reflect-config.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "org.apache.pekko.cluster.ddata.DistributedData$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.ddata.protobuf.ReplicatedDataSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.ddata.protobuf.ReplicatorMessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.cluster.ddata.ReplicatedDataSerialization"
+  },
+  {
+    "name": "org.apache.pekko.cluster.ddata.Replicator$ReplicatorMessage"
+  }
+]

--- a/persistence-query/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-persistence-query/reflect-config.json
+++ b/persistence-query/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-persistence-query/reflect-config.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "org.apache.pekko.persistence.query.PersistenceQuery$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.query.typed.internal.EventsBySliceFirehose$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.query.internal.QuerySerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.query.typed.EventEnvelope"
+  },
+  {
+    "name": "org.apache.pekko.persistence.query.Offset"
+  }
+]

--- a/persistence-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-persistence-typed/reflect-config.json
+++ b/persistence-typed/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-persistence-typed/reflect-config.json
@@ -1,0 +1,61 @@
+[
+  {
+    "name": "org.apache.pekko.persistence.typed.serialization.ReplicatedEventSourcingSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.crdt.ORSet$DeltaOp"
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.internal.VersionVector"
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.crdt.Counter"
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.crdt.Counter$Updated"
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.internal.ReplicatedEventMetadata"
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.internal.PublishedEventImpl"
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.crdt.ORSet"
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.internal.ReplicatedSnapshotMetadata"
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.internal.EventWriterExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.telemetry.DurableStateBehaviorInstrumentationProvider$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.typed.telemetry.EventSourcedBehaviorInstrumentationProvider$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  }
+]

--- a/persistence/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-persistence/reflect-config.json
+++ b/persistence/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-persistence/reflect-config.json
@@ -1,0 +1,182 @@
+[
+  {
+    "name": "org.apache.pekko.persistence.ThrowExceptionConfigurator",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.DiscardConfigurator",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.snapshot.NoSnapshotStore",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.journal.inmem.InmemJournal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.snapshot.local.LocalSnapshotStore",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.journal.leveldb.LeveldbStore",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.journal.leveldb.SharedLeveldbJournal",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.journal.PersistencePluginProxy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.Persistence$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.Persistence$PluginHolderExtensionId",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.PersistencePlugin$$anon$1",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.journal.PersistencePluginProxyExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.state.DurableStateStoreRegistry$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.telemetry.EventsourcedInstrumentationProvider$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.telemetry.RecoveryPermitterInstrumentationProvider$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.serialization.MessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.serialization.PayloadSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.serialization.SnapshotSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.persistence.serialization.Message"
+  },
+  {
+    "name": "org.apache.pekko.persistence.SerializedEvent"
+  },
+  {
+    "name": "org.apache.pekko.persistence.serialization.Snapshot"
+  },
+  {
+    "name": "org.apache.pekko.persistence.FilteredPayload$"
+  }
+]

--- a/remote/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-remote/native-image.properties
+++ b/remote/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-remote/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-monitoring=jfr

--- a/remote/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-remote/reflect-config.json
+++ b/remote/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-remote/reflect-config.json
@@ -1,0 +1,352 @@
+[
+  {
+    "name": "org.apache.pekko.remote.PhiAccrualFailureDetector",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config",
+          "org.apache.pekko.event.EventStream"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.artery.tcp.ConfigSSLEngineProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.DeadlineFailureDetector",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.typesafe.config.Config",
+          "org.apache.pekko.event.EventStream"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.RemoteActorRefProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "org.apache.pekko.event.EventStream",
+          "org.apache.pekko.actor.DynamicAccess"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.AddressUidExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.BoundAddressesExtension$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.RARP$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.ActorRefResolveThreadLocalCache$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.ArteryMessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.ByteStringSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.DaemonMsgCreateSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.IntSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.LongSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.MessageContainerSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.MiscMessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.ProtobufSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.StringSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.SystemMessageSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.actor.ActorRef"
+  },
+  {
+    "name": "org.apache.pekko.dispatch.sysmsg.SystemMessage"
+  },
+  {
+    "name": "org.apache.pekko.actor.Identify"
+  },
+  {
+    "name": "org.apache.pekko.remote.RemoteWatcher$Heartbeat$"
+  },
+  {
+    "name": "com.google.protobuf.GeneratedMessageV3"
+  },
+  {
+    "name": "org.apache.pekko.routing.BroadcastGroup"
+  },
+  {
+    "name": "org.apache.pekko.actor.ActorSelectionMessage"
+  },
+  {
+    "name": "org.apache.pekko.actor.Kill$"
+  },
+  {
+    "name": "org.apache.pekko.actor.PoisonPill$"
+  },
+  {
+    "name": "org.apache.pekko.protobufv3.internal.GeneratedMessageV3"
+  },
+  {
+    "name": "java.lang.Throwable"
+  },
+  {
+    "name": "org.apache.pekko.actor.ActorKilledException"
+  },
+  {
+    "name": "org.apache.pekko.routing.RandomPool"
+  },
+  {
+    "name": "org.apache.pekko.actor.InvalidMessageException"
+  },
+  {
+    "name": "java.util.concurrent.TimeoutException"
+  },
+  {
+    "name": "org.apache.pekko.routing.ScatterGatherFirstCompletedPool"
+  },
+  {
+    "name": "org.apache.pekko.routing.ScatterGatherFirstCompletedGroup"
+  },
+  {
+    "name": "org.apache.pekko.routing.RandomGroup"
+  },
+  {
+    "name": "org.apache.pekko.actor.Address"
+  },
+  {
+    "name": "org.apache.pekko.routing.DefaultResizer"
+  },
+  {
+    "name": "org.apache.pekko.remote.RemoteScope"
+  },
+  {
+    "name": "org.apache.pekko.actor.ActorIdentity"
+  },
+  {
+    "name": "org.apache.pekko.actor.Status$Success"
+  },
+  {
+    "name": "org.apache.pekko.actor.IllegalActorStateException"
+  },
+  {
+    "name": "org.apache.pekko.remote.DaemonMsgCreate"
+  },
+  {
+    "name": "org.apache.pekko.routing.FromConfig"
+  },
+  {
+    "name": "org.apache.pekko.routing.SmallestMailboxPool"
+  },
+  {
+    "name": "org.apache.pekko.remote.RemoteWatcher$HeartbeatRsp"
+  },
+  {
+    "name": "org.apache.pekko.actor.ActorInitializationException"
+  },
+  {
+    "name": "org.apache.pekko.remote.artery.ArteryMessage"
+  },
+  {
+    "name": "org.apache.pekko.routing.BroadcastPool"
+  },
+  {
+    "name": "scala.Some"
+  },
+  {
+    "name": "java.util.Optional"
+  },
+  {
+    "name": "org.apache.pekko.Done"
+  },
+  {
+    "name": "org.apache.pekko.NotUsed"
+  },
+  {
+    "name": "com.typesafe.config.impl.SimpleConfig"
+  },
+  {
+    "name": "org.apache.pekko.actor.Status$Failure"
+  },
+  {
+    "name": "org.apache.pekko.remote.UniqueAddress"
+  },
+  {
+    "name": "org.apache.pekko.routing.TailChoppingGroup"
+  },
+  {
+    "name": "org.apache.pekko.pattern.StatusReply"
+  },
+  {
+    "name": "org.apache.pekko.routing.TailChoppingPool"
+  },
+  {
+    "name": "org.apache.pekko.remote.routing.RemoteRouterConfig"
+  },
+  {
+    "name": "com.google.protobuf.GeneratedMessage"
+  },
+  {
+    "name": "org.apache.pekko.routing.RoundRobinGroup"
+  },
+  {
+    "name": "scalapb.GeneratedMessage"
+  },
+  {
+    "name": "org.apache.pekko.routing.BalancingPool"
+  },
+  {
+    "name": "org.apache.pekko.routing.RoundRobinPool"
+  },
+  {
+    "name": "com.typesafe.config.Config"
+  },
+  {
+    "name": "org.apache.pekko.remote.serialization.ThrowableNotSerializableException"
+  },
+  {
+    "name": "org.apache.pekko.actor.LocalScope$"
+  },
+  {
+    "name": "scala.None$"
+  },
+  {
+    "name": "org.apache.pekko.actor.InvalidActorNameException"
+  },
+  {
+    "name": "org.apache.pekko.remote.routing.RemoteRouterConfig"
+  }
+]

--- a/serialization-jackson/src/main/resources/META-INF/native-image/com.fasterxml.jackson.core/jackson-databind/reflect-config.json
+++ b/serialization-jackson/src/main/resources/META-INF/native-image/com.fasterxml.jackson.core/jackson-databind/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/serialization-jackson/src/main/resources/META-INF/native-image/com.fasterxml.jackson.datatype/jackson.datatype/reflect-config.json
+++ b/serialization-jackson/src/main/resources/META-INF/native-image/com.fasterxml.jackson.datatype/jackson.datatype/reflect-config.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "com.fasterxml.jackson.datatype.jdk8.Jdk8Module",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/serialization-jackson/src/main/resources/META-INF/native-image/com.fasterxml.jackson.module/jackson-module-parameter-names/reflect-config.json
+++ b/serialization-jackson/src/main/resources/META-INF/native-image/com.fasterxml.jackson.module/jackson-module-parameter-names/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "com.fasterxml.jackson.module.paramnames.ParameterNamesModule",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/serialization-jackson/src/main/resources/META-INF/native-image/com.fasterxml.jackson.module/jackson-module-scala/reflect-config.json
+++ b/serialization-jackson/src/main/resources/META-INF/native-image/com.fasterxml.jackson.module/jackson-module-scala/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "com.fasterxml.jackson.module.scala.DefaultScalaModule",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/serialization-jackson/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-serialization-jackson/native-image.properties
+++ b/serialization-jackson/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-serialization-jackson/native-image.properties
@@ -1,0 +1,1 @@
+Args = --features=org.apache.pekko.serialization.jackson.internal.PekkoJacksonSerializationFeature

--- a/serialization-jackson/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-serialization-jackson/reflect-config.json
+++ b/serialization-jackson/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-serialization-jackson/reflect-config.json
@@ -1,0 +1,234 @@
+[
+  {
+    "name": "org.apache.pekko.serialization.jackson.PekkoJacksonModule",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.PekkoTypedJacksonModule",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.PekkoStreamJacksonModule",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "com.fasterxml.jackson.module.paramnames.ParameterNamesModule",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "com.fasterxml.jackson.datatype.jdk8.Jdk8Module",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "com.fasterxml.jackson.module.scala.DefaultScalaModule",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.CborSerializable",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.JsonSerializable",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.JacksonObjectMapperProvider$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.ActorRefSerializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.ActorRefDeserializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.AddressSerializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.AddressDeserializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.FiniteDurationSerializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.FiniteDurationDeserializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.TypedActorRefSerializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.apache.pekko.actor.typed.ActorRef"
+    }
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.TypedActorRefDeserializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.apache.pekko.actor.typed.ActorRef"
+    }
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.SourceRefSerializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.apache.pekko.stream.SourceRef"
+    }
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.SourceRefDeserializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.apache.pekko.stream.SourceRef"
+    }
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.SinkRefSerializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.apache.pekko.stream.SinkRef"
+    }
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.SinkRefDeserializer",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ],
+    "condition": {
+      "typeReachable": "org.apache.pekko.stream.SinkRef"
+    }
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.JacksonObjectMapperProvider$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.JacksonCborSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.JacksonJsonSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.CborSerializable"
+  },
+  {
+    "name": "org.apache.pekko.serialization.jackson.JsonSerializable"
+  }
+]

--- a/serialization-jackson/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-serialization-jackson/resource-config.json
+++ b/serialization-jackson/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-serialization-jackson/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qcom/fasterxml/jackson/module/scala/build.properties\\E"
+      }
+    ]
+  }
+}

--- a/slf4j/src/main/resources/META-INF/native-image/ch.qos.logback/logback-classic/reflect-config.json
+++ b/slf4j/src/main/resources/META-INF/native-image/ch.qos.logback/logback-classic/reflect-config.json
@@ -1,0 +1,194 @@
+[
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.classic.pattern.DateConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.classic.pattern.LevelConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.classic.pattern.LineSeparatorConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.classic.pattern.LoggerConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.classic.pattern.MDCConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.classic.pattern.MarkerConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.classic.pattern.MessageConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.classic.pattern.ThreadConverter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.core.ConsoleAppender",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.core.OutputStreamAppender",
+    "methods": [
+      {
+        "name": "setEncoder",
+        "parameterTypes": [
+          "ch.qos.logback.core.encoder.Encoder"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.core.encoder.Encoder",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+    "methods": [
+      {
+        "name": "setParent",
+        "parameterTypes": [
+          "ch.qos.logback.core.spi.ContextAware"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.core.pattern.PatternLayoutEncoderBase",
+    "methods": [
+      {
+        "name": "setPattern",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "ch.qos.logback.classic.Logger"
+    },
+    "name": "ch.qos.logback.core.spi.ContextAware",
+    "methods": [
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  }
+]

--- a/slf4j/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-slf4j/native-image.properties
+++ b/slf4j/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-slf4j/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-build-time=org.slf4j.LoggerFactory,org.slf4j.impl.StaticLoggerBinder,org.slf4j.MDC,org.slf4j.helpers.Reporter

--- a/slf4j/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-slf4j/reflect-config.json
+++ b/slf4j/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-slf4j/reflect-config.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "org.apache.pekko.event.slf4j.Slf4jLogger",
+    "methods": [
+      {
+        "name": "<init>"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.event.slf4j.Slf4jLoggingFilter",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ActorSystem$Settings",
+          "org.apache.pekko.event.EventStream"
+        ]
+      }
+    ]
+  }
+]

--- a/stream/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-stream/reflect-config.json
+++ b/stream/src/main/resources/META-INF/native-image/org.apache.pekko/pekko-stream/reflect-config.json
@@ -1,0 +1,70 @@
+[
+  {
+    "name": "org.apache.pekko.stream.StreamRefResolver$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.stream.SystemMaterializer$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.stream.impl.FlowNames$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.stream.impl.streamref.StreamRefsMaster$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.stream.javadsl.Tcp$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.stream.scaladsl.Tcp$",
+    "fields": [
+      {
+        "name": "MODULE$"
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.stream.serialization.StreamRefSerializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.pekko.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.pekko.stream.SinkRef"
+  },
+  {
+    "name": "org.apache.pekko.stream.SourceRef"
+  },
+  {
+    "name": "org.apache.pekko.stream.impl.streamref.StreamRefsProtocol"
+  }
+]


### PR DESCRIPTION
I hope the title is self-explanatory. Providing reflection metadata to Graal's native image generation would be a nice addition to the library. The Akka counterparts of the artifacts already had these in place, so the contents were trivial.