### PR TITLE
fix: Fix ByteBuf leak in remoting transport.

### DIFF
--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/RemoteConnection.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/RemoteConnection.scala
@@ -56,8 +56,14 @@ private[pekko] class ProtobufEncoder extends MessageToMessageEncoder[Message] {
 private[pekko] class ProtobufDecoder(prototype: Message) extends MessageToMessageDecoder[ByteBuf] {
 
   override def decode(ctx: ChannelHandlerContext, msg: ByteBuf, out: java.util.List[AnyRef]): Unit = {
-    val bytes = ByteBufUtil.getBytes(msg)
-    out.add(prototype.getParserForType.parseFrom(bytes))
+    try {
+      val bytes = ByteBufUtil.getBytes(msg)
+      out.add(prototype.getParserForType.parseFrom(bytes))
+    } catch {
+      case NonFatal(e) => ctx.pipeline().fireExceptionCaught(e)
+    } finally {
+      msg.release()
+    }
   }
 }
 


### PR DESCRIPTION
Motivation:
refs: https://github.com/apache/pekko/issues/1634

Modification:
Call byteBuf.release after bytes read.

Result:
No leaks.

Sorry for everyone.

It's using retainedSlice in LengthFieldBasedFrameDecoder

    protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
        return buffer.retainedSlice(index, length);
    }