### PR TITLE
chore: Add the missing EmptySource case to TraversalBuilder (#1743)

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TraversalBuilderSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TraversalBuilderSpec.scala
@@ -17,7 +17,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream._
 import pekko.stream.impl.TraversalTestUtils._
-import pekko.stream.scaladsl.Keep
+import pekko.stream.scaladsl.{ Keep, Source }
 import pekko.testkit.PekkoSpec
 
 class TraversalBuilderSpec extends PekkoSpec {
@@ -445,6 +445,22 @@ class TraversalBuilderSpec extends PekkoSpec {
           (flow1, Attributes.name("test") and Attributes.name("flow"), TestIsland1),
           (sink, Attributes.none, TestDefaultIsland)))
     }
+  }
+
+  "find Source.empty via TraversalBuilder with isEmptySource" in {
+    val emptySource = EmptySource
+    TraversalBuilder.isEmptySource(emptySource) should be(true)
+  }
+
+  "find javadsl Source.empty via TraversalBuilder with isEmptySource" in {
+    import pekko.stream.javadsl.Source
+    val emptySource = Source.empty()
+    TraversalBuilder.isEmptySource(emptySource) should be(true)
+  }
+
+  "find scaldsl Source.empty via TraversalBuilder with isEmptySource" in {
+    val emptySource = Source.empty
+    TraversalBuilder.isEmptySource(emptySource) should be(true)
   }
 
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/TraversalBuilder.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/TraversalBuilder.scala
@@ -386,6 +386,7 @@ import pekko.util.unused
   def isEmptySource(graph: Graph[SourceShape[_], _]): Boolean = graph match {
     case source: scaladsl.Source[_, _] if source eq scaladsl.Source.empty => true
     case source: javadsl.Source[_, _] if source eq javadsl.Source.empty() => true
+    case EmptySource                                                      => true
     case _                                                                => false
   }
 


### PR DESCRIPTION
(cherry picked from commit ba639f68a2eebb521e01879f584d2f682a7934eb)