### PR TITLE
remove unnecessary items from license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -210,18 +210,7 @@ Copyright (c) 2003-2011, LAMP/EPFL
 
 ---------------
 
-pekko-actor contains code from scala-collection-compat in the `org.apache.pekko.util.ccompat` package
-which has released under an Apache 2.0 license.
-- actor/src/main/scala/org/apache/pekko/util/ccompat/package.scala
-
-Scala (https://www.scala-lang.org)
-
-Copyright EPFL and Lightbend, Inc.
-
----------------
-
-pekko-actor contains code from scala-library in the `org.apache.pekko.util.ccompat` package
-and in `org.apache.pekko.util.Helpers.scala` which was released under an Apache 2.0 license.
+pekko-actor contains code from scala-library which was released under an Apache 2.0 license.
 - actor/src/main/scala/org/apache/pekko/util/Helpers.scala
 
 Scala (https://www.scala-lang.org)

--- a/NOTICE
+++ b/NOTICE
@@ -23,18 +23,6 @@ Lightbend, Inc. (https://www.lightbend.com/).
 
 ---------------
 
-pekko-actor contains code from scala-collection-compat which was released under an Apache 2.0 license.
-
-scala-collection-compat
-Copyright (c) 2002-2023 EPFL
-Copyright (c) 2011-2023 Lightbend, Inc.
-
-Scala includes software developed at
-LAMP/EPFL (https://lamp.epfl.ch/) and
-Lightbend, Inc. (https://www.lightbend.com/).
-
----------------
-
 pekko-actor contains code from scala-library which was released under an Apache 2.0 license.
 
 Scala

--- a/legal/pekko-actor-jar-license.txt
+++ b/legal/pekko-actor-jar-license.txt
@@ -210,19 +210,7 @@ Copyright (c) 2003-2011, LAMP/EPFL
 
 ---------------
 
-pekko-actor contains code from scala-collection-compat in the `org.apache.pekko.util.ccompat` package
-which has released under an Apache 2.0 license.
-- actor/src/main/scala/org/apache/pekko/util/ccompat/package.scala
-
-Scala (https://www.scala-lang.org)
-
-Copyright EPFL and Lightbend, Inc.
-
----------------
-
-pekko-actor contains code from scala-library in the `org.apache.pekko.util.ccompat` package
-and in `org.apache.pekko.util.Helpers.scala` which was released under an Apache 2.0 license.
-- actor/src/main/scala-2.12/org/apache/pekko/util/ccompat/package.scala
+pekko-actor contains code from scala-library which was released under an Apache 2.0 license.
 - actor/src/main/scala/org/apache/pekko/util/Helpers.scala
 
 Scala (https://www.scala-lang.org)

--- a/legal/pekko-actor-jar-notice.txt
+++ b/legal/pekko-actor-jar-notice.txt
@@ -23,19 +23,6 @@ Lightbend, Inc. (https://www.lightbend.com/).
 
 ---------------
 
-pekko-actor contains code from scala-collection-compat which has changes made by the Scala-Lang team
-under an Apache 2.0 license.
-
-scala-collection-compat
-Copyright (c) 2002-2023 EPFL
-Copyright (c) 2011-2023 Lightbend, Inc.
-
-Scala includes software developed at
-LAMP/EPFL (https://lamp.epfl.ch/) and
-Lightbend, Inc. (https://www.lightbend.com/).
-
----------------
-
 pekko-actor contains code from scala-library which was released under an Apache 2.0 license.
 
 Scala


### PR DESCRIPTION
* the 3rd party code that we copied from scala-collection-compat has been removed
* likewise the Scala library borrowings only now apply to Helpers.scala