### PR TITLE
chore: fix up some GitHub Actions pins

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -54,7 +54,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-tags: true
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Setup Java 17
         uses: actions/setup-java@v5
@@ -74,7 +74,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -137,7 +137,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -180,7 +180,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/generate-doc-check.yml
+++ b/.github/workflows/generate-doc-check.yml
@@ -45,7 +45,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Install Graphviz
         run: |-

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -40,7 +40,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Check headers
         env:

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -39,7 +39,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
     
       - name: Setup Coursier
         uses: coursier/setup-action@039f736548afa5411c1382f40a5bd9c2d30e0383 # v1.3.9

--- a/.github/workflows/nightly-1.0-builds.yml
+++ b/.github/workflows/nightly-1.0-builds.yml
@@ -37,7 +37,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -91,7 +91,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -141,7 +141,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/nightly-1.1-builds.yml
+++ b/.github/workflows/nightly-1.1-builds.yml
@@ -37,7 +37,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -92,7 +92,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -143,7 +143,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/nightly-1.2-builds.yml
+++ b/.github/workflows/nightly-1.2-builds.yml
@@ -37,7 +37,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -92,7 +92,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -143,7 +143,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/nightly-builds-aeron.yml
+++ b/.github/workflows/nightly-builds-aeron.yml
@@ -45,7 +45,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -29,7 +29,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -83,7 +83,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
@@ -135,7 +135,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -49,7 +49,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Install Graphviz
         run: |-

--- a/.github/workflows/publish-1.0-nightly.yml
+++ b/.github/workflows/publish-1.0-nightly.yml
@@ -51,7 +51,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Install Graphviz
         run: |-

--- a/.github/workflows/publish-1.1-docs.yml
+++ b/.github/workflows/publish-1.1-docs.yml
@@ -49,7 +49,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Install Graphviz
         run: |-

--- a/.github/workflows/publish-1.1-nightly.yml
+++ b/.github/workflows/publish-1.1-nightly.yml
@@ -51,7 +51,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Install Graphviz
         run: |-

--- a/.github/workflows/publish-1.2-docs.yml
+++ b/.github/workflows/publish-1.2-docs.yml
@@ -46,10 +46,10 @@ jobs:
           java-version: 11
 
       - name: Install sbt
-        uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.2.11
+        uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Install Graphviz
         run: |-

--- a/.github/workflows/publish-1.2-nightly.yml
+++ b/.github/workflows/publish-1.2-nightly.yml
@@ -51,7 +51,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Install Graphviz
         run: |-

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -51,7 +51,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Install Graphviz
         run: |-

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
       - name: Launch Scala Steward
-        uses: scala-steward-org/scala-steward-action@v2
+        uses: scala-steward-org/scala-steward-action@53d486a68877f4a6d1e110e8058fe21e593db356 # v2.77.0
         env:
           JAVA_OPTS: "-XX:+UseG1GC -Xms4G -Xmx4G -Xss2M -XX:+AlwaysActAsServerClassMachine -XX:ReservedCodeCacheSize=256m -XX:MaxGCPauseMillis=750 -XX:+UseCompressedOops -XX:MetaspaceSize=512M"
         with:

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -54,7 +54,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # 6.4.7
 
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts


### PR DESCRIPTION
Notably don't rely on the scala-steward tag

done with octopin (but skipped commits for `actions/` actions)