### PR TITLE
try to fix doc build issue

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/SourceSink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/SourceSink.scala
@@ -47,11 +47,11 @@ import pekko.stream.stage.{
   override def createLogicAndMaterializedValue(
       inheritedAttributes: Attributes): (GraphStageLogic, Source[Any, NotUsed]) = {
 
-    /**
+    /*
      * NOTE: in the current implementation of Pekko Stream,
-     * We have to materialization twice to do the piping, which means, even we can treat the Sink as a Source.
+     * We have to materialize twice to do the piping, which means that we can treat the Sink as a Source.
      *
-     * In an idea word this stage should be purged out by the materializer optimization,
+     * In an ideal world, this stage should be purged out by the materializer optimization,
      * and we can directly connect the upstream to the downstream.
      */
     object logic extends TimerGraphStageLogic(shape) with InHandler with OutHandler { self =>


### PR DESCRIPTION
Nightly doc build has failed for a few days - e.g. https://github.com/apache/pekko/actions/runs/18082049707

```
[error] /home/runner/work/pekko/pekko/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/SourceSink.scala:50:5: discarding unmoored doc comment
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=lint-doc-detached
[error]     /**
[error]     ^
[error] one error found
```