### PR TITLE
fix build issue related to URL deprecation (PojoSRTestSupport in osgi module)

### DIFF
--- a/osgi/src/test/scala/org/apache/pekko/osgi/PojoSRTestSupport.scala
+++ b/osgi/src/test/scala/org/apache/pekko/osgi/PojoSRTestSupport.scala
@@ -18,7 +18,7 @@ import java.net.URL
 import java.util.{ Date, HashMap, ServiceLoader, UUID }
 import java.util.jar.JarInputStream
 
-import scala.annotation.tailrec
+import scala.annotation.{ nowarn, tailrec }
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
@@ -158,6 +158,7 @@ class BundleDescriptorBuilder(name: String) {
   /**
    * Build the actual PojoSR BundleDescriptor instance
    */
+  @nowarn("msg=deprecated")
   def build: BundleDescriptor = {
     val file: File = tinybundleToJarFile(name)
     new BundleDescriptor(


### PR DESCRIPTION
```
[08-02 21:27:58.894] [error] /home/runner/work/pekko/pekko/osgi/src/test/scala/org/apache/pekko/osgi/PojoSRTestSupport.scala:165:7: constructor URL in class URL is deprecated (since 20)
[08-02 21:27:58.894] [error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=deprecation, site=org.apache.pekko.osgi.BundleDescriptorBuilder.build, origin=java.net.URL.<init>, version=20
[08-02 21:27:58.894] [error]       new URL("jar:" + file.toURI().toString() + "!/"),
[08-02 21:27:58.894] [error]       ^
[08-02 21:27:58.910] [error] one error found
```

https://github.com/apache/pekko/actions/runs/16697884430/job/47264617078#step:8:520