### PR TITLE
feat: Add sneakyThrow for Java

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/japi/ThrowablesTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/japi/ThrowablesTest.java
@@ -29,4 +29,13 @@ public class ThrowablesTest {
     Assert.assertTrue(Throwables.isFatal(new InterruptedException("fatal")));
     Assert.assertTrue(Throwables.isFatal(new LinkageError("fatal")));
   }
+
+  private void doSneakyThrow() {
+    Throwables.sneakyThrow(new Exception("sneaky"));
+  }
+
+  @Test
+  public void testSneakyThrow() {
+    Assert.assertThrows("sneaky", Exception.class, this::doSneakyThrow);
+  }
 }

--- a/actor/src/main/scala/org/apache/pekko/japi/Throwables.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/Throwables.scala
@@ -49,4 +49,15 @@ object Throwables {
    * or false if it is to be considered non-fatal
    */
   def isFatal(throwable: Throwable): Boolean = !isNonFatal(throwable)
+
+  /**
+   * Throws the given `Throwable`, without requiring the caller to declare it in a `throws` clause.
+   * @param t the `Throwable` to throw
+   * @throws T the type of the `Throwable` to throw
+   * @return never returns normally, but has return type `R` to allow usage in expressions
+   * @since 2.0.0
+   */
+  def sneakyThrow[T <: Throwable, R](t: Throwable): R = {
+    throw t.asInstanceOf[T]
+  }
 }


### PR DESCRIPTION
Motivation:
When lambda doesn't support throwing exceptions, but the method we want to use declares that it throws exceptions, we can use this method to support it, similar to lombok's @sneakyThrows.

Usage:

```java

() -> {
 try {
     .....// can throw
   } catch(Throwable e) {
      Throwables.sneakThrow(e)
   }
}
```