### PR TITLE
use better byte buffer cleaner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -317,6 +317,11 @@ Copyright 2015 Ben Manes. All Rights Reserved.
 
 ---------------
 
+pekko-actor contains code in `org.apache.pekko.io.ByteBufferCleaner` which was based on code
+from Apache commons-io which was developed under the Apache 2.0 license.
+
+---------------
+
 pekko-cluster contains VectorClock.scala which is derived from code written
 by Coda Hale <https://github.com/codahale/vlock>.
 He has agreed to allow us to use this code under an Apache 2.0 license

--- a/actor-tests/src/test/scala/org/apache/pekko/io/ByteBufferCleanerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/ByteBufferCleanerSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.io
+
+import java.nio.ByteBuffer
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ByteBufferCleanerSpec extends AnyWordSpec with Matchers {
+
+  "ByteBufferCleaner" should {
+    "be able to clean direct byte buffers" in {
+      val buffer = ByteBuffer.allocateDirect(1024)
+      ByteBufferCleaner.isSupported shouldBe true
+      ByteBufferCleaner.clean(buffer) // This should not throw an exception
+    }
+  }
+}

--- a/actor-tests/src/test/scala/org/apache/pekko/io/ByteBufferCleanerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/ByteBufferCleanerSpec.scala
@@ -26,7 +26,7 @@ class ByteBufferCleanerSpec extends AnyWordSpec with Matchers {
 
   "ByteBufferCleaner" should {
     "be able to clean direct byte buffers" in {
-      val buffer = ByteBuffer.allocateDirect(1024)
+      val buffer = ByteBuffer.allocateDirect(1)
       ByteBufferCleaner.isSupported shouldBe true
       ByteBufferCleaner.clean(buffer) // This should not throw an exception
     }

--- a/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
+++ b/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
@@ -51,7 +51,7 @@ final class ByteBufferCleaner {
     private final Method cleanerMethod;
     private final Method cleanMethod;
 
-    private Java8Cleaner() throws ReflectiveOperationException, SecurityException {
+    private Java8Cleaner() throws ReflectiveOperationException {
       cleanMethod = Class.forName("sun.misc.Cleaner").getMethod("clean");
       cleanerMethod = Class.forName("sun.nio.ch.DirectBuffer").getMethod("cleaner");
     }
@@ -69,7 +69,7 @@ final class ByteBufferCleaner {
 
     private final MethodHandle invokeCleaner;
 
-    private Java9Cleaner() throws ReflectiveOperationException, SecurityException {
+    private Java9Cleaner() throws ReflectiveOperationException {
       final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
       final Field field = unsafeClass.getDeclaredField("theUnsafe");
       field.setAccessible(true);

--- a/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
+++ b/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.pekko.io;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+/**
+ * Cleans a direct {@link ByteBuffer}. Without manual intervention, direct ByteBuffers will be cleaned eventually upon
+ * garbage collection. However, this should not be relied upon since it may not occur in a timely fashion -
+ * especially since off heap ByeBuffers don't put pressure on the garbage collector.
+ * <p>
+ * <strong>Warning:</strong> Do not attempt to use a direct {@link ByteBuffer} that has been cleaned or bad things will happen.
+ * Don't use this class unless you can ensure that the cleaned buffer will not be accessed anymore.
+ * </p>
+ * <p>
+ * See <a href=https://bugs.openjdk.java.net/browse/JDK-4724038>JDK-4724038</a>
+ * </p>
+ */
+final class ByteBufferCleaner {
+
+    // copied from https://github.com/apache/commons-io/blob/441115a4b5cd63ae808dd4c40fc238cb52c8048f/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+
+    private interface Cleaner {
+        void clean(ByteBuffer buffer) throws ReflectiveOperationException;
+    }
+
+    private static final class Java8Cleaner implements Cleaner {
+
+        private final Method cleanerMethod;
+        private final Method cleanMethod;
+
+        private Java8Cleaner() throws ReflectiveOperationException, SecurityException {
+            cleanMethod = Class.forName("sun.misc.Cleaner").getMethod("clean");
+            cleanerMethod = Class.forName("sun.nio.ch.DirectBuffer").getMethod("cleaner");
+        }
+
+        @Override
+        public void clean(final ByteBuffer buffer) throws ReflectiveOperationException {
+            final Object cleaner = cleanerMethod.invoke(buffer);
+            if (cleaner != null) {
+                cleanMethod.invoke(cleaner);
+            }
+        }
+    }
+
+    private static final class Java9Cleaner implements Cleaner {
+
+        private final Object theUnsafe;
+        private final Method invokeCleaner;
+
+        private Java9Cleaner() throws ReflectiveOperationException, SecurityException {
+            final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+            final Field field = unsafeClass.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            theUnsafe = field.get(null);
+            invokeCleaner = unsafeClass.getMethod("invokeCleaner", ByteBuffer.class);
+        }
+
+        @Override
+        public void clean(final ByteBuffer buffer) throws ReflectiveOperationException {
+            invokeCleaner.invoke(theUnsafe, buffer);
+        }
+    }
+
+    private static final Cleaner INSTANCE = getCleaner();
+
+    /**
+     * Releases memory held by the given {@link ByteBuffer}.
+     *
+     * @param buffer to release.
+     * @throws IllegalStateException on internal failure.
+     */
+    static void clean(final ByteBuffer buffer) {
+        try {
+            INSTANCE.clean(buffer);
+        } catch (final Exception e) {
+            throw new IllegalStateException("Failed to clean direct buffer.", e);
+        }
+    }
+
+    private static Cleaner getCleaner() {
+        try {
+            return new Java8Cleaner();
+        } catch (final Exception e) {
+            try {
+                return new Java9Cleaner();
+            } catch (final Exception e1) {
+                throw new IllegalStateException("Failed to initialize a Cleaner.", e);
+            }
+        }
+    }
+
+    /**
+     * Tests if were able to load a suitable cleaner for the current JVM. Attempting to call
+     * {@code ByteBufferCleaner#clean(ByteBuffer)} when this method returns false will result in an exception.
+     *
+     * @return {@code true} if cleaning is supported, {@code false} otherwise.
+     */
+    static boolean isSupported() {
+        return INSTANCE != null;
+    }
+}

--- a/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
+++ b/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
@@ -39,7 +39,7 @@ import static java.lang.invoke.MethodType.methodType;
  */
 final class ByteBufferCleaner {
 
-  // copied from
+  // adapted from
   // https://github.com/apache/commons-io/blob/441115a4b5cd63ae808dd4c40fc238cb52c8048f/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
 
   private interface Cleaner {
@@ -78,13 +78,12 @@ final class ByteBufferCleaner {
       MethodHandle invokeCleaner =
           lookup.findVirtual(
               unsafeClass, "invokeCleaner", methodType(void.class, ByteBuffer.class));
-      invokeCleaner = invokeCleaner.bindTo(theUnsafe);
-      this.invokeCleaner = invokeCleaner;
+      this.invokeCleaner = invokeCleaner.bindTo(theUnsafe);
     }
 
     @Override
     public void clean(final ByteBuffer buffer) throws Throwable {
-      invokeCleaner.invoke(buffer);
+      invokeCleaner.invokeExact(buffer);
     }
   }
 

--- a/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
+++ b/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
@@ -1,12 +1,12 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
+ * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * the License. You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.pekko.io;
 
 import java.lang.reflect.Field;

--- a/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
+++ b/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 /**
  * Cleans a direct {@link ByteBuffer}. Without manual intervention, direct ByteBuffers will be
  * cleaned eventually upon garbage collection. However, this should not be relied upon since it may
- * not occur in a timely fashion - especially since off heap ByeBuffers don't put pressure on the
+ * not occur in a timely fashion - especially since off heap ByteBuffers don't put pressure on the
  * garbage collector.
  *
  * <p><strong>Warning:</strong> Do not attempt to use a direct {@link ByteBuffer} that has been

--- a/actor/src/main/scala/org/apache/pekko/io/DirectByteBufferPool.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/DirectByteBufferPool.scala
@@ -87,6 +87,7 @@ private[pekko] class DirectByteBufferPool(defaultBufferSize: Int, maxPoolEntries
 
 /** INTERNAL API */
 private[pekko] object DirectByteBufferPool {
+
   /**
    * DirectByteBuffers are garbage collected by using a phantom reference and a
    * reference queue. Every once a while, the JVM checks the reference queue and

--- a/actor/src/main/scala/org/apache/pekko/io/DirectByteBufferPool.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/DirectByteBufferPool.scala
@@ -98,7 +98,7 @@ private[pekko] object DirectByteBufferPool {
    */
   def tryCleanDirectByteBuffer(byteBuffer: ByteBuffer): Unit = {
     try {
-      if (ByteBufferCleaner.isSupported)
+      if (byteBuffer.isDirect() && ByteBufferCleaner.isSupported)
         ByteBufferCleaner.clean(byteBuffer)
     } catch {
       case NonFatal(_) => /* ok, best effort attempt to cleanup failed */

--- a/actor/src/main/scala/org/apache/pekko/io/DirectByteBufferPool.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/DirectByteBufferPool.scala
@@ -87,25 +87,6 @@ private[pekko] class DirectByteBufferPool(defaultBufferSize: Int, maxPoolEntries
 
 /** INTERNAL API */
 private[pekko] object DirectByteBufferPool {
-  private val CleanDirectBuffer: ByteBuffer => Unit =
-    try {
-      val cleanerMethod = Class.forName("java.nio.DirectByteBuffer").getMethod("cleaner")
-      cleanerMethod.setAccessible(true)
-
-      val cleanMethod = Class.forName("sun.misc.Cleaner").getMethod("clean")
-      cleanMethod.setAccessible(true)
-
-      { (bb: ByteBuffer) =>
-        try if (bb.isDirect) {
-            val cleaner = cleanerMethod.invoke(bb)
-            cleanMethod.invoke(cleaner)
-          }
-        catch {
-          case NonFatal(_) => /* ok, best effort attempt to cleanup failed */
-        }
-      }
-    } catch { case NonFatal(_) => _ => () /* reflection failed, use no-op fallback */ }
-
   /**
    * DirectByteBuffers are garbage collected by using a phantom reference and a
    * reference queue. Every once a while, the JVM checks the reference queue and
@@ -113,8 +94,13 @@ private[pekko] object DirectByteBufferPool {
    * immediately after discarding all references to a DirectByteBuffer, it's
    * easy to OutOfMemoryError yourself using DirectByteBuffers. This function
    * explicitly calls the Cleaner method of a DirectByteBuffer.
-   *
-   * Utilizes reflection to avoid dependency to `sun.misc.Cleaner`.
    */
-  def tryCleanDirectByteBuffer(byteBuffer: ByteBuffer): Unit = CleanDirectBuffer(byteBuffer)
+  def tryCleanDirectByteBuffer(byteBuffer: ByteBuffer): Unit = {
+    try {
+      if (ByteBufferCleaner.isSupported)
+        ByteBufferCleaner.clean(byteBuffer)
+    } catch {
+      case NonFatal(_) => /* ok, best effort attempt to cleanup failed */
+    }
+  }
 }


### PR DESCRIPTION
* see #2019 
* the existing cleaner code will not work in Java 9+
* this new code copied from commons-io will mean that the cleaner works in all Java versions
* the support it needs in sun.misc.Unsafe is deprecated in Java 23 but still exists and should work
* worst case scenario is that Java 23+ users who don't allow sun.misc.Unsafe to work will not get the Cleaner to proactively clean the byte buffers and will need to rely on the Garbage Collector
* I would like to backport this to Pekko 1.2.0