### PR TITLE
chore: Handle NormalShutdownReason in MergeHub

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -33,6 +33,7 @@ import pekko.annotation.InternalApi
 import pekko.dispatch.AbstractNodeQueue
 import pekko.stream._
 import pekko.stream.Attributes.LogLevels
+import pekko.stream.impl.ActorPublisher
 import pekko.stream.stage._
 
 /**
@@ -356,7 +357,8 @@ private[pekko] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Bo
 
           // Make some noise
           override def onUpstreamFailure(ex: Throwable): Unit = {
-            throw new MergeHub.ProducerFailed(
+            if (ex eq ActorPublisher.NormalShutdownReason) completeStage()
+            else throw new MergeHub.ProducerFailed(
               "Upstream producer failed with exception, " +
               "removing from MergeHub now",
               ex)


### PR DESCRIPTION
Motivation:
Fix https://github.com/apache/pekko/issues/1739 
as [anpin](https://github.com/anpin) just did。

Modification:
Handle the `NormalShutdownReason` as a normal complementation.

