### PR TITLE
don't test SessionRenegotiationFirstOne on java 24

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/DeprecatedTlsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/DeprecatedTlsSpec.scala
@@ -357,6 +357,19 @@ class DeprecatedTlsSpec extends StreamSpec(DeprecatedTlsSpec.configOverrides) wi
       def output = ByteString("TLS_ECDHE_RSA_WITH_AES_128_CBC_SHAhello")
     }
 
+    val renegotiationScenarios = if (JavaVersion.majorVersion <= 21)
+      Seq(
+        SessionRenegotiationBySender,
+        SessionRenegotiationByReceiver,
+        SessionRenegotiationFirstOne,
+        SessionRenegotiationFirstTwo)
+    else
+      // skip SessionRenegotiationFirstOne as it uses a weak cipher suite and the test will fail
+      Seq(
+        SessionRenegotiationBySender,
+        SessionRenegotiationByReceiver,
+        SessionRenegotiationFirstTwo)
+
     val scenarios =
       Seq(
         SingleBytes,
@@ -369,11 +382,7 @@ class DeprecatedTlsSpec extends StreamSpec(DeprecatedTlsSpec.configOverrides) wi
         CancellingRHS,
         CancellingRHSIgnoresBoth,
         LHSIgnoresBoth,
-        BothSidesIgnoreBoth,
-        SessionRenegotiationBySender,
-        SessionRenegotiationByReceiver,
-        SessionRenegotiationFirstOne,
-        SessionRenegotiationFirstTwo)
+        BothSidesIgnoreBoth) ++ renegotiationScenarios
 
     for {
       commPattern <- communicationPatterns


### PR DESCRIPTION
* Part of #2000 but there are many other broken tests still
* SessionRenegotiationFirstTwo is still tested and that uses a stronger cipher suite
* SessionRenegotiationFirstOne uses a weak cipher suite, TLS_RSA_WITH_AES_128_CBC_SHA, that no longer seems to work with Java 24

```
javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
[info]   at java.base/sun.security.ssl.HandshakeContext.<init>(HandshakeContext.java:162)
[info]   at java.base/sun.security.ssl.ClientHandshakeContext.<init>(ClientHandshakeContext.java:103)
``` 