### PR TITLE
use Scala Option Converter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -531,7 +531,7 @@ Scala has proven the most viable way to do it, as long as you keep the following
 
 1. Use `org.apache.pekko.util.FutureConverters` to translate `Future`s to `CompletionStage`s (or vice versa).
 
-1. Use `org.apache.pekko.util.OptionConverters` to translate `Option`s to Java `Optional`s (or vice versa).
+1. Use `scala.jdk.javaapi.OptionConverters` to translate `Option`s to Java `Optional`s (or vice versa).
 
 1. Use `org.apache.pekko.util.FunctionConverters` to translate Scala Functions to Java Functions (or vice versa).
  

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/CapturedLogEvent.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/CapturedLogEvent.scala
@@ -15,12 +15,13 @@ package org.apache.pekko.actor.testkit.typed
 
 import java.util.Optional
 
+import scala.jdk.javaapi.OptionConverters._
+
 import org.slf4j.Marker
 import org.slf4j.event.Level
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.util.OptionConverters._
 import pekko.util.OptionVal
 
 /**

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/CapturedLogEvent.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/CapturedLogEvent.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.actor.testkit.typed
 
 import java.util.Optional
 
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.slf4j.Marker
 import org.slf4j.event.Level

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/LoggingEvent.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/LoggingEvent.scala
@@ -15,12 +15,13 @@ package org.apache.pekko.actor.testkit.typed
 
 import java.util.Optional
 
+import scala.jdk.javaapi.OptionConverters._
+
 import org.slf4j.Marker
 import org.slf4j.event.Level
 
 import org.apache.pekko
 import pekko.util.ccompat.JavaConverters._
-import pekko.util.OptionConverters._
 
 object LoggingEvent {
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/LoggingEvent.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/LoggingEvent.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.actor.testkit.typed
 
 import java.util.Optional
 
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.slf4j.Marker
 import org.slf4j.event.Level

--- a/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
@@ -17,11 +17,9 @@
 
 package org.apache.pekko.util
 
-import org.apache.pekko
-import pekko.util.OptionConverters._
-
 import java.util._
 import scala.annotation.nowarn
+import scala.jdk.javaapi.OptionConverters._
 
 /**
  * These tests are here to ensure that methods from [[org.apache.pekko.util.FutureConverters]], [[org.apache.pekko.util.OptionConverters]]

--- a/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/Scala212CompatTest.scala
@@ -19,7 +19,7 @@ package org.apache.pekko.util
 
 import java.util._
 import scala.annotation.nowarn
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 /**
  * These tests are here to ensure that methods from [[org.apache.pekko.util.FutureConverters]], [[org.apache.pekko.util.OptionConverters]]

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/ProducerController.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/ProducerController.scala
@@ -17,6 +17,7 @@ import java.time.{ Duration => JavaDuration }
 import java.util.Optional
 
 import scala.concurrent.duration._
+import scala.jdk.javaapi.OptionConverters._
 import scala.reflect.ClassTag
 
 import com.typesafe.config.Config
@@ -33,7 +34,6 @@ import pekko.annotation.InternalApi
 import pekko.util.Helpers.toRootLowerCase
 import pekko.util.Helpers.Requiring
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 
 /**
  * Point-to-point reliable delivery between a single producer actor sending messages and a single consumer

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/ProducerController.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/ProducerController.scala
@@ -17,7 +17,7 @@ import java.time.{ Duration => JavaDuration }
 import java.util.Optional
 
 import scala.concurrent.duration._
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 
 import com.typesafe.config.Config

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/WorkPullingProducerController.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/WorkPullingProducerController.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.actor.typed.delivery
 import java.util.Optional
 
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.javaapi.OptionConverters._
 import scala.reflect.ClassTag
 
 import com.typesafe.config.Config
@@ -30,7 +31,6 @@ import pekko.actor.typed.receptionist.ServiceKey
 import pekko.actor.typed.scaladsl.Behaviors
 import pekko.annotation.ApiMayChange
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 
 /**
  * Work pulling is a pattern where several worker actors pull tasks in their own pace from

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/WorkPullingProducerController.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/WorkPullingProducerController.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.actor.typed.delivery
 import java.util.Optional
 
 import scala.concurrent.duration.FiniteDuration
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 
 import com.typesafe.config.Config

--- a/actor/src/main/scala/org/apache/pekko/actor/AbstractActor.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/AbstractActor.scala
@@ -283,7 +283,7 @@ abstract class AbstractActor extends Actor {
   @throws(classOf[Exception])
   @nowarn("msg=deprecated")
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     preRestart(reason, message.toJava)
   }
 
@@ -295,7 +295,7 @@ abstract class AbstractActor extends Actor {
    */
   @throws(classOf[Exception])
   def preRestart(reason: Throwable, message: Optional[Any]): Unit = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     super.preRestart(reason, message.toScala)
   }
 

