### PR TITLE
add containsSlice/indexOfSlice tests

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -996,6 +996,34 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       verify(byteString.copyToArray(_, 2, 3))(0, 0, 1)
       verify(byteString.copyToArray(_, 3, 3))(0, 0, 0)
     }
+    "containsSlice" in {
+      val slice0 = ByteString1.fromString("xyz")
+      val slice1 = ByteString1.fromString("xyzabc")
+      val notSlice = ByteString1.fromString("12345")
+      val byteStringLong = ByteString1.fromString("abcdefghijklmnopqrstuvwxyz")
+      val byteStrings = ByteStrings(byteStringLong, byteStringLong)
+      byteStringLong.containsSlice(slice0) should ===(true)
+      byteStringLong.containsSlice(slice1) should ===(false)
+      byteStringLong.containsSlice(notSlice) should ===(false)
+
+      byteStrings.containsSlice(slice0) should ===(true)
+      byteStrings.containsSlice(slice1) should ===(true)
+      byteStrings.containsSlice(notSlice) should ===(false)
+    }
+    "indexOfSlice" in {
+      val slice0 = ByteString1.fromString("xyz")
+      val slice1 = ByteString1.fromString("xyzabc")
+      val notSlice = ByteString1.fromString("12345")
+      val byteStringLong = ByteString1.fromString("abcdefghijklmnopqrstuvwxyz")
+      val byteStrings = ByteStrings(byteStringLong, byteStringLong)
+      byteStringLong.indexOfSlice(slice0) should ===(23)
+      byteStringLong.indexOfSlice(slice1) should ===(-1)
+      byteStringLong.indexOfSlice(notSlice) should ===(-1)
+
+      byteStrings.indexOfSlice(slice0) should ===(23)
+      byteStrings.indexOfSlice(slice1) should ===(23)
+      byteStrings.indexOfSlice(notSlice) should ===(-1)
+    }
   }
 
   "A ByteString" must {


### PR DESCRIPTION
ByteString inherits these from Scala Seq.
They are used in pekko-http.