### PR TITLE
silence compiler warnings new in scala 2.13.17

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ActorSystemSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ActorSystemSpec.scala
@@ -88,6 +88,7 @@ object ActorSystemSpec {
 
   class SlowDispatcher(_config: Config, _prerequisites: DispatcherPrerequisites)
       extends MessageDispatcherConfigurator(_config, _prerequisites) {
+    @nowarn("msg=inferred structural type")
     private val instance = new Dispatcher(
       this,
       this.config.getString("id"),

--- a/actor-tests/src/test/scala/org/apache/pekko/event/LoggingReceiveSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/event/LoggingReceiveSpec.scala
@@ -104,6 +104,7 @@ class LoggingReceiveSpec extends AnyWordSpec with BeforeAndAfterAll {
           case null =>
         }
 
+        @scala.annotation.nowarn("msg=inferred structural type")
         val actor = TestActorRef(new Actor {
           def switch: Actor.Receive = { case "becomenull" => context.become(r, false) }
           def receive =

--- a/actor/src/main/scala-2.13/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala-2.13/org/apache/pekko/util/ByteString.scala
@@ -921,6 +921,7 @@ sealed abstract class ByteString
    *
    * @return this ByteString copied into a byte array
    */
+  @nowarn("msg=easy to mistake")
   protected[ByteString] def toArray: Array[Byte] = toArray[Byte]
 
   final override def toArray[B >: Byte](implicit arg0: ClassTag[B]): Array[B] = {

--- a/actor/src/main/scala/org/apache/pekko/actor/Address.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Address.scala
@@ -76,6 +76,7 @@ final case class Address private[pekko] (protocol: String, system: String, host:
   def hasGlobalScope: Boolean = host.isDefined
 
   // store hashCode
+  @scala.annotation.nowarn("msg=deprecated")
   @transient override lazy val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
 
   /**

--- a/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
@@ -29,10 +29,10 @@
 
 package org.apache.pekko.util
 
+import scala.annotation.nowarn
 import scala.util.hashing.MurmurHash3
 
 import org.apache.pekko.annotation.InternalApi
-import scala.annotation.nowarn
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
@@ -32,6 +32,7 @@ package org.apache.pekko.util
 import scala.util.hashing.MurmurHash3
 
 import org.apache.pekko.annotation.InternalApi
+import scala.annotation.nowarn
 
 /**
  * INTERNAL API
@@ -74,6 +75,7 @@ private[pekko] object FrequencySketch {
     implicit val StringHasher: StringHasher = new StringHasher(DefaultSeed)
 
     final class StringHasher(seed: Int) extends Hasher[String] {
+      @nowarn("msg=deprecated")
       override def hash(value: String): Int = MurmurHash3.stringHash(value, seed)
     }
   }

--- a/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
@@ -628,6 +628,7 @@ private[persistence] trait Eventsourced
    * @param replayMax maximum number of messages to replay.
    * @param timeout recovery event timeout
    */
+  @nowarn("msg=inferred structural type")
   private def recoveryStarted(replayMax: Long, timeout: FiniteDuration) = new State {
 
     val timeoutCancellable = {
@@ -745,6 +746,7 @@ private[persistence] trait Eventsourced
    *
    * All incoming messages are stashed.
    */
+  @nowarn("msg=inferred structural type")
   private def recovering(recoveryBehavior: Receive, timeout: FiniteDuration) =
     new State {
 

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/Control.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/Control.scala
@@ -203,6 +203,7 @@ private[remote] class OutboundControlJunction(
   val out: Outlet[OutboundEnvelope] = Outlet("OutboundControlJunction.out")
   override val shape: FlowShape[OutboundEnvelope, OutboundEnvelope] = FlowShape(in, out)
 
+  @scala.annotation.nowarn("msg=inferred structural type")
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
 
     val logic = new GraphStageLogic(shape)

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/QueueSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/QueueSource.scala
@@ -50,6 +50,7 @@ import pekko.stream.stage._
   val out = Outlet[T]("queueSource.out")
   override val shape: SourceShape[T] = SourceShape.of(out)
 
+  @scala.annotation.nowarn("msg=inferred structural type")
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
     val completion = Promise[Done]()
     val name = inheritedAttributes.nameOrDefault(getClass.toString)

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/SetupStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/SetupStage.scala
@@ -45,6 +45,7 @@ import pekko.stream.stage.OutHandler
     (createStageLogic(matPromise), matPromise.future)
   }
 
+  @scala.annotation.nowarn("msg=inferred structural type")
   private def createStageLogic(matPromise: Promise[M]) = new GraphStageLogic(shape) {
     import SetupStage._
 
@@ -88,6 +89,7 @@ import pekko.stream.stage.OutHandler
     (createStageLogic(matPromise), matPromise.future)
   }
 
+  @scala.annotation.nowarn("msg=inferred structural type")
   private def createStageLogic(matPromise: Promise[M]) = new GraphStageLogic(shape) {
     import SetupStage._
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
@@ -255,6 +255,7 @@ import org.reactivestreams.Subscriber
 
   override protected def initialAttributes: Attributes = DefaultAttributes.seqSink
 
+  @scala.annotation.nowarn("msg=inferred structural type")
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
     val p: Promise[That] = Promise()
     val logic = new GraphStageLogic(shape) with InHandler {
@@ -312,6 +313,7 @@ import org.reactivestreams.Subscriber
 
   override def toString: String = "QueueSink"
 
+  @scala.annotation.nowarn("msg=inferred structural type")
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
     val stageLogic = new GraphStageLogic(shape) with InHandler with SinkQueueWithCancel[T] {
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/TcpStages.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/TcpStages.scala
@@ -64,6 +64,7 @@ import pekko.util.ByteString
     throw new UnsupportedOperationException("Not used")
 
   // TODO: Timeout on bind
+  @nowarn("msg=inferred structural type")
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes, eagerMaterialzer: Materializer) = {
     val bindingPromise = Promise[ServerBinding]()
 

--- a/testkit/src/test/scala/org/apache/pekko/testkit/metrics/MetricsKit.scala
+++ b/testkit/src/test/scala/org/apache/pekko/testkit/metrics/MetricsKit.scala
@@ -192,6 +192,7 @@ private[pekko] object MetricsKit {
     override def matches(name: String, metric: Metric) = classOf[KnownOpsInTimespanTimer].isInstance(metric)
   }
 
+  @scala.annotation.nowarn("msg=inferred structural type")
   val GcMetricsFilter = new MetricFilter {
     val keyPattern = """.*\.gc\..*""".r.pattern
 


### PR DESCRIPTION
* see #2254
* tested with latest pre-release nightly for scala 2.13.17
* these may not be the only issues