### PR TITLE
chore: Remove the deprecated overloaded aggregateWithBoundary  method

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -4305,54 +4305,18 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @param harvest     this is invoked before emit within the current stage/operator
    * @param emitOnTimer decide whether the current aggregated elements can be emitted, the custom function is invoked on every interval
    */
-  @deprecated("Use the overloaded one which accepts an Optional instead.", since = "1.2.0")
-  def aggregateWithBoundary[Agg, Emit](allocate: function.Creator[Agg],
-      aggregate: function.Function2[Agg, Out, Pair[Agg, Boolean]],
-      harvest: function.Function[Agg, Emit],
-      emitOnTimer: Pair[function.Predicate[Agg], java.time.Duration])
-      : javadsl.Flow[In, Emit, Mat] = {
-    asScala
-      .aggregateWithBoundary(() => allocate.create())(
-        aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
-        harvest = agg => harvest.apply(agg),
-        emitOnTimer = Option(emitOnTimer).map {
-          case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
-        })
-      .asJava
-  }
-
-  /**
-   * Aggregate input elements into an arbitrary data structure that can be completed and emitted downstream
-   * when custom condition is met which can be triggered by aggregate or timer.
-   * It can be thought of a more general [[groupedWeightedWithin]].
-   *
-   * '''Emits when''' the aggregation function decides the aggregate is complete or the timer function returns true
-   *
-   * '''Backpressures when''' downstream backpressures and the aggregate is complete
-   *
-   * '''Completes when''' upstream completes and the last aggregate has been emitted downstream
-   *
-   * '''Cancels when''' downstream cancels
-   *
-   * @param allocate    allocate the initial data structure for aggregated elements
-   * @param aggregate   update the aggregated elements, return true if ready to emit after update.
-   * @param harvest     this is invoked before emit within the current stage/operator
-   * @param emitOnTimer decide whether the current aggregated elements can be emitted, the custom function is invoked on every interval
-   */
   def aggregateWithBoundary[Agg, Emit](allocate: function.Creator[Agg],
       aggregate: function.Function2[Agg, Out, Pair[Agg, Boolean]],
       harvest: function.Function[Agg, Emit],
       emitOnTimer: Optional[Pair[function.Predicate[Agg], java.time.Duration]])
       : javadsl.Flow[In, Emit, Mat] = {
     import org.apache.pekko.util.OptionConverters._
-    asScala
-      .aggregateWithBoundary(() => allocate.create())(
-        aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
-        harvest = agg => harvest.apply(agg),
-        emitOnTimer = emitOnTimer.toScala.map {
-          case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
-        })
-      .asJava
+    new Flow(delegate.aggregateWithBoundary(() => allocate.create())(
+      aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
+      harvest = agg => harvest.apply(agg),
+      emitOnTimer = emitOnTimer.toScala.map {
+        case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
+      }))
   }
 
   override def getAttributes: Attributes = delegate.getAttributes

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -4747,52 +4747,17 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @param harvest     this is invoked before emit within the current stage/operator
    * @param emitOnTimer decide whether the current aggregated elements can be emitted, the custom function is invoked on every interval
    */
