### PR TITLE
Add info about port change in cluster-management

### DIFF
--- a/docs/src/main/paradox/migration/migration-guide-akka-1.0.x.md
+++ b/docs/src/main/paradox/migration/migration-guide-akka-1.0.x.md
@@ -20,6 +20,10 @@ These migration notes are designed for users migrating from Akka 2.6 to Pekko 1.
 * We have changed the default ports used by the pekko-remote module.
     * With @ref:[Classic Remoting](../remoting.md), Akka defaults to 2552, while Pekko defaults to 7355.
     * With @ref:[Artery Remoting](../remoting-artery.md), Akka defaults to 25520, while Pekko defaults to 17355.
+* We have changed the default port used by the pekko-cluster-management module.
+    * With Akka defaults to 8558, while Pekko defaults to 7626.
+
+
 
 ## Dependency Changes
 * The Scala 2.13/Scala 3 versions of Pekko no longer include [scala-java8-compat](https://github.com/scala/scala-java8-compat)

--- a/docs/src/main/paradox/migration/migration-guide-akka-1.0.x.md
+++ b/docs/src/main/paradox/migration/migration-guide-akka-1.0.x.md
@@ -21,7 +21,7 @@ These migration notes are designed for users migrating from Akka 2.6 to Pekko 1.
     * With @ref:[Classic Remoting](../remoting.md), Akka defaults to 2552, while Pekko defaults to 7355.
     * With @ref:[Artery Remoting](../remoting-artery.md), Akka defaults to 25520, while Pekko defaults to 17355.
 * We have changed the default port used by the pekko-cluster-management module.
-    * With Akka defaults to 8558, while Pekko defaults to 7626.
+    * Akka defaults to 8558, while Pekko defaults to 7626.
 
 
 


### PR DESCRIPTION
pekko uses a different port than akka for the module cluster-mangement. This is not documented in the migration guide. This PR adds it.

Sources:
* [Pekko Doc](https://nightlies.apache.org/pekko/docs/pekko-management/main-snapshot/docs/pekko-management.html#basic-configuration)
* [Akka Doc](https://doc.akka.io/libraries/akka-management/current/akka-management.html#basic-configuration)

