### PR TITLE
fix: Fix occasional ordering issue in FlowWithContext#unsafeOptionalDataVia

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowWithContextSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowWithContextSpec.scala
@@ -194,17 +194,19 @@ class FlowWithContextSpec extends StreamSpec {
         .asFlowWithContext[Option[String], Int, Int](collapseContext = Tuple2.apply)(extractContext = _._2)
         .map(_._1)
 
-      SourceWithContext
-        .fromTuples(Source(data)).via(
-          FlowWithContext.unsafeOptionalDataVia(
-            flow,
-            Flow.fromFunction { (string: String) => string.toInt }
-          )(Keep.none)
-        )
-        .runWith(TestSink.probe[(Option[Int], Int)])
-        .request(4)
-        .expectNext((Some(1), 1), (None, 2), (None, 3), (Some(4), 4))
-        .expectComplete()
+      for (_ <- 0 until 64) {
+        SourceWithContext
+          .fromTuples(Source(data)).via(
+            FlowWithContext.unsafeOptionalDataVia(
+              flow,
+              Flow.fromFunction { (string: String) => string.toInt }
+            )(Keep.none)
+          )
+          .runWith(TestSink.probe[(Option[Int], Int)])
+          .request(4)
+          .expectNext((Some(1), 1), (None, 2), (None, 3), (Some(4), 4))
+          .expectComplete()
+      }
     }
   }
 }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceWithContextSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceWithContextSpec.scala
@@ -242,14 +242,16 @@ class SourceWithContextSpec extends StreamSpec {
 
       val source = SourceWithContext.fromTuples(Source(data))
 
-      SourceWithContext.unsafeOptionalDataVia(
-        source,
-        Flow.fromFunction { (string: String) => string.toInt }
-      )(Keep.none)
-        .runWith(TestSink.probe[(Option[Int], Int)])
-        .request(4)
-        .expectNext((Some(1), 1), (None, 2), (None, 3), (Some(4), 4))
-        .expectComplete()
+      for (_ <- 0 until 64) {
+        SourceWithContext.unsafeOptionalDataVia(
+          source,
+          Flow.fromFunction { (string: String) => string.toInt }
+        )(Keep.none)
+          .runWith(TestSink.probe[(Option[Int], Int)])
+          .request(4)
+          .expectNext((Some(1), 1), (None, 2), (None, 3), (Some(4), 4))
+          .expectComplete()
+      }
     }
   }
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
@@ -87,7 +87,7 @@ object SourceWithContext {
 
         //format: off
         s ~> sequence ~> partition.in
-        partition.out(0).asInstanceOf[Outlet[(Option[FOut], IndexedCtx)]] ~> mergeSequence.in(0)
+        partition.out(0).asInstanceOf[Outlet[(Option[FOut], IndexedCtx)]]                   ~> mergeSequence.in(0)
         partition.out(1) ~> unzip.in
                             unzip.out0 ~> unwrapSome ~> viaF ~> zipper.in0
                             unzip.out1                       ~> zipper.in1


### PR DESCRIPTION
Motivation:
Find this when run https://github.com/apache/pekko/pull/1680
Fix: https://github.com/apache/pekko/actions/runs/12616423403/job/35157651854#step:7:20761

Modification:
port the fix in https://github.com/apache/pekko/pull/1611

Result:
ran 1024 times, works.
