### PR TITLE
chore: Add identity function.

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/util/ConstantFunJavaTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/util/ConstantFunJavaTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.util;
+
+import org.apache.pekko.japi.function.Function;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConstantFunJavaTest {
+  @Test
+  public void alwaysReturnSameValue() {
+    final Object value = new Object();
+    final Function<Object, Object> fun = ConstantFun.javaIdentityFunction();
+    try {
+      Assert.assertTrue(fun.apply(value) == value);
+    } catch (Exception e) {
+      Assert.fail("Exception thrown: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void alwaysReturnFunctionInstance() {
+    final Function<Object, Object> funObj = ConstantFun.javaIdentityFunction();
+    final Function<String, String> funStr = ConstantFun.javaIdentityFunction();
+    try {
+      Assert.assertTrue(funObj.equals(funStr));
+    } catch (Exception e) {
+      Assert.fail("Exception thrown: " + e.getMessage());
+    }
+  }
+}

--- a/actor/src/main/scala/org/apache/pekko/japi/function/Function.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/function/Function.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.japi.function
 
+import org.apache.pekko.util.ConstantFun
+
 import scala.annotation.nowarn
 
 /**
@@ -26,6 +28,15 @@ import scala.annotation.nowarn
 trait Function[-T, +R] extends java.io.Serializable {
   @throws(classOf[Exception])
   def apply(param: T): R
+}
+
+object Function {
+
+  /**
+   * Returns a `Function` that always returns its input argument.
+   * @since 1.2.0
+   */
+  def identity[T]: Function[T, T] = ConstantFun.javaIdentityFunction
 }
 
 /**

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
@@ -749,9 +749,7 @@ public class FlowTest extends StreamTest {
     mainInputs.add(Source.from(input2));
 
     final Flow<Source<Integer, NotUsed>, List<Integer>, NotUsed> flow =
-        Flow.<Source<Integer, NotUsed>>create()
-            .flatMapConcat(ConstantFun.javaIdentityFunction())
-            .grouped(6);
+        Flow.<Source<Integer, NotUsed>>create().flatMapConcat(Function.identity()).grouped(6);
     CompletionStage<List<Integer>> future =
         Source.from(mainInputs).via(flow).runWith(Sink.head(), system);
 
@@ -775,9 +773,7 @@ public class FlowTest extends StreamTest {
     mainInputs.add(Source.from(input4));
 
     final Flow<Source<Integer, NotUsed>, List<Integer>, NotUsed> flow =
-        Flow.<Source<Integer, NotUsed>>create()
-            .flatMapMerge(3, ConstantFun.javaIdentityFunction())
-            .grouped(60);
+        Flow.<Source<Integer, NotUsed>>create().flatMapMerge(3, Function.identity()).grouped(60);
     CompletionStage<List<Integer>> future =
         Source.from(mainInputs).via(flow).runWith(Sink.head(), system);
 

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -470,7 +470,7 @@ public class SourceTest extends StreamTest {
 
     CompletionStage<List<Integer>> future =
         Source.from(mainInputs)
-            .flatMapConcat(ConstantFun.javaIdentityFunction())
+            .flatMapConcat(Function.identity())
             .grouped(6)
             .runWith(Sink.head(), system);
 
@@ -495,7 +495,7 @@ public class SourceTest extends StreamTest {
 
     CompletionStage<List<Integer>> future =
         Source.from(mainInputs)
-            .flatMapMerge(3, ConstantFun.javaIdentityFunction())
+            .flatMapMerge(3, Function.identity())
             .grouped(60)
             .runWith(Sink.head(), system);
 


### PR DESCRIPTION
Motivation:
Make life easier for Java developers without the `i -> i`

Modification:
Add an `identity` helper function.

Result:
Clean code.