### PR TITLE
chore: Remove ReentrantGuard

### DIFF
--- a/actor/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
+++ b/actor/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
@@ -145,3 +145,8 @@ ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.japi.pf.Un
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.japi.pf.UnitPFBuilder.matchEquals")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.japi.pf.UnitPFBuilder.matchAny")
 ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.japi.JAPI")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.event.LoggingBus.org$apache$pekko$event$LoggingBus$_setter_$org$apache$pekko$event$LoggingBus$$guard_=")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.event.LoggingBus.org$apache$pekko$event$LoggingBus$$guard")
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.util.ReentrantGuard")
+
+

--- a/actor/src/main/scala/org/apache/pekko/util/LockUtil.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/LockUtil.scala
@@ -14,16 +14,6 @@
 package org.apache.pekko.util
 
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.locks.ReentrantLock
-
-final class ReentrantGuard extends ReentrantLock {
-
-  final def withGuard[T](body: => T): T = {
-    lock()
-    try body
-    finally unlock()
-  }
-}
 
 /**
  * An atomic switch that can be either on or off


### PR DESCRIPTION
It creates a closure every time, making it use less, to write high-performance code.

If you think this can be removed, we can start the deprecation in 1.2.x