### PR TITLE
Update scala-library to 2.13.15 (#1505)

### DIFF
--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/ActorContextSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/ActorContextSpec.scala
@@ -13,6 +13,7 @@
 
 package org.apache.pekko.actor.typed
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
@@ -88,7 +89,9 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit with AnyWordSp
   "An ActorContext" must {
 
     "be usable from Behavior.interpretMessage" in {
-      // compilation only
+      // false-postive 'unused' warning possibly fixed in 2.13.6 https://github.com/scala/bug/issues/13041
+      @nowarn
+      // test compilation only
       lazy val b: Behavior[String] = Behaviors.receive { (context, message) =>
         Behavior.interpretMessage(b, context, message)
       }

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/RequestResponseActors.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/RequestResponseActors.scala
@@ -85,7 +85,7 @@ object RequestResponseActors {
     val fullPathToDispatcher = "pekko.actor." + dispatcher
     val latch = new CountDownLatch(numActors)
     val actorsPairs = for {
-      i <- (1 to (numActors / 2)).toVector
+      _ <- (1 to (numActors / 2)).toVector
       userQueryActor = system.actorOf(
         UserQueryActor.props(latch, numQueriesPerActor, numUsersInDBPerActor).withDispatcher(fullPathToDispatcher))
       userServiceActor = system.actorOf(

--- a/cluster-tools/src/main/scala/org/apache/pekko/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/cluster-tools/src/main/scala/org/apache/pekko/cluster/pubsub/DistributedPubSubMediator.scala
@@ -855,7 +855,7 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings)
     val topicPrefix = self.path.toStringWithoutAddress
     (for {
       (_, bucket) <- registry
-      (key, value) <- bucket.content.toSeq
+      (key, _) <- bucket.content.toSeq
       if key.startsWith(topicPrefix)
       topic = key.substring(topicPrefix.length + 1)
       if !topic.contains('/') // exclude group topics

--- a/persistence/src/main/scala/org/apache/pekko/persistence/serialization/MessageSerializer.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/serialization/MessageSerializer.scala
@@ -149,6 +149,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
       else None)
   }
 
+  @nowarn("msg=deprecated")
   def persistentFSMSnapshot(persistentFSMSnapshot: mf.PersistentFSMSnapshot): PersistentFSMSnapshot[Any] = {
     PersistentFSMSnapshot(
       persistentFSMSnapshot.getStateIdentifier,

--- a/persistence/src/test/scala/org/apache/pekko/persistence/serialization/SnapshotSerializerSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/serialization/SnapshotSerializerSpec.scala
@@ -17,6 +17,8 @@
 
 package org.apache.pekko.persistence.serialization
 
+import annotation.nowarn
+
 import org.apache.pekko
 import pekko.persistence.fsm.PersistentFSM.PersistentFSMSnapshot
 import pekko.serialization.SerializationExtension
@@ -24,6 +26,7 @@ import pekko.testkit.PekkoSpec
 
 import java.util.Base64
 
+@nowarn("msg=deprecated")
 private[serialization] object SnapshotSerializerTestData {
   val fsmSnapshot = PersistentFSMSnapshot[String]("test-identifier", "test-data", None)
   // https://github.com/apache/pekko/pull/837#issuecomment-1847320309

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies {
   val jacksonDatabindVersion = jacksonCoreVersion
 
   val scala212Version = "2.12.20"
-  val scala213Version = "2.13.14"
+  val scala213Version = "2.13.15"
   val scala3Version = "3.3.4"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 

--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -74,9 +74,10 @@ object PekkoDisciplinePlugin extends AutoPlugin {
     "pekko-stream-tests-tck",
     "pekko-testkit")
 
-  lazy val defaultScalaOptions = Def.setting(CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 12)) => "-Wconf:cat=unused-nowarn:s,any:e"
-    case _             => "-Wconf:cat=unused-nowarn:s,cat=other-shadowing:s,any:e"
+  lazy val defaultScalaOptions = Def.setting(CrossVersion.partialVersion(scalaVersion.value).get match {
+    case (3, _)  => "-Wconf:cat=unused-nowarn:s,cat=other-shadowing:s,any:e"
+    case (2, 13) => "-Wconf:any:e,cat=unused-nowarn:s,cat=other-shadowing:s"
+    case (2, 12) => "-Wconf:cat=unused-nowarn:s,any:e"
   })
 
   lazy val nowarnSettings = Seq(
@@ -101,16 +102,18 @@ object PekkoDisciplinePlugin extends AutoPlugin {
   lazy val docs =
     Seq(
       Compile / scalacOptions -= defaultScalaOptions.value,
-      Compile / scalacOptions ++= (
-        if (scalaVersion.value.startsWith("3.")) Nil
-        else Seq("-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e")
-      ),
+      Compile / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value).get match {
+        case (3, _)  => Nil
+        case (2, 13) => Seq("-Wconf:any:e,cat=unused:s,cat=deprecation:s,cat=unchecked:s")
+        case (2, 12) => Seq("-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e")
+      }),
       Test / scalacOptions --= Seq("-Xlint", "-unchecked", "-deprecation"),
       Test / scalacOptions -= defaultScalaOptions.value,
-      Test / scalacOptions ++= (
-        if (scalaVersion.value.startsWith("3.")) Nil
-        else Seq("-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e")
-      ),
+      Test / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value).get match {
+        case (3, _)  => Nil
+        case (2, 13) => Seq("-Wconf:any:e,cat=unused:s,cat=deprecation:s,cat=unchecked:s")
+        case (2, 12) => Seq("-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e")
+      }),
       Compile / doc / scalacOptions := Seq())
 
   lazy val disciplineSettings =

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -51,10 +51,10 @@ site-link-validator {
   ignore-prefixes = [
     ## GitHub will block with "429 Too Many Requests"
     "https://github.com/"
-    "https://www.scala-lang.org/api/2.13.14/scala/runtime/AbstractFunction1.html"
-    "https://www.scala-lang.org/api/2.13.14/scala/runtime/AbstractFunction2.html"
-    "https://www.scala-lang.org/api/2.13.14/scala/runtime/AbstractFunction3.html"
-    "https://www.scala-lang.org/api/2.13.14/scala/runtime/AbstractPartialFunction.html"
+    "https://www.scala-lang.org/api/2.13.15/scala/runtime/AbstractFunction1.html"
+    "https://www.scala-lang.org/api/2.13.15/scala/runtime/AbstractFunction2.html"
+    "https://www.scala-lang.org/api/2.13.15/scala/runtime/AbstractFunction3.html"
+    "https://www.scala-lang.org/api/2.13.15/scala/runtime/AbstractPartialFunction.html"
     ## Bug, see https://github.com/scala/bug/issues/12807 and https://github.com/lampepfl/dotty/issues/17973
     "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/StandardOpenOption$.html"
   ]


### PR DESCRIPTION
* Update scala-library to 2.13.15

* Update link-validator.conf

* fix `-Wconf` to match new semantics

Override order reversed, see also https://github.com/scala/scala/releases

backport https://github.com/apache/pekko/pull/1505

This will make future maintain easier.

---------

Co-authored-by: Arnout Engelen <arnout@bzzt.net>
Co-authored-by: PJ Fanning <pjfanning@users.noreply.github.com>
(cherry picked from commit dad6b9f6e3289334d709053849595d5f0e1f686e)