### PR TITLE
chore: Enable netty leak detector in CI

### DIFF
--- a/.jvmopts-ci
+++ b/.jvmopts-ci
@@ -12,3 +12,4 @@
 -XX:-ClassUnloadingWithConcurrentMark
 -Djava.security.egd=file:/dev/./urandom
 -Dpekko.ci-server=true
+-Dio.netty.leakDetection.level=PARANOID


### PR DESCRIPTION
Motivation:
It needs to be enabled in `.jvmopts-ci` too.
refs: https://github.com/apache/pekko/issues/1634

otherwise, it's just :
```
          io.netty.util.ResourceLeakDetector -- -Dio.netty.leakDetection.level: simple
```

Modification:
Add `-Dio.netty.leakDetection.level=PARANOID` (max level) to `.jvmopts-ci` 

Result:
Can detect leak in CI