### PR TITLE
enable compatibility check in cluster test

### DIFF
--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterJoinSpec
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterJoinSpec
@@ -35,8 +35,7 @@ object ClusterJoinSpec {
       pekko.remote.classic.netty.tcp.port = 0
       pekko.remote.artery.advanced.aeron.idle-cpu-level = 3
 
-      pekko.cluster.jmx.multi-mbeans-in-same-jvm = on
-      pekko.cluster.configuration-compatibility-check.enforce-on-join = off""")
+      pekko.cluster.jmx.multi-mbeans-in-same-jvm = on""")
 
 
   val configWithNetty: Config =


### PR DESCRIPTION
This is a new test added in #1861. The compat check should probably not have been disabled.

I will do a separate investigation for the equivalent mixed cluster tests in main and 1.1.x branches (#1865).

The CI issue is an unrelated link validation issue.