### PR TITLE
Pin sbt-assembly version to 2.2

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,8 @@
 updates.pin = [
   # Scala 3.3 is the latest LTS version
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
+  # sbt-assembly 2.3 causes build issues (https://github.com/apache/pekko/pull/1744)
+  { groupId = "com.eed3si9n", artifactId = "sbt-assembly", version = "2.2." }
 ]
 
 updates.ignore = [
@@ -13,7 +15,6 @@ updates.ignore = [
   { groupId = "com.fasterxml.jackson.datatype" }
   { groupId = "com.fasterxml.jackson.jaxrs" }
   # other ignored updates
-  { groupId = "com.typesafe", artifactId = "ssl-config-core" }
   { groupId = "com.lightbend.sbt", artifactId = "sbt-java-formatter" }
 ]
 


### PR DESCRIPTION
* see #1744 
* also sslconfig: we use the latest version so need to ignore updates