### PR TITLE
chore: Migrate to pekko.japi.function

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/actor/ActorCreationTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/actor/ActorCreationTest.java
@@ -22,7 +22,7 @@ import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.apache.pekko.japi.Creator;
+import org.apache.pekko.japi.function.Creator;
 
 import org.scalatestplus.junit.JUnitSuite;
 

--- a/actor-tests/src/test/java/org/apache/pekko/actor/JavaAPI.java
+++ b/actor-tests/src/test/java/org/apache/pekko/actor/JavaAPI.java
@@ -15,7 +15,7 @@ package org.apache.pekko.actor;
 
 import org.apache.pekko.event.Logging;
 import org.apache.pekko.event.Logging.LoggerInitialized;
-import org.apache.pekko.japi.Creator;
+import org.apache.pekko.japi.function.Creator;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.japi.Util;
 import org.apache.pekko.japi.tuple.Tuple22;

--- a/actor-tests/src/test/java/org/apache/pekko/actor/NonStaticCreator.java
+++ b/actor-tests/src/test/java/org/apache/pekko/actor/NonStaticCreator.java
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.actor;
 
-import org.apache.pekko.japi.Creator;
+import org.apache.pekko.japi.function.Creator;
 
 public class NonStaticCreator implements Creator<UntypedAbstractActor> {
   @Override

--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
@@ -13,6 +13,7 @@
 
 package org.apache.pekko.dispatch;
 
+import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.testkit.PekkoJUnitActorSystemResource;
 import org.apache.pekko.actor.ActorSystem;
 

--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
@@ -14,6 +14,7 @@
 package org.apache.pekko.dispatch;
 
 import org.apache.pekko.japi.function.Function;
+import org.apache.pekko.japi.function.Function2;
 import org.apache.pekko.testkit.PekkoJUnitActorSystemResource;
 import org.apache.pekko.actor.ActorSystem;
 

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/PropsCreationSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/PropsCreationSpec.scala
@@ -31,7 +31,7 @@ object PropsCreationSpec {
     override def receive = Actor.emptyBehavior
   }
 
-  object OneParamActorCreator extends pekko.japi.Creator[Actor] {
+  object OneParamActorCreator extends pekko.japi.function.Creator[Actor] {
     override def create(): Actor = new OneParamActor(null)
   }
 

--- a/actor-tests/src/test/scala/org/apache/pekko/event/EventBusSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/event/EventBusSpec.scala
@@ -18,7 +18,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.pekko
 import pekko.actor.{ Actor, ActorRef, ActorSystem, PoisonPill, Props }
-import pekko.japi.Procedure
+import pekko.japi.function.Procedure
 import pekko.testkit._
 
 object EventBusSpec {

--- a/actor-typed/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
+++ b/actor-typed/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Migrate functions in japi.* to to japi.function.*
+# Migrate functions in japi.* to japi.function.*
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.typed.javadsl.Adapter.props")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.typed.javadsl.Behaviors.receiveMessage")

--- a/actor-typed/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
+++ b/actor-typed/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Migrate functions in japi.* to to japi.function.*
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.typed.javadsl.Adapter.props")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.typed.javadsl.Behaviors.receiveMessage")

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Adapter.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Adapter.scala
@@ -23,7 +23,7 @@ import pekko.actor.typed.Scheduler
 import pekko.actor.typed.SupervisorStrategy
 import pekko.actor.typed.internal.adapter.ActorContextAdapter
 import pekko.actor.typed.scaladsl.adapter._
-import pekko.japi.Creator
+import pekko.japi.function.Creator
 
 /**
  * Adapters between typed and classic actors and actor systems.

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Behaviors.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Behaviors.scala
@@ -160,7 +160,7 @@ object Behaviors {
    *
    * @since 1.1.0
    */
-  def receiveMessageWithSame[T](onMessage: pekko.japi.Procedure[T]): Behavior[T] =
+  def receiveMessageWithSame[T](onMessage: pekko.japi.function.Procedure[T]): Behavior[T] =
     new BehaviorImpl.ReceiveBehavior((_, msg) => {
       onMessage.apply(msg)
       same[T]

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Behaviors.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Behaviors.scala
@@ -140,7 +140,7 @@ object Behaviors {
    * that can potentially be different from this one. State is maintained by returning
    * a new behavior that holds the new immutable state.
    */
-  def receiveMessage[T](onMessage: pekko.japi.Function[T, Behavior[T]]): Behavior[T] =
+  def receiveMessage[T](onMessage: pekko.japi.function.Function[T, Behavior[T]]): Behavior[T] =
     new BehaviorImpl.ReceiveBehavior((_, msg) => onMessage.apply(msg))
 
   /**

--- a/actor/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
+++ b/actor/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Migrate functions in japi.* to to japi.function.*
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.AllForOneStrategy.this")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.OneForOneStrategy.this")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.Props.create")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.SupervisorStrategy.makeDecider")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.dispatch.ExecutionContexts.fromExecutorService")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.dispatch.ExecutionContexts.fromExecutor")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.dispatch.Filter.filterOf")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.dispatch.Futures.traverse")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.dispatch.Futures.reduce")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.dispatch.Futures.fold")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.dispatch.Futures.find")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.japi.Creator")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.japi.Effect")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.japi.Function")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.japi.Function2")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.japi.Predicate")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.japi.Procedure")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.pattern.Patterns.askWithReplyTo")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.serialization.SerializationSetup.create")
+

--- a/actor/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
+++ b/actor/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Migrate functions in japi.* to to japi.function.*
+# Migrate functions in japi.* to japi.function.*
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.AllForOneStrategy.this")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.OneForOneStrategy.this")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.actor.Props.create")

--- a/actor/src/main/scala/org/apache/pekko/actor/AbstractProps.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/AbstractProps.scala
@@ -20,7 +20,7 @@ import scala.annotation.tailrec
 import scala.annotation.varargs
 
 import org.apache.pekko
-import pekko.japi.Creator
+import pekko.japi.function.Creator
 
 /**
  * Java API: Factory for Props instances.

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
@@ -29,7 +29,7 @@ import pekko.annotation.{ InternalApi, InternalStableApi }
 import pekko.dispatch.{ Envelope, MessageDispatcher }
 import pekko.dispatch.sysmsg._
 import pekko.event.Logging.{ Debug, Error, LogEvent }
-import pekko.japi.Procedure
+import pekko.japi.function.Procedure
 import pekko.util.unused
 
 /**

--- a/actor/src/main/scala/org/apache/pekko/actor/FaultHandling.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/FaultHandling.scala
@@ -248,7 +248,7 @@ object SupervisorStrategy extends SupervisorStrategyLowPriorityImplicits {
   implicit def seqThrowable2Decider(trapExit: immutable.Seq[Class[_ <: Throwable]]): Decider = makeDecider(trapExit)
 
   type Decider = PartialFunction[Throwable, Directive]
-  type JDecider = pekko.japi.Function[Throwable, Directive]
+  type JDecider = pekko.japi.function.Function[Throwable, Directive]
   type CauseDirective = (Class[_ <: Throwable], Directive)
 
   /**

--- a/actor/src/main/scala/org/apache/pekko/actor/IndirectActorProducer.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/IndirectActorProducer.scala
@@ -18,7 +18,7 @@ import scala.collection.immutable
 import scala.annotation.nowarn
 
 import org.apache.pekko
-import pekko.japi.Creator
+import pekko.japi.function.Creator
 import pekko.util.Reflect
 
 /**

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -169,7 +169,7 @@ object Futures {
   def fold[T <: AnyRef, R <: AnyRef](
       zero: R,
       futures: JIterable[Future[T]],
-      fun: pekko.japi.Function2[R, T, R],
+      fun: pekko.japi.function.Function2[R, T, R],
       executor: ExecutionContext): Future[R] =
     compat.Future.fold(futures.asScala)(zero)(fun.apply)(executor)
 
@@ -178,7 +178,7 @@ object Futures {
    */
   def reduce[T <: AnyRef, R >: T](
       futures: JIterable[Future[T]],
-      fun: pekko.japi.Function2[R, T, R],
+      fun: pekko.japi.function.Function2[R, T, R],
       executor: ExecutionContext): Future[R] =
     compat.Future.reduce[T, R](futures.asScala)(fun.apply)(executor)
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -27,7 +27,8 @@ import org.apache.pekko
 import pekko.annotation.InternalStableApi
 import pekko.compat
 import pekko.dispatch.internal.SameThreadExecutionContext
-import pekko.japi.{ Option => JOption, Procedure }
+import pekko.japi.{ Option => JOption }
+import pekko.japi.function.Procedure
 import pekko.util.unused
 
 /**

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -199,7 +199,8 @@ object Futures {
    * This is useful for performing a parallel map. For example, to apply a function to all items of a list
    * in parallel.
    */
-  def traverse[A, B](in: JIterable[A], fn: pekko.japi.function.Function[A, Future[B]], executor: ExecutionContext): Future[JIterable[B]] = {
+  def traverse[A, B](in: JIterable[A], fn: pekko.japi.function.Function[A, Future[B]], executor: ExecutionContext)
+      : Future[JIterable[B]] = {
     implicit val d = executor
     in.asScala.foldLeft(Future(new JLinkedList[B]())) { (fr, a) =>
       val fb = fn(a)

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -27,7 +27,7 @@ import org.apache.pekko
 import pekko.annotation.InternalStableApi
 import pekko.compat
 import pekko.dispatch.internal.SameThreadExecutionContext
-import pekko.japi.{ Function => JFunc, Option => JOption, Procedure }
+import pekko.japi.{ Option => JOption, Procedure }
 import pekko.util.unused
 
 /**
@@ -148,7 +148,7 @@ object Futures {
    */
   def find[T <: AnyRef](
       futures: JIterable[Future[T]],
-      predicate: JFunc[T, java.lang.Boolean],
+      predicate: pekko.japi.function.Function[T, java.lang.Boolean],
       executor: ExecutionContext): Future[JOption[T]] = {
     implicit val ec = executor
     compat.Future.find[T](futures.asScala)(predicate.apply(_))(executor).map(JOption.fromScalaOption)
@@ -198,7 +198,7 @@ object Futures {
    * This is useful for performing a parallel map. For example, to apply a function to all items of a list
    * in parallel.
    */
-  def traverse[A, B](in: JIterable[A], fn: JFunc[A, Future[B]], executor: ExecutionContext): Future[JIterable[B]] = {
+  def traverse[A, B](in: JIterable[A], fn: pekko.japi.function.Function[A, Future[B]], executor: ExecutionContext): Future[JIterable[B]] = {
     implicit val d = executor
     in.asScala.foldLeft(Future(new JLinkedList[B]())) { (fr, a) =>
       val fb = fn(a)
@@ -345,7 +345,7 @@ abstract class Recover[+T] extends japi.RecoverBridge[T] {
  * to failure cases.
  */
 object Filter {
-  def filterOf[T](f: pekko.japi.Function[T, java.lang.Boolean]): (T => Boolean) =
+  def filterOf[T](f: pekko.japi.function.Function[T, java.lang.Boolean]): (T => Boolean) =
     new Function1[T, Boolean] { def apply(result: T): Boolean = f(result).booleanValue() }
 }
 

--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -27,17 +27,6 @@ import org.apache.pekko
 import pekko.util.Collections.EmptyImmutableSeq
 
 /**
- * A Procedure is like a Function, but it doesn't produce a return value.
- *
- * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Procedure]].
- */
-@FunctionalInterface
-trait Procedure[T] {
-  @throws(classOf[Exception])
-  def apply(param: T): Unit
-}
-
-/**
  * An executable piece of code that takes no parameters and doesn't return any value.
  *
  * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Effect]].

--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -38,16 +38,6 @@ trait Effect {
 }
 
 /**
- * Java API: Defines a criteria and determines whether the parameter meets this criteria.
- *
- * This class is kept for compatibility, but for future API's please prefer [[java.util.function.Predicate]].
- */
-@FunctionalInterface
-trait Predicate[T] {
-  def test(param: T): Boolean
-}
-
-/**
  * Java API
  * Represents a pair (tuple) of two elements.
  *

--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -25,17 +25,6 @@ import org.apache.pekko
 import pekko.util.Collections.EmptyImmutableSeq
 
 /**
- * An executable piece of code that takes no parameters and doesn't return any value.
- *
- * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Effect]].
- */
-@FunctionalInterface
-trait Effect {
-  @throws(classOf[Exception])
-  def apply(): Unit
-}
-
-/**
  * Java API
  * Represents a pair (tuple) of two elements.
  *

--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -27,17 +27,6 @@ import org.apache.pekko
 import pekko.util.Collections.EmptyImmutableSeq
 
 /**
- * A Function interface. Used to create 2-arg first-class-functions is Java.
- *
- * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Function2]].
- */
-@FunctionalInterface
-trait Function2[T1, T2, R] {
-  @throws(classOf[Exception])
-  def apply(arg1: T1, arg2: T2): R
-}
-
-/**
  * A Procedure is like a Function, but it doesn't produce a return value.
  *
  * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Procedure]].

--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -21,8 +21,6 @@ import scala.reflect.ClassTag
 import scala.runtime.AbstractPartialFunction
 import scala.util.control.NoStackTrace
 
-import scala.annotation.nowarn
-
 import org.apache.pekko
 import pekko.util.Collections.EmptyImmutableSeq
 
@@ -49,23 +47,6 @@ case class Pair[A, B](first: A, second: B) {
 }
 object Pair {
   def create[A, B](first: A, second: B): Pair[A, B] = new Pair(first, second)
-}
-
-/**
- * A constructor/factory, takes no parameters but creates a new value of type T every call.
- *
- * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Creator]].
- */
-@nowarn("msg=@SerialVersionUID has no effect")
-@SerialVersionUID(1L)
-@FunctionalInterface
-trait Creator[T] extends Serializable {
-
-  /**
-   * This method must return a different instance upon every call.
-   */
-  @throws(classOf[Exception])
-  def create(): T
 }
 
 object JavaPartialFunction {

--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -27,17 +27,6 @@ import org.apache.pekko
 import pekko.util.Collections.EmptyImmutableSeq
 
 /**
- * A Function interface. Used to create first-class-functions is Java.
- *
- * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Function]].
- */
-@FunctionalInterface
-trait Function[T, R] {
-  @throws(classOf[Exception])
-  def apply(param: T): R
-}
-
-/**
  * A Function interface. Used to create 2-arg first-class-functions is Java.
  *
  * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Function2]].

--- a/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
@@ -126,7 +126,7 @@ object Patterns {
    *   timeout);
    * }}}
    */
-  def askWithReplyTo(actor: ActorRef, messageFactory: japi.Function[ActorRef, Any], timeout: Timeout): Future[AnyRef] =
+  def askWithReplyTo(actor: ActorRef, messageFactory: japi.function.Function[ActorRef, Any], timeout: Timeout): Future[AnyRef] =
     extended.ask(actor, messageFactory.apply _)(timeout).asInstanceOf[Future[AnyRef]]
 
   /**
@@ -197,7 +197,7 @@ object Patterns {
    */
   def askWithReplyTo(
       actor: ActorRef,
-      messageFactory: japi.Function[ActorRef, Any],
+      messageFactory: japi.function.Function[ActorRef, Any],
       timeoutMillis: Long): Future[AnyRef] =
     extended.ask(actor, messageFactory.apply _)(Timeout(timeoutMillis.millis)).asInstanceOf[Future[AnyRef]]
 
@@ -312,7 +312,7 @@ object Patterns {
    */
   def askWithReplyTo(
       selection: ActorSelection,
-      messageFactory: japi.Function[ActorRef, Any],
+      messageFactory: japi.function.Function[ActorRef, Any],
       timeoutMillis: Long): Future[AnyRef] =
     extended.ask(selection, messageFactory.apply _)(Timeout(timeoutMillis.millis)).asInstanceOf[Future[AnyRef]]
 
@@ -329,7 +329,7 @@ object Patterns {
    */
   def askWithReplyTo(
       selection: ActorSelection,
-      messageFactory: japi.Function[ActorRef, Any],
+      messageFactory: japi.function.Function[ActorRef, Any],
       timeout: java.time.Duration): CompletionStage[AnyRef] =
     extended.ask(selection, messageFactory.apply _)(timeout.asScala).asJava.asInstanceOf[CompletionStage[AnyRef]]
 

--- a/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
@@ -126,7 +126,8 @@ object Patterns {
    *   timeout);
    * }}}
    */
-  def askWithReplyTo(actor: ActorRef, messageFactory: japi.function.Function[ActorRef, Any], timeout: Timeout): Future[AnyRef] =
+  def askWithReplyTo(actor: ActorRef, messageFactory: japi.function.Function[ActorRef, Any], timeout: Timeout)
+      : Future[AnyRef] =
     extended.ask(actor, messageFactory.apply _)(timeout).asInstanceOf[Future[AnyRef]]
 
   /**

--- a/actor/src/main/scala/org/apache/pekko/serialization/SerializationSetup.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/SerializationSetup.scala
@@ -34,7 +34,7 @@ object SerializationSetup {
    * Java API: Programmatic definition of serializers
    * @param createSerializers create pairs of serializer and the set of classes it should be used for
    */
-  def create(createSerializers: pekko.japi.Function[ExtendedActorSystem, java.util.List[SerializerDetails]])
+  def create(createSerializers: pekko.japi.function.Function[ExtendedActorSystem, java.util.List[SerializerDetails]])
       : SerializationSetup =
     apply(sys => createSerializers(sys).asScala.toVector)
 

--- a/docs/src/test/java/jdocs/persistence/LambdaPersistenceDocTest.java
+++ b/docs/src/test/java/jdocs/persistence/LambdaPersistenceDocTest.java
@@ -14,7 +14,7 @@
 package jdocs.persistence;
 
 import org.apache.pekko.actor.*;
-import org.apache.pekko.japi.Procedure;
+import org.apache.pekko.japi.function.Procedure;
 import org.apache.pekko.pattern.BackoffOpts;
 import org.apache.pekko.pattern.BackoffSupervisor;
 import org.apache.pekko.persistence.*;

--- a/docs/src/test/java/jdocs/stream/GraphStageDocTest.java
+++ b/docs/src/test/java/jdocs/stream/GraphStageDocTest.java
@@ -19,7 +19,7 @@ import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Option;
 import org.apache.pekko.japi.Pair;
-import org.apache.pekko.japi.Predicate;
+import org.apache.pekko.japi.function.Predicate;
 import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.japi.function.Procedure;
 import org.apache.pekko.stream.*;

--- a/docs/src/test/java/jdocs/stream/GraphStageDocTest.java
+++ b/docs/src/test/java/jdocs/stream/GraphStageDocTest.java
@@ -20,7 +20,7 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Option;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.japi.Predicate;
-import org.apache.pekko.japi.Function;
+import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.japi.function.Procedure;
 import org.apache.pekko.stream.*;
 import org.apache.pekko.stream.javadsl.*;

--- a/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMultiGroupByTest.java
+++ b/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMultiGroupByTest.java
@@ -15,8 +15,8 @@ package jdocs.stream.javadsl.cookbook;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Function;
 import org.apache.pekko.japi.Pair;
+import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.SubSource;

--- a/docs/src/test/java/jdocs/stream/operators/source/Restart.java
+++ b/docs/src/test/java/jdocs/stream/operators/source/Restart.java
@@ -15,7 +15,7 @@ package jdocs.stream.operators.source;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.Cancellable;
-import org.apache.pekko.japi.Creator;
+import org.apache.pekko.japi.function.Creator;
 import org.apache.pekko.stream.KillSwitches;
 import org.apache.pekko.stream.RestartSettings;
 import org.apache.pekko.stream.UniqueKillSwitch;

--- a/docs/src/test/java/jdocs/testkit/ParentChildTest.java
+++ b/docs/src/test/java/jdocs/testkit/ParentChildTest.java
@@ -14,7 +14,7 @@
 package jdocs.testkit;
 
 import org.apache.pekko.actor.*;
-import org.apache.pekko.japi.Creator;
+import org.apache.pekko.japi.function.Creator;
 import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.testkit.PekkoJUnitActorSystemResource;
 import org.apache.pekko.testkit.TestProbe;

--- a/docs/src/test/java/jdocs/testkit/ParentChildTest.java
+++ b/docs/src/test/java/jdocs/testkit/ParentChildTest.java
@@ -15,7 +15,7 @@ package jdocs.testkit;
 
 import org.apache.pekko.actor.*;
 import org.apache.pekko.japi.Creator;
-import org.apache.pekko.japi.Function;
+import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.testkit.PekkoJUnitActorSystemResource;
 import org.apache.pekko.testkit.TestProbe;
 import org.apache.pekko.testkit.javadsl.TestKit;

--- a/persistence/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
+++ b/persistence/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Migrate functions in japi.* to to japi.function.*
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActor.persist")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActor.persistAll")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActor.persistAsync")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActor.persistAllAsync")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActor.deferAsync")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActor.defer")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActorWithAtLeastOnceDelivery.deliver")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActorWithTimers.persist")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActorWithTimers.persistAll")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActorWithTimers.persistAsync")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActorWithTimers.persistAllAsync")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActorWithTimers.deferAsync")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActorWithTimers.defer")
+
+

--- a/persistence/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
+++ b/persistence/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Migrate functions in japi.* to to japi.function.*
+# Migrate functions in japi.* to japi.function.*
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActor.persist")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActor.persistAll")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.AbstractPersistentActor.persistAsync")

--- a/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala
@@ -448,7 +448,7 @@ abstract class AbstractPersistentActorWithAtLeastOnceDelivery
    * This method will throw [[AtLeastOnceDelivery.MaxUnconfirmedMessagesExceededException]]
    * if [[#numberOfUnconfirmed]] is greater than or equal to [[#maxUnconfirmedMessages]].
    */
-  def deliver(destination: ActorPath, deliveryIdToMessage: pekko.japi.Function[java.lang.Long, Object]): Unit =
+  def deliver(destination: ActorPath, deliveryIdToMessage: pekko.japi.function.Function[java.lang.Long, Object]): Unit =
     internalDeliver(destination)(id => deliveryIdToMessage.apply(id))
 
   /**
@@ -471,6 +471,6 @@ abstract class AbstractPersistentActorWithAtLeastOnceDelivery
    * This method will throw [[AtLeastOnceDelivery.MaxUnconfirmedMessagesExceededException]]
    * if [[#numberOfUnconfirmed]] is greater than or equal to [[#maxUnconfirmedMessages]].
    */
-  def deliver(destination: ActorSelection, deliveryIdToMessage: pekko.japi.Function[java.lang.Long, Object]): Unit =
+  def deliver(destination: ActorSelection, deliveryIdToMessage: pekko.japi.function.Function[java.lang.Long, Object]): Unit =
     internalDeliver(destination)(id => deliveryIdToMessage.apply(id))
 }

--- a/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala
@@ -471,6 +471,7 @@ abstract class AbstractPersistentActorWithAtLeastOnceDelivery
    * This method will throw [[AtLeastOnceDelivery.MaxUnconfirmedMessagesExceededException]]
    * if [[#numberOfUnconfirmed]] is greater than or equal to [[#maxUnconfirmedMessages]].
    */
-  def deliver(destination: ActorSelection, deliveryIdToMessage: pekko.japi.function.Function[java.lang.Long, Object]): Unit =
+  def deliver(destination: ActorSelection, deliveryIdToMessage: pekko.japi.function.Function[java.lang.Long, Object])
+      : Unit =
     internalDeliver(destination)(id => deliveryIdToMessage.apply(id))
 }

--- a/persistence/src/main/scala/org/apache/pekko/persistence/PersistentActor.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/PersistentActor.scala
@@ -23,7 +23,7 @@ import com.typesafe.config.Config
 import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.InternalApi
-import pekko.japi.Procedure
+import pekko.japi.function.Procedure
 import pekko.japi.Util
 
 abstract class RecoveryCompleted

--- a/persistence/src/test/scala/org/apache/pekko/persistence/TimerPersistentActorSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/TimerPersistentActorSpec.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.ConfigFactory
 
 import org.apache.pekko
 import pekko.actor._
-import pekko.japi.Procedure
+import pekko.japi.function.Procedure
 import pekko.testkit.{ EventFilter, ImplicitSender }
 import pekko.testkit.TestEvent.Mute
 

--- a/stream/src/main/java/org/apache/pekko/stream/javadsl/JavaFlowSupport.java
+++ b/stream/src/main/java/org/apache/pekko/stream/javadsl/JavaFlowSupport.java
@@ -15,7 +15,7 @@ package org.apache.pekko.stream.javadsl;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.japi.Pair;
-import org.apache.pekko.japi.Creator;
+import org.apache.pekko.japi.function.Creator;
 import org.apache.pekko.stream.impl.JavaFlowAndRsConverters;
 
 /**
@@ -92,7 +92,7 @@ public final class JavaFlowSupport {
      * Creates a Flow from a {@link java.util.concurrent.Flow.Processor>> and returns a materialized value.
      */
     public static <I, O, M> org.apache.pekko.stream.javadsl.Flow<I, O, M> fromProcessorMat(
-        org.apache.pekko.japi.Creator<
+        org.apache.pekko.japi.function.Creator<
                 org.apache.pekko.japi.Pair<java.util.concurrent.Flow.Processor<I, O>, M>>
             processorFactory)
         throws Exception {

--- a/stream/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
+++ b/stream/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Migrate functions in japi.* to to japi.function.*
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.stream.javadsl.JavaFlowSupport#Flow.fromProcessor")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.stream.javadsl.JavaFlowSupport#Flow.fromProcessorMat")

--- a/stream/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
+++ b/stream/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Migrate functions in japi.* to to japi.function.*
+# Migrate functions in japi.* to japi.function.*
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.stream.javadsl.JavaFlowSupport#Flow.fromProcessor")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.stream.javadsl.JavaFlowSupport#Flow.fromProcessorMat")


### PR DESCRIPTION
Motivation:
refs: https://github.com/apache/pekko/issues/267

Make use of `pekko.japi.function`