### PR TITLE
JavaDSL TestKit - add shutdownActorSystem that takes Java Duration params

### DIFF
--- a/testkit/src/main/scala/org/apache/pekko/testkit/javadsl/TestKit.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/javadsl/TestKit.scala
@@ -583,6 +583,42 @@ object TestKit {
     shutdownActorSystem(actorSystem, 10.seconds, verifySystemShutdown)
   }
 
+
+  /**
+   * Java API: Shut down an actor system and wait for termination.
+   * On failure debug output will be logged about the remaining actors in the system.
+   *
+   * The `duration` is dilated by the timefactor. This overloaded
+   * method accepts `java.time.Duration`.
+   * 
+   * If verifySystemShutdown is true, then an exception will be thrown on failure.
+   * 
+   * @since 1.3.0
+   */
+  def shutdownActorSystem(
+      actorSystem: ActorSystem,
+      duration: java.time.Duration): Unit = {
+    import scala.jdk.DurationConverters._
+    pekko.testkit.TestKit.shutdownActorSystem(actorSystem, duration.toScala)
+  }
+
+  /**
+   * Java API: Shut down an actor system and wait for termination.
+   * On failure debug output will be logged about the remaining actors in the system.
+   *
+   * The `duration` is dilated by the timefactor. This overloaded
+   * method accepts `java.time.Duration`.
+   * 
+   * @since 1.3.0
+   */
+  def shutdownActorSystem(
+      actorSystem: ActorSystem,
+      duration: java.time.Duration,
+      verifySystemShutdown: Boolean): Unit = {
+    import scala.jdk.DurationConverters._
+    pekko.testkit.TestKit.shutdownActorSystem(actorSystem, duration.toScala, verifySystemShutdown)
+  }
+
 }
 
 /**

--- a/testkit/src/main/scala/org/apache/pekko/testkit/javadsl/TestKit.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/javadsl/TestKit.scala
@@ -583,16 +583,15 @@ object TestKit {
     shutdownActorSystem(actorSystem, 10.seconds, verifySystemShutdown)
   }
 
-
   /**
-   * Java API: Shut down an actor system and wait for termination.
+   * Shut down an actor system and wait for termination.
    * On failure debug output will be logged about the remaining actors in the system.
    *
    * The `duration` is dilated by the timefactor. This overloaded
    * method accepts `java.time.Duration`.
-   * 
+   *
    * If verifySystemShutdown is true, then an exception will be thrown on failure.
-   * 
+   *
    * @since 1.3.0
    */
   def shutdownActorSystem(
@@ -603,12 +602,12 @@ object TestKit {
   }
 
   /**
-   * Java API: Shut down an actor system and wait for termination.
+   * Shut down an actor system and wait for termination.
    * On failure debug output will be logged about the remaining actors in the system.
    *
    * The `duration` is dilated by the timefactor. This overloaded
    * method accepts `java.time.Duration`.
-   * 
+   *
    * @since 1.3.0
    */
   def shutdownActorSystem(

--- a/testkit/src/test/java/org/apache/pekko/testkit/javadsl/TestKitApiTest.java
+++ b/testkit/src/test/java/org/apache/pekko/testkit/javadsl/TestKitApiTest.java
@@ -176,5 +176,7 @@ public class TestKitApiTest {
     testKit.unwatch(actorRef);
 
     testKit.setAutoPilot(autoPilot);
+
+    TestKit.shutdownActorSystem(testKit.getSystem(), Duration.ofSeconds(10));
   }
 }


### PR DESCRIPTION
* fixes #2226
* Aim is to backfit to 1.3.0.
* The shutdownActorSystem code has long accepted Scala Durations - the duration is optional. So it hasn't caused too many problems so I, personally, am not too pushed about removing the old methods that allow Scala Duration params. I don't see why we can't support both.