### PR TITLE
Update README to remove Java 11 requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Depending on which version (or sometimes module) you want to work on, you should
 * `1.0.x` – maintenance branch of Pekko 1.0
 * `1.1.x` – maintenance branch of Pekko 1.1
 * `1.2.x` – maintenance branch of Pekko 1.2
+* `1.3.x` – maintenance branch of Pekko 1.3 (unreleased but active development ongoing)
 
 ### Tags
 
@@ -348,7 +349,7 @@ If you'd like to check if your links and formatting look good in JavaDoc (and no
 sbt -Dpekko.genjavadoc.enabled=true Javaunidoc/doc
 ```
 
-Which will generate JavaDoc style docs in `./target/javaunidoc/index.html`. This requires a JDK version 11 or later.
+Which will generate JavaDoc style docs in `./target/javaunidoc/index.html`. This requires a JDK version 17 or later.
 
 #### Changing the project information page index
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ To use IntelliJ IDEA, you need to configure your project to use JDK 8. For a vis
 - `sbt publishLocal` will push the jars to your local Apache Ivy repository
 - `sbt publishM2` will push the jars to your local Apache Maven repository
 - `sbt docs/paradox` will build the docs (the ones describing the module features)
-     - Requires Java 11 minimum
      - `sbt docs/paradoxBrowse` does the same but will open the docs in your browser when complete
      - the `index.html` file will appear in `target/paradox/site/main/`
 - `sbt unidoc` will build the Javadocs for all the modules and load them to one place (may require Graphviz, see Prerequisites above)


### PR DESCRIPTION
Removed the requirement for Java 11 minimum from the documentation. The docs already mention Java 17 min so this Java 11 mention is actually incorrect.