--- a/actor/src/main/scala/org/apache/pekko/actor/AbstractActor.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/AbstractActor.scala
@@ -283,7 +283,7 @@ abstract class AbstractActor extends Actor {
   @throws(classOf[Exception])
   @nowarn("msg=deprecated")
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     preRestart(reason, message.toJava)
   }
 
@@ -295,7 +295,7 @@ abstract class AbstractActor extends Actor {
    */
   @throws(classOf[Exception])
   def preRestart(reason: Throwable, message: Optional[Any]): Unit = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     super.preRestart(reason, message.toScala)
   }
 

--- a/actor/src/main/scala/org/apache/pekko/actor/Actor.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Actor.scala
@@ -100,7 +100,7 @@ final case class ActorIdentity(correlationId: Any, ref: Option[ActorRef]) {
    * not defined if no actor matched the request.
    */
   def getActorRef: Optional[ActorRef] = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     ref.toJava
   }
 }

--- a/actor/src/main/scala/org/apache/pekko/actor/Actor.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Actor.scala
@@ -100,7 +100,7 @@ final case class ActorIdentity(correlationId: Any, ref: Option[ActorRef]) {
    * not defined if no actor matched the request.
    */
   def getActorRef: Optional[ActorRef] = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     ref.toJava
   }
 }

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
@@ -23,7 +23,7 @@ import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future, Promise }
 import scala.concurrent.blocking
 import scala.concurrent.duration.Duration
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.{ ControlThrowable, NonFatal }
 

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
@@ -23,6 +23,7 @@ import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future, Promise }
 import scala.concurrent.blocking
 import scala.concurrent.duration.Duration
+import scala.jdk.javaapi.OptionConverters._
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.{ ControlThrowable, NonFatal }
 
@@ -41,7 +42,6 @@ import pekko.japi.Util.immutableSeq
 import pekko.serialization.SerializationExtension
 import pekko.util._
 import pekko.util.FutureConverters._
-import pekko.util.OptionConverters._
 import pekko.util.Helpers.toRootLowerCase
 import pekko.util.ccompat.JavaConverters._
 

--- a/actor/src/main/scala/org/apache/pekko/actor/Address.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Address.scala
@@ -20,7 +20,7 @@ import java.util.Optional
 
 import scala.annotation.tailrec
 import scala.collection.immutable
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.annotation.InternalApi

--- a/actor/src/main/scala/org/apache/pekko/actor/Address.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Address.scala
@@ -12,6 +12,7 @@
  */
 
 package org.apache.pekko.actor
+
 import java.net.MalformedURLException
 import java.net.URI
 import java.net.URISyntaxException
@@ -19,10 +20,10 @@ import java.util.Optional
 
 import scala.annotation.tailrec
 import scala.collection.immutable