-  @deprecated("Use the overloaded one which accepts an Optional instead.", since = "1.2.0")
-  def aggregateWithBoundary[Agg, Emit](allocate: function.Creator[Agg],
-      aggregate: function.Function2[Agg, Out, Pair[Agg, Boolean]],
-      harvest: function.Function[Agg, Emit],
-      emitOnTimer: Pair[function.Predicate[Agg], java.time.Duration]): javadsl.Source[Emit, Mat] = {
-    asScala
-      .aggregateWithBoundary(() => allocate.create())(
-        aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
-        harvest = agg => harvest.apply(agg),
-        emitOnTimer = Option(emitOnTimer).map {
-          case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
-        })
-      .asJava
-  }
-
-  /**
-   * Aggregate input elements into an arbitrary data structure that can be completed and emitted downstream
-   * when custom condition is met which can be triggered by aggregate or timer.
-   * It can be thought of a more general [[groupedWeightedWithin]].
-   *
-   * '''Emits when''' the aggregation function decides the aggregate is complete or the timer function returns true
-   *
-   * '''Backpressures when''' downstream backpressures and the aggregate is complete
-   *
-   * '''Completes when''' upstream completes and the last aggregate has been emitted downstream
-   *
-   * '''Cancels when''' downstream cancels
-   *
-   * @param allocate    allocate the initial data structure for aggregated elements
-   * @param aggregate   update the aggregated elements, return true if ready to emit after update.
-   * @param harvest     this is invoked before emit within the current stage/operator
-   * @param emitOnTimer decide whether the current aggregated elements can be emitted, the custom function is invoked on every interval
-   */
   def aggregateWithBoundary[Agg, Emit](allocate: function.Creator[Agg],
       aggregate: function.Function2[Agg, Out, Pair[Agg, Boolean]],
       harvest: function.Function[Agg, Emit],
       emitOnTimer: Optional[Pair[function.Predicate[Agg], java.time.Duration]]): javadsl.Source[Emit, Mat] = {
     import org.apache.pekko.util.OptionConverters._
-    asScala
-      .aggregateWithBoundary(() => allocate.create())(
-        aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
-        harvest = agg => harvest.apply(agg),
-        emitOnTimer = emitOnTimer.toScala.map {
-          case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
-        })
-      .asJava
+    new Source(delegate.aggregateWithBoundary(() => allocate.create())(
+      aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
+      harvest = agg => harvest.apply(agg),
+      emitOnTimer = emitOnTimer.toScala.map {
+        case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
+      }))
   }
 
   override def getAttributes: Attributes = delegate.getAttributes

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -2788,52 +2788,18 @@ final class SubFlow[In, Out, Mat](
    * @param harvest     this is invoked before emit within the current stage/operator
    * @param emitOnTimer decide whether the current aggregated elements can be emitted, the custom function is invoked on every interval
    */
-  @deprecated("Use the overloaded one which accepts an Optional instead.", since = "1.2.0")
-  def aggregateWithBoundary[Agg, Emit](allocate: function.Creator[Agg],
-      aggregate: function.Function2[Agg, Out, Pair[Agg, Boolean]],
-      harvest: function.Function[Agg, Emit],
-      emitOnTimer: Pair[function.Predicate[Agg], java.time.Duration])
-      : javadsl.SubFlow[In, Emit, Mat] = {
-    new SubFlow(
-      asScala.aggregateWithBoundary(() => allocate.create())(
-        aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
-        harvest = agg => harvest.apply(agg),
-        emitOnTimer = Option(emitOnTimer).map {
-          case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
-        }))
-  }
-
-  /**
-   * Aggregate input elements into an arbitrary data structure that can be completed and emitted downstream
-   * when custom condition is met which can be triggered by aggregate or timer.
-   * It can be thought of a more general [[groupedWeightedWithin]].
-   *
-   * '''Emits when''' the aggregation function decides the aggregate is complete or the timer function returns true
-   *
-   * '''Backpressures when''' downstream backpressures and the aggregate is complete
-   *
-   * '''Completes when''' upstream completes and the last aggregate has been emitted downstream
-   *
-   * '''Cancels when''' downstream cancels
-   *
-   * @param allocate    allocate the initial data structure for aggregated elements
-   * @param aggregate   update the aggregated elements, return true if ready to emit after update.
-   * @param harvest     this is invoked before emit within the current stage/operator
-   * @param emitOnTimer decide whether the current aggregated elements can be emitted, the custom function is invoked on every interval
-   */
   def aggregateWithBoundary[Agg, Emit](allocate: function.Creator[Agg],
       aggregate: function.Function2[Agg, Out, Pair[Agg, Boolean]],
       harvest: function.Function[Agg, Emit],
       emitOnTimer: Optional[Pair[function.Predicate[Agg], java.time.Duration]])
       : javadsl.SubFlow[In, Emit, Mat] = {
     import org.apache.pekko.util.OptionConverters._
-    new SubFlow(
-      asScala.aggregateWithBoundary(() => allocate.create())(
-        aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
-        harvest = agg => harvest.apply(agg),
-        emitOnTimer = emitOnTimer.toScala.map {
-          case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
-        }))
+    new SubFlow(delegate.aggregateWithBoundary(() => allocate.create())(
+      aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
+      harvest = agg => harvest.apply(agg),
+      emitOnTimer = emitOnTimer.toScala.map {
+        case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
+      }))
   }
 
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -2762,51 +2762,17 @@ final class SubSource[Out, Mat](
    * @param harvest     this is invoked before emit within the current stage/operator
    * @param emitOnTimer decide whether the current aggregated elements can be emitted, the custom function is invoked on every interval
    */
-  @deprecated("Use the overloaded one which accepts an Optional instead.", since = "1.2.0")
-  def aggregateWithBoundary[Agg, Emit](allocate: function.Creator[Agg],
-      aggregate: function.Function2[Agg, Out, Pair[Agg, Boolean]],
-      harvest: function.Function[Agg, Emit],
-      emitOnTimer: Pair[function.Predicate[Agg], java.time.Duration])
-      : javadsl.SubSource[Emit, Mat] = {
-    new SubSource(
-      asScala.aggregateWithBoundary(() => allocate.create())(
-        aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
-        harvest = agg => harvest.apply(agg),
-        emitOnTimer = Option(emitOnTimer).map {
-          case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
-        }))
-  }
-
-  /**
-   * Aggregate input elements into an arbitrary data structure that can be completed and emitted downstream
-   * when custom condition is met which can be triggered by aggregate or timer.
-   * It can be thought of a more general [[groupedWeightedWithin]].
-   *
-   * '''Emits when''' the aggregation function decides the aggregate is complete or the timer function returns true
-   *
-   * '''Backpressures when''' downstream backpressures and the aggregate is complete
-   *
-   * '''Completes when''' upstream completes and the last aggregate has been emitted downstream
-   *
-   * '''Cancels when''' downstream cancels
-   *
-   * @param allocate    allocate the initial data structure for aggregated elements
-   * @param aggregate   update the aggregated elements, return true if ready to emit after update.
-   * @param harvest     this is invoked before emit within the current stage/operator
-   * @param emitOnTimer decide whether the current aggregated elements can be emitted, the custom function is invoked on every interval
-   */
   def aggregateWithBoundary[Agg, Emit](allocate: function.Creator[Agg],
       aggregate: function.Function2[Agg, Out, Pair[Agg, Boolean]],
       harvest: function.Function[Agg, Emit],
       emitOnTimer: Optional[Pair[function.Predicate[Agg], java.time.Duration]])
       : javadsl.SubSource[Emit, Mat] = {
     import org.apache.pekko.util.OptionConverters._
-    new SubSource(
-      asScala.aggregateWithBoundary(() => allocate.create())(
-        aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
-        harvest = agg => harvest.apply(agg),
-        emitOnTimer = emitOnTimer.toScala.map {
-          case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
-        }))
+    new SubSource(delegate.aggregateWithBoundary(() => allocate.create())(
+      aggregate = (agg, out) => aggregate.apply(agg, out).toScala,
+      harvest = agg => harvest.apply(agg),
+      emitOnTimer = emitOnTimer.toScala.map {
+        case Pair(predicate, duration) => (agg => predicate.test(agg), duration.asScala)
+      }))
   }
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -3972,7 +3972,6 @@ trait FlowOps[+Out, +Mat] {
    * @param harvest     this is invoked before emit within the current stage/operator
    * @param emitOnTimer decide whether the current aggregated elements can be emitted, the custom function is invoked on every interval
    */
-  @ApiMayChange
   def aggregateWithBoundary[Agg, Emit](allocate: () => Agg)(
       aggregate: (Agg, Out) => (Agg, Boolean),
       harvest: Agg => Emit,


### PR DESCRIPTION
Motivation：
Remove the deprecated one for javadsl.