### PR TITLE
fix: Fix occasional ordering issue in FlowWithContext#unsafeOptionalD…

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
@@ -87,7 +87,7 @@ object SourceWithContext {
 
         //format: off
         s ~> sequence ~> partition.in
-        partition.out(0).asInstanceOf[Outlet[(Option[FOut], IndexedCtx)]] ~> mergeSequence.in(0)
+        partition.out(0).asInstanceOf[Outlet[(Option[FOut], IndexedCtx)]]                   ~> mergeSequence.in(0)
         partition.out(1) ~> unzip.in
                             unzip.out0 ~> unwrapSome ~> viaF ~> zipper.in0
                             unzip.out1                       ~> zipper.in1


### PR DESCRIPTION
…ataVia (#1681)

* chore: Test more rounds for unsafeDataVia keeping order.

* fix: Fix flask ordering in FlowWithContext#unsafeOptionalDataVia operator.

(cherry picked from commit 477fd393c20cd507917e589a2b919f37449a08f5)