### PR TITLE
refactor compiler options

### DIFF
--- a/project/Jdk9.scala
+++ b/project/Jdk9.scala
@@ -57,14 +57,14 @@ object Jdk9 extends AutoPlugin {
   lazy val compileJdk9Settings = Seq(
     // following the scala-2.12, scala-sbt-1.0, ... convention
     unmanagedSourceDirectories := additionalSourceDirectories.value,
-    scalacOptions := PekkoBuild.DefaultScalacOptions.value ++ Seq("-release", majorVersion.toString),
-    javacOptions := PekkoBuild.DefaultJavacOptions ++ Seq("--release", majorVersion.toString))
+    scalacOptions := PekkoBuild.DefaultScalacOptions.value ++ JdkOptions.targetJdkScalacOptions(scalaVersion.value),
+    javacOptions := PekkoBuild.DefaultJavacOptions ++ Seq("--release", JdkOptions.targetJavaVersion))
 
   lazy val testJdk9Settings = Seq(
     // following the scala-2.12, scala-sbt-1.0, ... convention
     unmanagedSourceDirectories := additionalTestSourceDirectories.value,
-    scalacOptions := PekkoBuild.DefaultScalacOptions.value ++ Seq("-release", majorVersion.toString),
-    javacOptions := PekkoBuild.DefaultJavacOptions ++ Seq("--release", majorVersion.toString),
+    scalacOptions := PekkoBuild.DefaultScalacOptions.value ++ Seq("-release", JdkOptions.targetJavaVersion),
+    javacOptions := PekkoBuild.DefaultJavacOptions ++ Seq("--release", JdkOptions.targetJavaVersion),
     compile := compile.dependsOn(CompileJdk9 / compile).value,
     classpathConfiguration := TestJdk9,
     externalDependencyClasspath := (Test / externalDependencyClasspath).value)

--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -19,11 +19,11 @@ import sbt.librarymanagement.VersionNumber
 
 object JdkOptions extends AutoPlugin {
 
-  lazy val specificationVersion: String = sys.props("java.specification.version")
-
   object JavaVersion {
     val majorVersion: Int = java.lang.Runtime.version().feature()
   }
+
+  val targetJavaVersion = "17"
 
   lazy val versionSpecificJavaOptions =
     // for virtual threads
@@ -35,7 +35,9 @@ object JdkOptions extends AutoPlugin {
     "--add-opens=java.base/java.nio=ALL-UNNAMED" :: Nil
 
   def targetJdkScalacOptions(scalaVersion: String): Seq[String] =
-    Seq(if (scalaVersion.startsWith("3.")) "-Xtarget:17" else "release:17")
+    Seq("-release", JdkOptions.targetJavaVersion) ++ {
+      if (scalaVersion.startsWith("3.")) Seq(s"-Xtarget:${targetJavaVersion}") else Seq.empty
+    }
 
-  val targetJdkJavacOptions = Seq("-source", "17", "-target", "17")
+  val targetJdkJavacOptions = Seq("--release", targetJavaVersion)
 }


### PR DESCRIPTION
* I was experimenting with building with Java 25. Not working at all with Scala 2.13.17 but I can get Scala 3.3.6 to build jars.
* I tidied up the Java version settings to try to help