### PR TITLE
remove unnecessary scalafix plugin

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -3,7 +3,6 @@ rules = [
   RemoveUnused
   SortImports
   ExplicitResultTypes
-  "github:ohze/scalafix-rules/FinalObject"
   fix.scala213.DottyMigrate
 //  fix.scala213.NullaryOverride
 ]

--- a/project/ScalaFixExtraRulesPlugin.scala
+++ b/project/ScalaFixExtraRulesPlugin.scala
@@ -23,9 +23,6 @@ object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport {
   import scalafix.sbt.ScalafixPlugin.autoImport.scalafixDependencies
   override lazy val projectSettings: Seq[Def.Setting[_]] = super.projectSettings ++ {
     ThisBuild / scalafixDependencies ++= Seq(
-      "com.nequissimus" %% "sort-imports" % "0.6.1",
-      // https://github.com/ohze/scala-rewrites
-      // an extended version of https://github.com/scala/scala-rewrites
-      "com.sandinh" %% "scala-rewrites" % "0.1.10-sd")
+      "com.nequissimus" %% "sort-imports" % "0.6.1")
   }
 }


### PR DESCRIPTION
I tested `sbt sortImports`and the com.sandinh/scala-rewrites plugin makes no difference.
