### PR TITLE
protect 1.3.x branch (#2264)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -72,6 +72,30 @@ github:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
         required_approving_review_count: 1
+    1.2.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
+    1.3.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
 
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
cherry pick 91554a46db54de1c76bf03c9cb0379fa05a8f45b

something that we can tag as v1.3..0-M0 to ensure that snapshots end up with 1.3 versions