### PR TITLE
make deprecated function package private

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/actor/RepointableActorRef.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/RepointableActorRef.scala
@@ -156,7 +156,8 @@ private[pekko] class RepointableActorRef(
     case _                => true
   }
 
-  @deprecated("Use context.watch(actor) and receive Terminated(actor)", "Akka 2.2") def isTerminated: Boolean =
+  @deprecated("Use context.watch(actor) and receive Terminated(actor)", "Akka 2.2")
+  private[pekko] def isTerminated: Boolean =
     underlying.isTerminated
 
   def provider: ActorRefProvider = system.provider


### PR DESCRIPTION
hard to remove outright because it overrides a function on a trait that this class extends