### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -23,7 +23,7 @@ jobs:
     name: Check / Code Style
     runs-on: ubuntu-22.04
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
     name: Check / Tests
     runs-on: ubuntu-22.04
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -144,7 +144,7 @@ jobs:
 
       - name: sbt ${{ matrix.command }}
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
@@ -161,7 +161,7 @@ jobs:
     name: Java 21 Extra Tests (including all tests that need Java 9+)
     runs-on: ubuntu-22.04
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/generate-doc-check.yml
+++ b/.github/workflows/generate-doc-check.yml
@@ -53,5 +53,5 @@ jobs:
 
       - name: Compile testClass&docs for all Scala versions
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: sbt ";+TestJdk9 / compile ; +compile:doc"

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Check headers
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
           -Dsbt.override.build.repos=false \

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create the Pekko site
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           cp .jvmopts-ci .jvmopts
           sbt -Dpekko.genjavadoc.enabled=true -Dpekko.genlicensereport.enabled=true "Javaunidoc/doc; Compile/unidoc; docs/paradox"

--- a/.github/workflows/nightly-1.0-builds.yml
+++ b/.github/workflows/nightly-1.0-builds.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: sbt cluster-metrics/test
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \
@@ -99,7 +99,7 @@ jobs:
 
       - name: sbt ${{ matrix.command }}
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
@@ -149,7 +149,7 @@ jobs:
 
       - name: Compile and Test
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \

--- a/.github/workflows/nightly-1.1-builds.yml
+++ b/.github/workflows/nightly-1.1-builds.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: sbt cluster-metrics/test
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \
@@ -100,7 +100,7 @@ jobs:
 
       - name: sbt ${{ matrix.command }}
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
@@ -151,7 +151,7 @@ jobs:
 
       - name: Compile and Test
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \

--- a/.github/workflows/nightly-builds-aeron.yml
+++ b/.github/workflows/nightly-builds-aeron.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: sbt ${{ matrix.command }}
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: sbt cluster-metrics/test
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \
@@ -100,7 +100,7 @@ jobs:
 
       - name: sbt ${{ matrix.command }}
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
@@ -127,7 +127,7 @@ jobs:
         scalaVersion: ["2.12.x", "2.13.x", "3.3.x"]
         javaVersion: [8, 11, 17, 21]
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -58,7 +58,7 @@ jobs:
       # TODO come up with a better way to control the version, possibly based on git tags
       - name: Build Documentation
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt -Dpekko.genjavadoc.enabled=true -Dpekko.genlicensereport.enabled=true "set ThisBuild / version := \"1.0.3\"; docs/paradox; unidoc"
 

--- a/.github/workflows/publish-1.0-nightly.yml
+++ b/.github/workflows/publish-1.0-nightly.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository == 'apache/pekko'
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-1.1-docs.yml
+++ b/.github/workflows/publish-1.1-docs.yml
@@ -58,7 +58,7 @@ jobs:
       # TODO come up with a better way to control the version, possibly based on git tags
       - name: Build Documentation
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt -Dpekko.genjavadoc.enabled=true -Dpekko.genlicensereport.enabled=true "set ThisBuild / version := \"1.1.3\"; docs/paradox; unidoc"
 

--- a/.github/workflows/publish-1.1-nightly.yml
+++ b/.github/workflows/publish-1.1-nightly.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository == 'apache/pekko'
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository == 'apache/pekko'
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Compile and run tests on Scala 3
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false
         run: |
           sbt \

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: sbt test
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
             -Djava.security.egd=file:/dev/./urandom \

--- a/project/PekkoDevelocityPlugin.scala
+++ b/project/PekkoDevelocityPlugin.scala
@@ -27,7 +27,7 @@ import sbt.Keys.insideCI
 
 object PekkoDevelocityPlugin extends AutoPlugin {
 
-  private val ApacheDevelocityUrl = url("https://ge.apache.org")
+  private val ApacheDevelocityUrl = url("https://develocity.apache.org")
   private val PekkoProjectId = ProjectId("pekko")
   private val ObfuscatedIPv4Address = "0.0.0.0"
 


### PR DESCRIPTION
This PR migrates the Pekko project to publish Build Scans to the the new Develocity instance at develocity.apache.org.