+import scala.jdk.javaapi.OptionConverters._
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.util.OptionConverters._
 
 /**
  * The address specifies the physical location under which an Actor can be

--- a/actor/src/main/scala/org/apache/pekko/actor/CoordinatedShutdown.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/CoordinatedShutdown.scala
@@ -23,7 +23,7 @@ import scala.annotation.tailrec
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.util.Try
 import scala.util.control.NonFatal
 

--- a/actor/src/main/scala/org/apache/pekko/actor/CoordinatedShutdown.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/CoordinatedShutdown.scala
@@ -23,6 +23,7 @@ import scala.annotation.tailrec
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.javaapi.OptionConverters._
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -35,7 +36,6 @@ import pekko.annotation.InternalApi
 import pekko.dispatch.ExecutionContexts
 import pekko.event.Logging
 import pekko.pattern.after
-import pekko.util.OptionConverters._
 import pekko.util.OptionVal
 import pekko.util.FutureConverters._
 

--- a/actor/src/main/scala/org/apache/pekko/actor/setup/ActorSystemSetup.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/setup/ActorSystemSetup.scala
@@ -17,7 +17,7 @@ import java.util.Optional
 
 import scala.annotation.varargs
 import scala.reflect.ClassTag
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.annotation.InternalApi

--- a/actor/src/main/scala/org/apache/pekko/actor/setup/ActorSystemSetup.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/setup/ActorSystemSetup.scala
@@ -17,10 +17,10 @@ import java.util.Optional
 
 import scala.annotation.varargs
 import scala.reflect.ClassTag
+import scala.jdk.javaapi.OptionConverters._
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.util.OptionConverters._
 
 /**
  * Marker supertype for a setup part that can be put inside [[pekko.actor.setup.ActorSystemSetup]], if a specific concrete setup

--- a/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
@@ -815,7 +815,7 @@ object Patterns {
       delayFunction: japi.function.IntFunction[Optional[java.time.Duration]],
       scheduler: Scheduler,
       context: ExecutionContext): CompletionStage[T] = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     require(attempt != null, "Parameter attempt should not be null.")
     scalaRetry(
       () => attempt.call().asScala,
@@ -856,7 +856,7 @@ object Patterns {
       delayFunction: japi.function.IntFunction[Optional[java.time.Duration]],
       scheduler: Scheduler,
       context: ExecutionContext): CompletionStage[T] = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     require(attempt != null, "Parameter attempt should not be null.")
     scalaRetry(
       () => attempt.call().asScala,

--- a/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/Patterns.scala
@@ -815,7 +815,7 @@ object Patterns {
       delayFunction: japi.function.IntFunction[Optional[java.time.Duration]],
       scheduler: Scheduler,
       context: ExecutionContext): CompletionStage[T] = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     require(attempt != null, "Parameter attempt should not be null.")
     scalaRetry(
       () => attempt.call().asScala,
@@ -856,7 +856,7 @@ object Patterns {
       delayFunction: japi.function.IntFunction[Optional[java.time.Duration]],
       scheduler: Scheduler,
       context: ExecutionContext): CompletionStage[T] = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     require(attempt != null, "Parameter attempt should not be null.")
     scalaRetry(
       () => attempt.call().asScala,

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.cluster.sharding.typed.delivery
 import java.util.Optional
 
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.javaapi.OptionConverters._
 import scala.reflect.ClassTag
 
 import com.typesafe.config.Config
@@ -33,7 +34,6 @@ import pekko.annotation.ApiMayChange
 import pekko.cluster.sharding.typed.ShardingEnvelope
 import pekko.cluster.sharding.typed.delivery.internal.ShardingProducerControllerImpl
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 
 /**
  * Reliable delivery between a producer actor sending messages to sharded consumer

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/ShardingProducerController.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.cluster.sharding.typed.delivery
 import java.util.Optional
 
 import scala.concurrent.duration.FiniteDuration
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 
 import com.typesafe.config.Config

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -147,7 +147,7 @@ import pekko.util.JavaDurationConverters._
 
   // javadsl impl
   override def init[M, E](entity: javadsl.Entity[M, E]): ActorRef[E] = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     init(
       new scaladsl.Entity(
         createBehavior = (ctx: EntityContext[M]) =>

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -147,7 +147,7 @@ import pekko.util.JavaDurationConverters._
 
   // javadsl impl
   override def init[M, E](entity: javadsl.Entity[M, E]): ActorRef[E] = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     init(
       new scaladsl.Entity(
         createBehavior = (ctx: EntityContext[M]) =>

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -17,7 +17,7 @@ import java.util.function.IntFunction
 import java.util.Optional
 
 import scala.reflect.ClassTag
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.actor.typed.ActorRef

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -17,6 +17,8 @@ import java.util.function.IntFunction
 import java.util.Optional
 
 import scala.reflect.ClassTag
+import scala.jdk.javaapi.OptionConverters._
+
 import org.apache.pekko
 import pekko.actor.typed.ActorRef
 import pekko.actor.typed.ActorSystem
@@ -40,7 +42,6 @@ import pekko.cluster.sharding.typed.scaladsl.StartEntity
 import pekko.cluster.typed.Cluster
 import pekko.cluster.typed.SelfUp
 import pekko.cluster.typed.Subscribe
-import pekko.util.OptionConverters._
 import pekko.util.PrettyDuration
 
 /**

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -19,7 +19,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.annotation.nowarn
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.actor.typed.ActorRef

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -19,6 +19,8 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.annotation.nowarn
+import scala.jdk.javaapi.OptionConverters._
+
 import org.apache.pekko
 import pekko.actor.typed.ActorRef
 import pekko.actor.typed.ActorSystem
@@ -32,7 +34,6 @@ import pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import pekko.cluster.sharding.typed.internal.EntityTypeKeyImpl
 import pekko.japi.function.{ Function => JFunction }
 import pekko.pattern.StatusReply
-import pekko.util.OptionConverters._
 
 @FunctionalInterface
 trait EntityFactory[M] {

--- a/coordination/src/main/scala/org/apache/pekko/coordination/lease/internal/LeaseAdapter.scala
+++ b/coordination/src/main/scala/org/apache/pekko/coordination/lease/internal/LeaseAdapter.scala
@@ -19,6 +19,7 @@ import java.util.function.Consumer
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.jdk.javaapi.OptionConverters._
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
@@ -26,7 +27,6 @@ import pekko.coordination.lease.LeaseSettings
 import pekko.coordination.lease.javadsl.{ Lease => JavaLease }
 import pekko.coordination.lease.scaladsl.{ Lease => ScalaLease }
 import pekko.util.FutureConverters._
-import pekko.util.OptionConverters._
 
 /**
  * INTERNAL API

--- a/coordination/src/main/scala/org/apache/pekko/coordination/lease/internal/LeaseAdapter.scala
+++ b/coordination/src/main/scala/org/apache/pekko/coordination/lease/internal/LeaseAdapter.scala
@@ -19,7 +19,7 @@ import java.util.function.Consumer
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.annotation.InternalApi

--- a/discovery/src/main/scala/org/apache/pekko/discovery/ServiceDiscovery.scala
+++ b/discovery/src/main/scala/org/apache/pekko/discovery/ServiceDiscovery.scala
@@ -21,11 +21,11 @@ import java.util.concurrent.TimeUnit
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.javaapi.OptionConverters._
 
 import org.apache.pekko
 import pekko.actor.{ DeadLetterSuppression, NoSerializationVerificationNeeded }
 import pekko.util.HashCode
-import pekko.util.OptionConverters._
 
 object ServiceDiscovery {
 

--- a/discovery/src/main/scala/org/apache/pekko/discovery/ServiceDiscovery.scala
+++ b/discovery/src/main/scala/org/apache/pekko/discovery/ServiceDiscovery.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.actor.{ DeadLetterSuppression, NoSerializationVerificationNeeded }

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/ReplicatedData.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/ReplicatedData.scala
@@ -15,9 +15,10 @@ package org.apache.pekko.cluster.ddata
 
 import java.util.Optional
 
+import scala.jdk.javaapi.OptionConverters._
+
 import org.apache.pekko
 import pekko.cluster.UniqueAddress
-import pekko.util.OptionConverters._
 
 /**
  * Interface for implementing a state based convergent

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/ReplicatedData.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/ReplicatedData.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.cluster.ddata
 
 import java.util.Optional
 
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.cluster.UniqueAddress

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/EventEnvelope.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/EventEnvelope.scala
@@ -64,7 +64,7 @@ final class EventEnvelope(
    * Java API
    */
   def getEventMetaData(): Optional[Any] = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     eventMetadata.toJava
   }
 

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/EventEnvelope.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/EventEnvelope.scala
@@ -64,7 +64,7 @@ final class EventEnvelope(
    * Java API
    */
   def getEventMetaData(): Optional[Any] = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     eventMetadata.toJava
   }
 

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/EventEnvelope.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/EventEnvelope.scala
@@ -93,7 +93,7 @@ final class EventEnvelope[Event](
    * Java API
    */
   def getOptionalEvent(): Optional[Event] = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     eventOption.toJava
   }
 
