### PR TITLE
try to fix broken cluster metrics test

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,7 +1,6 @@
 name: Nightly Builds
 
 on:
-  pull_request:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
@@ -58,7 +57,7 @@ jobs:
   pekko-classic-remoting-tests:
     name: Pekko Classic Remoting Tests
     runs-on: ubuntu-22.04
-    if: github.repository == 'apache/xpekko'
+    if: github.repository == 'apache/pekko'
     strategy:
       fail-fast: false
       matrix:
@@ -115,8 +114,8 @@ jobs:
         # No need to specify the full Scala version. Only the Scala
         # binary version is required and Pekko build will set the right
         # full version from it.
-        scalaVersion: ["2.12.x"]
-        javaVersion: [8]
+        scalaVersion: ["2.12.x", "2.13.x", "3.3.x"]
+        javaVersion: [8, 11, 17, 21]
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,6 +1,7 @@
 name: Nightly Builds
 
 on:
+  pull_request:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
@@ -57,7 +58,7 @@ jobs:
   pekko-classic-remoting-tests:
     name: Pekko Classic Remoting Tests
     runs-on: ubuntu-22.04
-    if: github.repository == 'apache/pekko'
+    if: github.repository == 'apache/xpekko'
     strategy:
       fail-fast: false
       matrix:
@@ -114,8 +115,8 @@ jobs:
         # No need to specify the full Scala version. Only the Scala
         # binary version is required and Pekko build will set the right
         # full version from it.
-        scalaVersion: ["2.12.x", "2.13.x", "3.3.x"]
-        javaVersion: [8, 11, 17, 21]
+        scalaVersion: ["2.12.x"]
+        javaVersion: [8]
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStream.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStream.scala
@@ -17,10 +17,11 @@
 
 package org.apache.pekko.cluster.metrics.protobuf
 
