### PR TITLE
chore: ignore even more configs for dependency submission

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -38,5 +38,5 @@ jobs:
         uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v3
         with:
-          configs-ignore: provided optional test TestJdk9 compile-internal pr-validation multi-jvm
+          configs-ignore: provided optional test TestJdk9 compile-internal runtime-internal pr-validation multi-jvm scala-tool scala-doc-tool
           modules-ignore: pekko-bench-jmh_2.12 pekko-docs_2.12 pekko-bench-jmh_2.13 pekko-docs_2.13 pekko-bench-jmh_3 pekko-docs_3


### PR DESCRIPTION
confirmed ignoring `runtime-internal` suppresses the really old guava, the `scala-doc-tool` and `scala-tool` configs currently don't pull in any problematic dependencies but they should not be relevant to our users either.

Follow-up on https://github.com/apache/pekko/pull/1689 and https://github.com/apache/pekko/pull/1392