@@ -101,7 +101,7 @@ final class EventEnvelope[Event](
    * Java API
    */
   def getEventMetaData(): Optional[AnyRef] = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     eventMetadata.map(_.asInstanceOf[AnyRef]).toJava
   }
 

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/EventEnvelope.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/EventEnvelope.scala
@@ -93,7 +93,7 @@ final class EventEnvelope[Event](
    * Java API
    */
   def getOptionalEvent(): Optional[Event] = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     eventOption.toJava
   }
 
@@ -101,7 +101,7 @@ final class EventEnvelope[Event](
    * Java API
    */
   def getEventMetaData(): Optional[AnyRef] = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     eventMetadata.map(_.asInstanceOf[AnyRef]).toJava
   }
 

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
@@ -226,7 +226,7 @@ final class EventSourcedBehaviorTestKit[Command, Event, State](
 
   private val _persistenceTestKit = new PersistenceTestKit(delegate.persistenceTestKit)
   private val _snapshotTestKit = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     delegate.snapshotTestKit.map(new SnapshotTestKit(_)).toJava
   }
 

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
@@ -226,7 +226,7 @@ final class EventSourcedBehaviorTestKit[Command, Event, State](
 
   private val _persistenceTestKit = new PersistenceTestKit(delegate.persistenceTestKit)
   private val _snapshotTestKit = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     delegate.snapshotTestKit.map(new SnapshotTestKit(_)).toJava
   }
 

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.persistence.testkit.state.javadsl
 import java.util.Optional
 import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.japi.Pair

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
@@ -15,6 +15,9 @@ package org.apache.pekko.persistence.testkit.state.javadsl
 
 import java.util.Optional
 import java.util.concurrent.{ CompletableFuture, CompletionStage }
