### PR TITLE
add deprecated annotations to FunctionalInterfaces that are being removed in pekko 2.0.0

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -32,6 +32,7 @@ import pekko.util.Collections.EmptyImmutableSeq
  * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Function]].
  */
 @FunctionalInterface
+@deprecated("Will be removed in favour of pekko.japi.function.Function in Pekko 2.0.0", "Pekko 1.2.0")
 trait Function[T, R] {
   @throws(classOf[Exception])
   def apply(param: T): R
@@ -43,6 +44,7 @@ trait Function[T, R] {
  * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Function2]].
  */
 @FunctionalInterface
+@deprecated("Will be removed in favour of pekko.japi.function.Function2 in Pekko 2.0.0", "Pekko 1.2.0")
 trait Function2[T1, T2, R] {
   @throws(classOf[Exception])
   def apply(arg1: T1, arg2: T2): R
@@ -54,6 +56,7 @@ trait Function2[T1, T2, R] {
  * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Procedure]].
  */
 @FunctionalInterface
+@deprecated("Will be removed in favour of pekko.japi.function.Procedure in Pekko 2.0.0", "Pekko 1.2.0")
 trait Procedure[T] {
   @throws(classOf[Exception])
   def apply(param: T): Unit
@@ -65,6 +68,7 @@ trait Procedure[T] {
  * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Effect]].
  */
 @FunctionalInterface
+@deprecated("Will be removed in favour of pekko.japi.function.Effect in Pekko 2.0.0", "Pekko 1.2.0")
 trait Effect {
   @throws(classOf[Exception])
   def apply(): Unit
@@ -76,6 +80,7 @@ trait Effect {
  * This class is kept for compatibility, but for future API's please prefer [[java.util.function.Predicate]].
  */
 @FunctionalInterface
+@deprecated("Will be removed in favour of pekko.japi.function.Predicate in Pekko 2.0.0", "Pekko 1.2.0")
 trait Predicate[T] {
   def test(param: T): Boolean
 }
@@ -102,6 +107,7 @@ object Pair {
 @nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 @FunctionalInterface
+@deprecated("Will be removed in favour of pekko.japi.function.Creator in Pekko 2.0.0", "Pekko 1.2.0")
 trait Creator[T] extends Serializable {
 
   /**


### PR DESCRIPTION
* these are being removed in main branch - #2001 
* so this is targeted only at 1.2.x branch to warn users