-import java.io.{ InputStream, ObjectInputStream, ObjectStreamClass }
+import java.io.{ InputStream, ObjectStreamClass }
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
+import pekko.util.ClassLoaderObjectInputStream
 
 /**
  * A special ObjectInputStream that will only load built-in primitives or
@@ -32,7 +33,7 @@ import pekko.annotation.InternalApi
 @InternalApi
 private[protobuf] class NumberInputStream(
     classLoader: ClassLoader,
-    inputStream: InputStream) extends ObjectInputStream(inputStream) {
+    inputStream: InputStream) extends ClassLoaderObjectInputStream(classLoader, inputStream) {
 
   /**
    * Resolve a class specified by the descriptor using the provided classloader
@@ -44,7 +45,7 @@ private[protobuf] class NumberInputStream(
    * @throws ClassNotFoundException if the Class cannot be found (or is rejected)
    */
   override protected def resolveClass(objectStreamClass: ObjectStreamClass): Class[_] = {
-    val clazz = Class.forName(objectStreamClass.getName(), false, classLoader)
+    val clazz = super.resolveClass(objectStreamClass)
     if (clazz.isPrimitive() || classOf[Number].isAssignableFrom(clazz)) {
       clazz
     } else {

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStream.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStream.scala
@@ -53,8 +53,8 @@ private[protobuf] class NumberInputStream(
     } else {
       throw new ClassNotFoundException(
         s"Class rejected: ${objectStreamClass.getName()} " +
-          "(only primitive types, arrays of primitive types, subclasses of java.lang.Number " +
-          "and java.math classes are allowed)")
+        "(only primitive types, arrays of primitive types, subclasses of java.lang.Number " +
+        "and java.math classes are allowed)")
     }
   }
 

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStream.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStream.scala
@@ -37,8 +37,8 @@ private[protobuf] class NumberInputStream(
 
   /**
    * Resolve a class specified by the descriptor using the provided classloader
-   * and that treats any class that is not a primitive or a subclass of
-   * <code>java.lang.Number</code> as not found.
+   * and that treats any class that is not a primitive, an array of primitives
+   * or a subclass of <code>java.lang.Number</code> as not found.
    *
    * @param objectStreamClass  descriptor of the class
    * @return the Class object described by the ObjectStreamClass
@@ -46,7 +46,8 @@ private[protobuf] class NumberInputStream(
    */
   override protected def resolveClass(objectStreamClass: ObjectStreamClass): Class[_] = {
     val clazz = super.resolveClass(objectStreamClass)
-    if (clazz.isPrimitive() || classOf[Number].isAssignableFrom(clazz)) {
+    if (clazz.isPrimitive() || (clazz.isArray() && clazz.getComponentType.isPrimitive) ||
+      classOf[Number].isAssignableFrom(clazz)) {
       clazz
     } else {
       throw new ClassNotFoundException(

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStream.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStream.scala
@@ -38,7 +38,8 @@ private[protobuf] class NumberInputStream(
   /**
    * Resolve a class specified by the descriptor using the provided classloader
    * and that treats any class that is not a primitive, an array of primitives
-   * or a subclass of <code>java.lang.Number</code> as not found.
+   * or a subclass of <code>java.lang.Number</code>
+   * or <code>java.math</code> classes as not found.
    *
    * @param objectStreamClass  descriptor of the class
    * @return the Class object described by the ObjectStreamClass
@@ -47,11 +48,13 @@ private[protobuf] class NumberInputStream(
   override protected def resolveClass(objectStreamClass: ObjectStreamClass): Class[_] = {
     val clazz = super.resolveClass(objectStreamClass)
     if (clazz.isPrimitive() || (clazz.isArray() && clazz.getComponentType.isPrimitive) ||
-      classOf[Number].isAssignableFrom(clazz)) {
+      classOf[Number].isAssignableFrom(clazz) || clazz.getPackage.getName == "java.math") {
       clazz
     } else {
       throw new ClassNotFoundException(
-        s"Class rejected: ${objectStreamClass.getName()} (only primitive types and subclasses of java.lang.Number are allowed)")
+        s"Class rejected: ${objectStreamClass.getName()} " +
+          "(only primitive types, arrays of primitive types, subclasses of java.lang.Number " +
+          "and java.math classes are allowed)")
     }
   }
 

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStreamSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/protobuf/NumberInputStreamSpec.scala
@@ -18,6 +18,8 @@
 package org.apache.pekko.cluster.metrics.protobuf
 
 import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream }
+import java.math.BigInteger
+import scala.math.BigInt
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -65,6 +67,74 @@ class NumberInputStreamSpec extends AnyWordSpec with Matchers {
       numberInputStream.close()
       result shouldBe an[Int]
       result.asInstanceOf[Int] shouldEqual i
+    }
+
+    "resolve java BigInteger" in {
+
+      val i = BigInteger.valueOf(Long.MaxValue)
+      val bos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(bos)
+      oos.writeObject(i)
+      oos.close()
+
+      val inputStream = new ByteArrayInputStream(bos.toByteArray)
+      val numberInputStream = new NumberInputStream(classLoader, inputStream)
+
+      val result = numberInputStream.readObject()
+      numberInputStream.close()
+      result shouldBe a[BigInteger]
+      result.asInstanceOf[BigInteger] shouldEqual i
+    }
+
+    "resolve scala BigInt" in {
+
+      val i = BigInt(Long.MaxValue).+(BigInt(1))
+      val bos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(bos)
+      oos.writeObject(i)
+      oos.close()
+
+      val inputStream = new ByteArrayInputStream(bos.toByteArray)
+      val numberInputStream = new NumberInputStream(classLoader, inputStream)
+
+      val result = numberInputStream.readObject()
+      numberInputStream.close()
+      result shouldBe a[BigInt]
+      result.asInstanceOf[BigInt] shouldEqual i
+    }
+
+    "resolve java BigDecimal" in {
+
+      val n = new java.math.BigDecimal("123456789012345678901234567890.12345678901234567890")
+      val bos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(bos)
+      oos.writeObject(n)
+      oos.close()
+
+      val inputStream = new ByteArrayInputStream(bos.toByteArray)
+      val numberInputStream = new NumberInputStream(classLoader, inputStream)
+
+      val result = numberInputStream.readObject()
+      numberInputStream.close()
+      result shouldBe a[java.math.BigDecimal]
+      result.asInstanceOf[java.math.BigDecimal] shouldEqual n
+    }
+
+    "resolve scala BigDecimal" in {
+
+      val n = scala.math.BigDecimal("123456789012345678901234567890.12345678901234567890")
+      val bos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(bos)
+      oos.writeObject(n)
+      oos.close()
+
+      val inputStream = new ByteArrayInputStream(bos.toByteArray)
+      val numberInputStream = new NumberInputStream(classLoader, inputStream)
+
+      val result = numberInputStream.readObject()
+      numberInputStream.close()
+      result shouldBe a[scala.math.BigDecimal]
+      result.asInstanceOf[scala.math.BigDecimal] shouldEqual n
     }
 
     "throw ClassNotFoundException for non-Number classes" in {


### PR DESCRIPTION
* see #1911 
* reworking the newly added NumberInputStream to allow arrays of primitives (eg arrays of bytes) fixes the issue - that oddly only occurs with Scala 2.12 runtime