### PR TITLE
chore: Make use of japi.funtion.* in Patterns

### DIFF
--- a/actor/src/main/java/org/apache/pekko/japi/function/IntFunction.java
+++ b/actor/src/main/java/org/apache/pekko/japi/function/IntFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.japi.function;
+
+/**
+ * Int function that can throw exceptions.
+ *
+ * @since 2.0.0
+ */
+@FunctionalInterface
+public interface IntFunction<R> extends java.io.Serializable {
+  long serialVersionUID = 1L;
+
+  /**
+   * Applies this function to the given argument.
+   *
+   * @param value the function argument
+   * @return the function result
+   * @throws Throwable if an error occurs
+   */
+  R apply(int value) throws Throwable;
+}

--- a/actor/src/main/java/org/apache/pekko/japi/function/package-info.java
+++ b/actor/src/main/java/org/apache/pekko/japi/function/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Java API for functional programming in Pekko. */
+package org.apache.pekko.japi.function;

--- a/actor/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
+++ b/actor/src/main/mima-filters/2.0.x.backwards.excludes/javaapi-functions.excludes
@@ -35,4 +35,5 @@ ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.japi.Predicate")
 ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.japi.Procedure")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.pattern.Patterns.askWithReplyTo")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.serialization.SerializationSetup.create")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.pattern.Patterns.retry")
 

--- a/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.pattern
 
 import java.util.Optional
 import java.util.concurrent.{ Callable, CompletionStage, TimeUnit }
-import java.util.function.BiPredicate
 
 import scala.concurrent.ExecutionContext
 
@@ -518,7 +517,7 @@ object Patterns {
    */
   def retry[T](
       attempt: Callable[CompletionStage[T]],
-      shouldRetry: BiPredicate[T, Throwable],
+      shouldRetry: japi.function.Predicate2[T, Throwable],
       attempts: Int,
       ec: ExecutionContext): CompletionStage[T] = {
     require(attempt != null, "Parameter attempt should not be null.")
@@ -585,7 +584,7 @@ object Patterns {
    */
   def retry[T](
       attempt: Callable[CompletionStage[T]],
-      shouldRetry: BiPredicate[T, Throwable],
+      shouldRetry: japi.function.Predicate2[T, Throwable],
       attempts: Int,
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
@@ -662,7 +661,7 @@ object Patterns {
    */
   def retry[T](
       attempt: Callable[CompletionStage[T]],
-      shouldRetry: BiPredicate[T, Throwable],
+      shouldRetry: japi.function.Predicate2[T, Throwable],
       attempts: Int,
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
@@ -738,7 +737,7 @@ object Patterns {
    */
   def retry[T](
       attempt: Callable[CompletionStage[T]],
-      shouldRetry: BiPredicate[T, Throwable],
+      shouldRetry: japi.function.Predicate2[T, Throwable],
       attempts: Int,
       delay: java.time.Duration,
       system: ClassicActorSystemProvider): CompletionStage[T] =
@@ -787,7 +786,7 @@ object Patterns {
    */
   def retry[T](
       attempt: Callable[CompletionStage[T]],
-      shouldRetry: BiPredicate[T, Throwable],
+      shouldRetry: japi.function.Predicate2[T, Throwable],
       attempts: Int,
       delay: java.time.Duration,
       scheduler: Scheduler,
@@ -813,7 +812,7 @@ object Patterns {
   def retry[T](
       attempt: Callable[CompletionStage[T]],
       attempts: Int,
-      delayFunction: java.util.function.IntFunction[Optional[java.time.Duration]],
+      delayFunction: japi.function.IntFunction[Optional[java.time.Duration]],
       scheduler: Scheduler,
       context: ExecutionContext): CompletionStage[T] = {
     import pekko.util.OptionConverters._
@@ -852,9 +851,9 @@ object Patterns {
    */
   def retry[T](
       attempt: Callable[CompletionStage[T]],
-      shouldRetry: BiPredicate[T, Throwable],
+      shouldRetry: japi.function.Predicate2[T, Throwable],
       attempts: Int,
-      delayFunction: java.util.function.IntFunction[Optional[java.time.Duration]],
+      delayFunction: japi.function.IntFunction[Optional[java.time.Duration]],
       scheduler: Scheduler,
       context: ExecutionContext): CompletionStage[T] = {
     import pekko.util.OptionConverters._

--- a/docs/src/test/java/jdocs/future/FutureDocTest.java
+++ b/docs/src/test/java/jdocs/future/FutureDocTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -97,4 +98,22 @@ public class FutureDocTest extends AbstractJavaTest {
 
     retriedFuture.toCompletableFuture().get(2, SECONDS);
   }
+
+    @Test
+    public void useRetryWithPredicateWithIntFunction() throws Exception {
+        // #retry
+        Callable<CompletionStage<String>> attempt = () -> CompletableFuture.completedFuture("test");
+
+        CompletionStage<String> retriedFuture =
+            Patterns.retry(
+                attempt,
+                (notUsed, e) -> e != null,
+                3,
+                current -> Optional.of(java.time.Duration.ofMillis(200)),
+                system.classicSystem().scheduler(),
+                system.executionContext());
+        // #retry
+
+        retriedFuture.toCompletableFuture().get(2, SECONDS);
+    }
 }


### PR DESCRIPTION
Motivation:
Make use of japi.funtion.* in Patterns
refs: https://github.com/apache/pekko/issues/2197