+
+import scala.jdk.javaapi.OptionConverters._
+
 import org.apache.pekko
 import pekko.japi.Pair
 import pekko.{ Done, NotUsed }
@@ -27,7 +30,6 @@ import pekko.persistence.state.javadsl.GetObjectResult
 import pekko.persistence.testkit.state.scaladsl.{ PersistenceTestKitDurableStateStore => SStore }
 import pekko.stream.javadsl.Source
 import pekko.util.FutureConverters._
-import pekko.util.OptionConverters._
 
 object PersistenceTestKitDurableStateStore {
   val Identifier = pekko.persistence.testkit.state.scaladsl.PersistenceTestKitDurableStateStore.Identifier

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -387,7 +387,7 @@ private[pekko] final case class PublishedEventImpl(
     replicatedMetaData: Option[ReplicatedPublishedEventMetaData])
     extends PublishedEvent
     with InternalProtocol {
-  import scala.jdk.javaapi.OptionConverters._
+  import scala.jdk.OptionConverters._
 
   def tags: Set[String] = payload match {
     case t: Tagged => t.tags

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -387,7 +387,7 @@ private[pekko] final case class PublishedEventImpl(
     replicatedMetaData: Option[ReplicatedPublishedEventMetaData])
     extends PublishedEvent
     with InternalProtocol {
-  import pekko.util.OptionConverters._
+  import scala.jdk.javaapi.OptionConverters._
 
   def tags: Set[String] = payload match {
     case t: Tagged => t.tags

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.persistence.typed.javadsl
 import java.util.Collections
 import java.util.Optional
 
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import com.typesafe.config.Config
 import org.apache.pekko

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -16,6 +16,8 @@ package org.apache.pekko.persistence.typed.javadsl
 import java.util.Collections
 import java.util.Optional
 
+import scala.jdk.javaapi.OptionConverters._
+
 import com.typesafe.config.Config
 import org.apache.pekko
 import pekko.actor.typed
@@ -27,7 +29,6 @@ import pekko.annotation.InternalApi
 import pekko.persistence.typed._
 import pekko.persistence.typed.EventAdapter
 import pekko.persistence.typed.internal._
-import pekko.util.OptionConverters._
 import pekko.util.unused
 
 abstract class EventSourcedBehavior[Command, Event, State] private[pekko] (

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/PersistentFSMMigration.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/PersistentFSMMigration.scala
@@ -20,7 +20,7 @@ import org.apache.pekko
 import pekko.japi.function.Function3
 import pekko.persistence.typed.SnapshotAdapter
 import pekko.util.JavaDurationConverters._
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 /**
  * Helper functions for migration from PersistentFSM to Persistence Typed

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/PersistentFSMMigration.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/PersistentFSMMigration.scala
@@ -20,7 +20,7 @@ import org.apache.pekko
 import pekko.japi.function.Function3
 import pekko.persistence.typed.SnapshotAdapter
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
+import scala.jdk.javaapi.OptionConverters._
 
 /**
  * Helper functions for migration from PersistentFSM to Persistence Typed

--- a/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/japi/SnapshotStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/japi/SnapshotStore.scala
@@ -30,7 +30,7 @@ abstract class SnapshotStore extends SSnapshotStore with SnapshotStorePlugin {
   override final def loadAsync(
       persistenceId: String,
       criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
-    import pekko.util.OptionConverters._
+    import scala.jdk.javaapi.OptionConverters._
     doLoadAsync(persistenceId, criteria).asScala.map(_.toScala)(ExecutionContexts.parasitic)
   }
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/japi/SnapshotStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/japi/SnapshotStore.scala
@@ -30,7 +30,7 @@ abstract class SnapshotStore extends SSnapshotStore with SnapshotStorePlugin {
   override final def loadAsync(
       persistenceId: String,
       criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
-    import scala.jdk.javaapi.OptionConverters._
+    import scala.jdk.OptionConverters._
     doLoadAsync(persistenceId, criteria).asScala.map(_.toScala)(ExecutionContexts.parasitic)
   }
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/state/javadsl/DurableStateStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/state/javadsl/DurableStateStore.scala
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletionStage
 
 import org.apache.pekko
 import pekko.persistence.state.scaladsl.{ GetObjectResult => SGetObjectResult }
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 /**
  * API for reading durable state objects with payload `A`.

--- a/persistence/src/main/scala/org/apache/pekko/persistence/state/javadsl/DurableStateStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/state/javadsl/DurableStateStore.scala
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletionStage
 
 import org.apache.pekko
 import pekko.persistence.state.scaladsl.{ GetObjectResult => SGetObjectResult }
-import pekko.util.OptionConverters._
+import scala.jdk.javaapi.OptionConverters._
 
 /**
  * API for reading durable state objects with payload `A`.

--- a/persistence/src/main/scala/org/apache/pekko/persistence/state/scaladsl/DurableStateStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/state/scaladsl/DurableStateStore.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.persistence.state.scaladsl
 
 import scala.concurrent.Future
 
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.persistence.state.javadsl.{ GetObjectResult => JGetObjectResult }

--- a/persistence/src/main/scala/org/apache/pekko/persistence/state/scaladsl/DurableStateStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/state/scaladsl/DurableStateStore.scala
@@ -15,9 +15,10 @@ package org.apache.pekko.persistence.state.scaladsl
 
 import scala.concurrent.Future
 
+import scala.jdk.javaapi.OptionConverters._
+
 import org.apache.pekko
 import pekko.persistence.state.javadsl.{ GetObjectResult => JGetObjectResult }
-import pekko.util.OptionConverters._
 
 /**
  * API for reading durable state objects with payload `A`.

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -17,7 +17,9 @@ import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import scala.annotation.nowarn
 import scala.collection.immutable
+import scala.jdk.javaapi.OptionConverters._
 import scala.util.{ Failure, Success }
+
 import com.fasterxml.jackson.annotation.{ JsonAutoDetect, JsonCreator, PropertyAccessor }
 import com.fasterxml.jackson.core.{
   JsonFactory,
@@ -56,7 +58,6 @@ import pekko.actor.setup.Setup
 import pekko.annotation.InternalStableApi
 import pekko.event.{ Logging, LoggingAdapter }
 import pekko.util.unused
-import pekko.util.OptionConverters._
 
 object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvider] with ExtensionIdProvider {
   override def get(system: ActorSystem): JacksonObjectMapperProvider = super.get(system)

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -17,7 +17,7 @@ import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import scala.annotation.nowarn
 import scala.collection.immutable
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.util.{ Failure, Success }
 
 import com.fasterxml.jackson.annotation.{ JsonAutoDetect, JsonCreator, PropertyAccessor }

--- a/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
@@ -19,6 +19,7 @@ import java.util.Optional
 
 import scala.annotation.tailrec
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.javaapi.OptionConverters._
 import scala.reflect.{ classTag, ClassTag }
 import scala.util.control.NonFatal
 
@@ -32,7 +33,6 @@ import pekko.stream.impl.TraversalBuilder
 import pekko.util.{ ByteString, OptionVal }
 import pekko.util.JavaDurationConverters._
 import pekko.util.LineNumbers
-import pekko.util.OptionConverters._
 
 /**
  * Holds attributes which can be used to alter [[pekko.stream.scaladsl.Flow]] / [[pekko.stream.javadsl.Flow]]

--- a/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
@@ -19,7 +19,7 @@ import java.util.Optional
 
 import scala.annotation.tailrec
 import scala.concurrent.duration.FiniteDuration
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.{ classTag, ClassTag }
 import scala.util.control.NonFatal
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletionStage
 import scala.annotation.varargs
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
+import scala.jdk.javaapi.OptionConverters._
 import scala.reflect.ClassTag
 
 import org.apache.pekko
@@ -37,7 +38,6 @@ import pekko.stream.impl.fusing.{ StatefulMapConcat, ZipWithIndexJava }
 import pekko.util.ConstantFun
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 import pekko.util.Timeout
 import pekko.util.unused
 import org.reactivestreams.Processor

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletionStage
 import scala.annotation.varargs
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 
 import org.apache.pekko

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
@@ -17,7 +17,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.annotation.ApiMayChange

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/FlowWithContext.scala
@@ -17,6 +17,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.annotation.unchecked.uncheckedVariance
+import scala.jdk.javaapi.OptionConverters._
 
 import org.apache.pekko
 import pekko.annotation.ApiMayChange
@@ -26,7 +27,6 @@ import pekko.stream._
 import pekko.util.ConstantFun
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 import pekko.util.ccompat.JavaConverters._
 
 object FlowWithContext {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Queue.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Queue.scala
@@ -17,13 +17,13 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
+import scala.jdk.javaapi.OptionConverters._
 
 import org.apache.pekko
 import pekko.Done
 import pekko.dispatch.ExecutionContexts
 import pekko.stream.QueueOfferResult
 import pekko.util.FutureConverters._
-import pekko.util.OptionConverters._
 
 /**
  * This trait allows to have a queue as a data source for some stream.

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Queue.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Queue.scala
@@ -17,7 +17,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.Done

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/RetryFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/RetryFlow.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.stream.javadsl
 
 import java.util.Optional
 
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.annotation.ApiMayChange

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/RetryFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/RetryFlow.scala
@@ -15,12 +15,13 @@ package org.apache.pekko.stream.javadsl
 
 import java.util.Optional
 
+import scala.jdk.javaapi.OptionConverters._
+
 import org.apache.pekko
 import pekko.annotation.ApiMayChange
 import pekko.japi.Pair
 import pekko.stream.scaladsl
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 
 object RetryFlow {
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
@@ -19,6 +19,7 @@ import java.util.stream.Collector
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
+import scala.jdk.javaapi.OptionConverters._
 import scala.util.Try
 
 import org.apache.pekko
@@ -32,7 +33,6 @@ import pekko.stream.impl.LinearTraversalBuilder
 import pekko.stream.scaladsl.SinkToCompletionStage
 import pekko.util.ConstantFun.scalaAnyToUnit
 import pekko.util.FutureConverters._
-import pekko.util.OptionConverters._
 
 import org.reactivestreams.{ Publisher, Subscriber }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
@@ -19,7 +19,7 @@ import java.util.stream.Collector
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.util.Try
 
 import org.apache.pekko

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -21,7 +21,7 @@ import scala.annotation.varargs
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.concurrent.{ Future, Promise }
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 
 import org.apache.pekko

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -21,6 +21,7 @@ import scala.annotation.varargs
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.concurrent.{ Future, Promise }
+import scala.jdk.javaapi.OptionConverters._
 import scala.reflect.ClassTag
 
 import org.apache.pekko
@@ -36,7 +37,6 @@ import pekko.stream.impl.fusing.{ ArraySource, StatefulMapConcat, ZipWithIndexJa
 import pekko.util.{ unused, _ }
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 import pekko.util.ccompat.JavaConverters._
 
 import org.reactivestreams.{ Publisher, Subscriber }

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
@@ -17,7 +17,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.actor.ClassicActorSystemProvider

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
@@ -17,6 +17,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.annotation.unchecked.uncheckedVariance
+import scala.jdk.javaapi.OptionConverters._
 
 import org.apache.pekko
 import pekko.actor.ClassicActorSystemProvider
@@ -28,7 +29,6 @@ import pekko.stream._
 import pekko.util.ConstantFun
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 import pekko.util.ccompat.JavaConverters._
 
 object SourceWithContext {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletionStage
 import scala.annotation.varargs
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 
 import org.apache.pekko

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletionStage
 import scala.annotation.varargs
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
+import scala.jdk.javaapi.OptionConverters._
 import scala.reflect.ClassTag
 
 import org.apache.pekko
@@ -30,7 +31,6 @@ import pekko.stream.impl.fusing.{ StatefulMapConcat, ZipWithIndexJava }
 import pekko.util.ConstantFun
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 import pekko.util.ccompat.JavaConverters._
 
 object SubFlow {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletionStage
 import scala.annotation.varargs
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 
 import org.apache.pekko

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletionStage
 import scala.annotation.varargs
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
+import scala.jdk.javaapi.OptionConverters._
 import scala.reflect.ClassTag
 
 import org.apache.pekko
@@ -30,7 +31,6 @@ import pekko.stream.impl.fusing.{ StatefulMapConcat, ZipWithIndexJava }
 import pekko.util.ConstantFun
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 import pekko.util.ccompat.JavaConverters._
 
 /**

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Tcp.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Tcp.scala
@@ -21,7 +21,7 @@ import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLSession
 
 import scala.concurrent.duration._
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.util.Failure
 import scala.util.Success
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Tcp.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Tcp.scala
@@ -21,6 +21,7 @@ import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLSession
 
 import scala.concurrent.duration._
+import scala.jdk.javaapi.OptionConverters._
 import scala.util.Failure
 import scala.util.Success
 
@@ -41,7 +42,6 @@ import pekko.stream.scaladsl
 import pekko.util.ByteString
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
-import pekko.util.OptionConverters._
 
 object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
 

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Queue.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Queue.scala
@@ -17,6 +17,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
+import scala.jdk.javaapi.OptionConverters._
 
 import org.apache.pekko
 import pekko.Done
@@ -24,7 +25,6 @@ import pekko.annotation.InternalApi
 import pekko.dispatch.ExecutionContexts
 import pekko.stream.QueueOfferResult
 import pekko.util.FutureConverters._
-import pekko.util.OptionConverters._
 
 /**
  * This trait allows to have a queue as a data source for some stream.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Queue.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Queue.scala
@@ -17,7 +17,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
-import scala.jdk.javaapi.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.Done


### PR DESCRIPTION
* still WIP, I need to reorder many of the imports
* the advantage to using the Scala OptionConverter directly is that the Pekko one does not inline the toScala method
* I intend to leave the Pekko OptionConverter in the code at least for now, maybe I can deprecate it