### PR TITLE
[CI] fix issue with running scala-cli scripts

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -54,16 +54,6 @@ jobs:
             -Dmultinode.XX:+AlwaysActAsServerClassMachine \
             clean cluster-metrics/test
 
-# comment out test report until an apache or GitHub published action (action-surefire-report) can be found or added allowlist from INFRA
-#      - name: Test Reports
-#        # Makes it easier to spot failures instead of looking at the logs.
-#        if: ${{ failure() }}
-#        uses: marcospereira/action-surefire-report@v1
-#        with:
-#          report_paths: '**/target/test-reports/TEST-*.xml'
-#          fail_if_no_tests: false
-#          skip_publishing: true
-
   pekko-classic-remoting-tests:
     name: Pekko Classic Remoting Tests
     runs-on: ubuntu-22.04
@@ -166,23 +156,6 @@ jobs:
             -Dio.netty.leakDetection.level=PARANOID \
             clean "++ ${{ matrix.scalaVersion }} test" checkTestsHaveRun
 
-# comment out test report until an apache or GitHub published action (action-surefire-report) can be found or added allowlist from INFRA
-#      - name: Test Reports
-#        # Makes it easier to spot failures instead of looking at the logs.
-#        if: ${{ failure() }}
-#        uses: marcospereira/action-surefire-report@v1
-#        with:
-#          report_paths: '**/target/test-reports/TEST-*.xml'
-#          fail_if_no_tests: false
-
-#      # Archive test results so we can do some diagnostics later
-#      - name: Upload test results
-#        uses: actions/upload-artifact@v2
-#        if: success() || failure()        # run this step even if previous step failed
-#        with:
-#          name: test-results-${{ matrix.javaVersion }}-${{ matrix.scalaVersion }}
-#          path: '**/target/test-reports/TEST-*.xml'
-
       - name: Docs
         # Docs generation requires JDK 11.
         if: ${{ matrix.javaVersion == 11 }}
@@ -204,6 +177,7 @@ jobs:
 
       - name: Install scala-cli
         if: ${{ matrix.javaVersion == 11 }}
+        # uses: VirtusLab/scala-cli-setup@v1
         run: |-
           curl -sS "https://virtuslab.github.io/scala-cli-packages/KEY.gpg" | sudo gpg --dearmor  -o /etc/apt/trusted.gpg.d/scala-cli.gpg 2>/dev/null
           sudo curl -s --compressed -o /etc/apt/sources.list.d/scala_cli_packages.list "https://virtuslab.github.io/scala-cli-packages/debian/scala_cli_packages.list"

--- a/.github/workflows/verify-jdk9-classes.sh
+++ b/.github/workflows/verify-jdk9-classes.sh
@@ -17,12 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-echo "Checking Scala CLI version..."
-scala-cli --version
-
 echo "Starting verification with Scala-CLI..."
 
 for file in stream/target/scala-cli/*.sc; do
+  cat $file
   echo "Starting verification for with file: $file."
   if scala-cli "$file" ; then
     echo "Verification successful for $file."

--- a/project/VerifyJDK9Classes.scala
+++ b/project/VerifyJDK9Classes.scala
@@ -29,9 +29,9 @@ object VerifyJDK9Classes {
 
   def generateAndWriteScalaCLIScript(dir: SettingKey[File]): Def.Initialize[Task[Seq[sbt.File]]] =
     Def.task[Seq[File]] {
-      val binaryVersion = scalaBinaryVersion.value
-      val script = generateScalaCLIScript(version.value, binaryVersion)
-      val file = dir.value / "scala-cli" / s"VerifyJDK9Classes-${binaryVersion}.sc"
+      val scalaVer = scalaVersion.value
+      val script = generateScalaCLIScript(version.value, scalaVer)
+      val file = dir.value / "scala-cli" / s"VerifyJDK9Classes-${scalaVer}.sc"
       val content = script.stripMargin.format(version.value)
       if (!file.exists || IO.read(file) != content) IO.write(file, content)
       // the generated file is not used.
@@ -40,6 +40,9 @@ object VerifyJDK9Classes {
 
   private def generateScalaCLIScript(version: String, scalaBinaryVersion: String): String =
     s"""
+      |//> using scala ${scalaBinaryVersion}
+      |//> using dep "org.apache.pekko::pekko-stream:${version}"
+      |
       |/*
       | * Licensed to the Apache Software Foundation (ASF) under one or more
       | * contributor license agreements. See the NOTICE file distributed with
@@ -56,8 +59,7 @@ object VerifyJDK9Classes {
       | * See the License for the specific language governing permissions and
       | * limitations under the License.
       | */
-      |//> using scala ${scalaBinaryVersion}
-      |//> using dep "org.apache.pekko::pekko-stream:${version}"
+      |
       |object VerifyJDK9Classes {
       |  def main(args: Array[String]): Unit = {
       |    import org.apache.pekko.actor.ActorSystem


### PR DESCRIPTION
* the CI action is not yet approved by ASF Infra team
* The main fix is to have the license header in the generated script appear after the CLI directives for the scala version and imports.
* fixes #1751