### PR TITLE
chore: Update the readme for Java 17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ Depending on which version (or sometimes module) you want to work on, you should
 
 * `main` – active development branch of Pekko
 * `1.0.x` – maintenance branch of Pekko 1.0
+* `1.1.x` – maintenance branch of Pekko 1.1
+* `1.2.x` – maintenance branch of Pekko 1.2
 
 ### Tags
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,13 @@ The CI build is Linux based (Ubuntu) and most Pekko developers use Macs or Linux
 
 To use IntelliJ IDEA, you need to configure your project to use JDK 8. For a visual guide, refer to this [Q&A](https://github.com/apache/pekko/discussions/1847#discussioncomment-13166066).
 
-- File > Project Structure > Project Settings > Project > Set your JDK to version 8
-- Settings > ... > Scala Compiler Server > Set your JDK to version 8 
-- Settings > ... > sbt > Set your JRE to version 8
+- File > Project Structure > Project Settings > Project > Set your JDK to version 17
+- Settings > ... > Scala Compiler Server > Set your JDK to version 17 
+- Settings > ... > sbt > Set your JRE to version 17
 
 ### Prerequisites
-- Make sure you have installed a Java Development Kit (JDK) version 11 or later.
+- Make sure you have installed a Java Development Kit (JDK) version 17 or later.
 - Make sure you have [sbt](https://www.scala-sbt.org/) installed and using this JDK.
-- Make sure you also have Java 8 installed (JDK or JRE).
 - [Graphviz](https://graphviz.gitlab.io/download/) is needed for the scaladoc generation build task, which is part of the release.
 
 ### Running the Build


### PR DESCRIPTION
It's Java 17 now on main branch