### PR TITLE
upgrade to netty 4.1.121 due to CVE-2025-24970

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
   val agronaVersion = "1.22.0"
   val bouncyCastleVersion = "1.79"
-  val nettyVersion = "4.1.116.Final"
+  val nettyVersion = "4.1.121.Final"
   val logbackVersion = "1.3.14"
 
   val jacksonCoreVersion = "2.17.3"


### PR DESCRIPTION
* upgrading netty in 1.1.x branch in anticipation of 1.1.4 release
* includes fix for CVE-2025-24970
* main branch uses 4.2.1 but it seems best not to risk a non-patch upgrade in a Pekko patch release