### PR TITLE
chore: Implement zipWithIndex with statefulMap

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -3305,14 +3305,11 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream cancels
    */
   def zipWithIndex: Repr[(Out, Long)] = {
-    statefulMapConcat[(Out, Long)] { () =>
-      var index: Long = 0L
-      elem => {
-        val zipped = (elem, index)
-        index += 1
-        immutable.Iterable[(Out, Long)](zipped)
-      }
-    }
+    via(
+      new StatefulMap[Long, Out, (Out, Long)](
+        () => 0L,
+        (index, out) => (index + 1L, (out, index)),
+        ConstantFun.scalaAnyToNone).withAttributes(DefaultAttributes.zipWithIndex))
   }
 
   /**


### PR DESCRIPTION
Motivation:
Performance, but it was reverted in https://github.com/apache/pekko/issues/1525

Modification:
Reimplemented it in the right way.

Result:
Better performance

Root cause:
The attributes should be set on the inner graph.

@remyhaemmerle-da sorry ~

