### PR TITLE
remove final use of sun.misc.Unsafe

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/AsciiStringCopySpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/AsciiStringCopySpec.scala
@@ -26,7 +26,6 @@ class AsciiStringCopySpec extends AnyWordSpec with Matchers {
       // this is known to fail with JDK 11 on ARM32 (Raspberry Pi),
       // and therefore algorithm 0 is selected on that architecture
       Unsafe.testUSAsciiStrToBytesAlgorithm1("abc") should ===(true)
-      Unsafe.testUSAsciiStrToBytesAlgorithm2("abc") should ===(false)
     }
 
     "copy string internal representation successfully" in {


### PR DESCRIPTION
* String value field is a byte array in Java 17+ - no need to support it being a char array like it was in older JDKs
* the VarHandle still needs `--add-opens=java.base/java.lang=ALL-UNNAMED` or equivalent so I think is ok to keep the Pekko class name as pekko.util.Unsafe - and this is better for backward compatibility too because the public methods are used in other Pekko modules