### PR TITLE
Add zstd compression and decompression for pekko streams

### DIFF
--- a/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
+++ b/actor/src/main/java/org/apache/pekko/io/ByteBufferCleaner.java
@@ -23,6 +23,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import org.apache.pekko.annotation.InternalStableApi;
 
 /**
  * Cleans a direct {@link ByteBuffer}. Without manual intervention, direct ByteBuffers will be
@@ -36,7 +37,8 @@ import java.nio.ByteBuffer;
  *
  * <p>See <a href=https://bugs.openjdk.java.net/browse/JDK-4724038>JDK-4724038</a>
  */
-final class ByteBufferCleaner {
+@InternalStableApi
+public final class ByteBufferCleaner {
 
   // adapted from
   // https://github.com/apache/commons-io/blob/441115a4b5cd63ae808dd4c40fc238cb52c8048f/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -75,7 +77,7 @@ final class ByteBufferCleaner {
    * @param buffer to release.
    * @throws IllegalStateException on internal failure.
    */
-  static void clean(final ByteBuffer buffer) {
+  public static void clean(final ByteBuffer buffer) {
     try {
       INSTANCE.clean(buffer);
     } catch (final Throwable t) {
@@ -116,7 +118,7 @@ final class ByteBufferCleaner {
    *
    * @return {@code true} if cleaning is supported, {@code false} otherwise.
    */
-  static boolean isSupported() {
+  public static boolean isSupported() {
     return INSTANCE != null;
   }
 }

--- a/docs/src/main/paradox/stream/operators/Compression/zstd.md
+++ b/docs/src/main/paradox/stream/operators/Compression/zstd.md
@@ -1,0 +1,30 @@
+# Compression.zstd
+
+Creates a flow that zstd-compresses a stream of ByteStrings.
+
+@ref[Compression operators](../index.md#compression-operators)
+
+## Signature
+
+@apidoc[Compression.zstd](stream.*.Compression$) { scala="#zstd:org.apache.pekko.stream.scaladsl.Flow[org.apache.pekko.util.ByteString,org.apache.pekko.util.ByteString,org.apache.pekko.NotUsed]" java="#zstd()" }
+
+## Description
+
+Creates a flow that zstd-compresses a stream of ByteStrings. Note that the compressor
+will SYNC_FLUSH after every @apidoc[util.ByteString] so that it is guaranteed that every @apidoc[util.ByteString]
+coming out of the flow can be fully decompressed without waiting for additional data. This may
+come at a compression performance cost for very small chunks.
+
+Use the overload method to control the compression level.
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**emits** when the compression algorithm produces output for the received `ByteString`
+
+**backpressures** when downstream backpressures
+
+**completes** when upstream completes
+
+@@@

--- a/docs/src/main/paradox/stream/operators/Compression/zstdDecompress.md
+++ b/docs/src/main/paradox/stream/operators/Compression/zstdDecompress.md
@@ -1,0 +1,26 @@
+# Compression.zstdDecompress
+
+Creates a flow that zstd-decompresses a stream of ByteStrings.
+
+@ref[Compression operators](../index.md#compression-operators)
+
+## Signature
+
+@apidoc[Compression.zstdDecompress](stream.*.Compression$) { scala="#zstdDecompress(maxBytesPerChunk:Int):org.apache.pekko.stream.scaladsl.Flow[org.apache.pekko.util.ByteString,org.apache.pekko.util.ByteString,org.apache.pekko.NotUsed]" java="#zstdDecompress(int)" }
+
+## Description
+
+Creates a flow that zstd-decompresses a stream of ByteStrings. If the input is truncated, uses invalid
+compression method or is invalid (failed CRC checks) this operator fails with a `com.github.luben.zstd.ZstdIOException`.
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**emits** when the decompression algorithm produces output for the received `ByteString` (the emitted `ByteString` is of `maxBytesPerChunk` maximum length)
+
+**backpressures** when downstream backpressures
+
+**completes** when upstream completes
+
+@@@

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -352,7 +352,8 @@ object Dependencies {
 
   // pekko stream
 
-  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, TestDependencies.scalatest)
+  lazy val stream =
+    l ++= Seq[sbt.ModuleID](reactiveStreams, "com.github.luben" % "zstd-jni" % "1.5.7-6", TestDependencies.scalatest)
 
   lazy val streamTestkit = l ++= Seq(
     TestDependencies.scalatest,

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/CoderSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/CoderSpec.scala
@@ -15,11 +15,11 @@ package org.apache.pekko.stream.io.compression
 
 import java.io.{ ByteArrayOutputStream, InputStream, OutputStream }
 import java.util.concurrent.ThreadLocalRandom
-import java.util.zip.DataFormatException
 
 import scala.annotation.tailrec
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 import scala.util.control.NoStackTrace
 
 import org.apache.pekko
@@ -31,7 +31,8 @@ import pekko.util.ByteString
 import org.scalatest.Inspectors
 import org.scalatest.wordspec.AnyWordSpec
 
-abstract class CoderSpec(codecName: String) extends AnyWordSpec with CodecSpecSupport with Inspectors {
+abstract class CoderSpec[CorruptInputException: ClassTag](codecName: String) extends AnyWordSpec with CodecSpecSupport
+    with Inspectors {
   import CompressionTestingTools._
 
   protected def newCompressor(): Compressor
@@ -85,7 +86,7 @@ abstract class CoderSpec(codecName: String) extends AnyWordSpec with CodecSpecSu
       "throw an error on corrupt input" in {
         (the[RuntimeException] thrownBy {
           ourDecode(corruptContent)
-        }).ultimateCause should be(a[DataFormatException])
+        }).ultimateCause should be(a[CorruptInputException])
       }
     }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/DeflateSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/DeflateSpec.scala
@@ -21,7 +21,7 @@ import pekko.stream.impl.io.compression.{ Compressor, DeflateCompressor }
 import pekko.stream.scaladsl.{ Compression, Flow }
 import pekko.util.ByteString
 
-class DeflateSpec extends CoderSpec("deflate") {
+class DeflateSpec extends CoderSpec[DataFormatException]("deflate") {
   import CompressionTestingTools._
 
   protected def newCompressor(): Compressor = new DeflateCompressor

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/GzipSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/GzipSpec.scala
@@ -15,14 +15,14 @@ package org.apache.pekko.stream.io.compression
 
 import java.io.{ InputStream, OutputStream }
 import java.nio.charset.StandardCharsets
-import java.util.zip.{ GZIPInputStream, GZIPOutputStream, ZipException }
+import java.util.zip.{ DataFormatException, GZIPInputStream, GZIPOutputStream, ZipException }
 
 import org.apache.pekko
 import pekko.stream.impl.io.compression.{ Compressor, GzipCompressor }
 import pekko.stream.scaladsl.{ Compression, Flow }
 import pekko.util.ByteString
 
-class GzipSpec extends CoderSpec("gzip") {
+class GzipSpec extends CoderSpec[DataFormatException]("gzip") {
   import CompressionTestingTools._
 
   protected def newCompressor(): Compressor = new GzipCompressor

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/ZstdAutoFlushSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/ZstdAutoFlushSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.io.compression
+
+import org.apache.pekko
+import pekko.stream.scaladsl.{ Compression, Flow }
+import pekko.util.ByteString
+
+class ZstdAutoFlushSpec extends ZstdSpec {
+  override protected val encoderFlow: Flow[ByteString, ByteString, Any] =
+    Compression.zstd(Compression.ZstdDefaultCompressionLevel, dictionary = None, autoFlush = false)
+
+  override protected val autoFlush: Boolean = false
+
+}

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/ZstdSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/ZstdSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.io.compression
+
+import com.github.luben.zstd.{ ZstdIOException, ZstdInputStream, ZstdOutputStream }
+
+import org.apache.pekko
+import pekko.stream.impl.io.compression.{ Compressor, ZstdCompressor }
+import pekko.stream.scaladsl.{ Compression, Flow }
+import pekko.util.ByteString
+
+import java.io.{ InputStream, OutputStream }
+
+class ZstdSpec extends CoderSpec[ZstdIOException]("zstd") {
+  import CompressionTestingTools._
+
+  override protected def newCompressor(): Compressor = new ZstdCompressor
+
+  override protected def encoderFlow: Flow[ByteString, ByteString, Any] = Compression.zstd
+
+  override protected def decoderFlow(maxBytesPerChunk: Int): Flow[ByteString, ByteString, Any] =
+    Compression.zstdDecompress(maxBytesPerChunk)
+
+  override protected def newDecodedInputStream(underlying: InputStream): InputStream =
+    new ZstdInputStream(underlying)
+
+  override protected def newEncodedOutputStream(underlying: OutputStream): OutputStream =
+    new ZstdOutputStream(underlying)
+
+  override def extraTests(): Unit = {
+    "decode concatenated compressions" in {
+      ourDecode(Seq(encode("Hello, "), encode("dear "), encode("User!")).join) should readAs("Hello, dear User!")
+    }
+  }
+}

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/compression/ZstdCompressor.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/compression/ZstdCompressor.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.impl.io.compression
+
+import java.nio.ByteBuffer
+import com.github.luben.zstd.{ ZstdDictCompress, ZstdDirectBufferCompressingStreamNoFinalizer }
+import org.apache.pekko
+import org.apache.pekko.stream.scaladsl.Compression
+import pekko.annotation.InternalApi
+import pekko.util.ByteString
+
+/** INTERNAL API */
+@InternalApi private[pekko] class ZstdCompressor(
+    compressionLevel: Int =
+      Compression.ZstdDefaultCompressionLevel, dictionary: Option[ZstdDictionaryImpl] = None) extends Compressor {
+
+  private val targetBuffer = ByteBuffer.allocateDirect(65536)
+  private val compressingStream = new ZstdDirectBufferCompressingStreamNoFinalizer(targetBuffer, compressionLevel)
+
+  dictionary.foreach { dict =>
+    (dict.level, dict.length, dict.offset) match {
+      case (None, None, None) =>
+        compressingStream.setDict(dict.dictionary)
+      case (Some(dictLevel), None, None) =>
+        compressingStream.setDict(new ZstdDictCompress(dict.dictionary, dictLevel))
+      case (Some(dictLevel), Some(dictLength), Some(dictOffset)) =>
+        compressingStream.setDict(new ZstdDictCompress(dict.dictionary, dictLevel, dictLength, dictOffset))
+      case _ =>
+        throw new IllegalArgumentException("Invalid combination of ZstdDictionary parameters")
+    }
+  }
+
+  override def compress(input: ByteString): ByteString = {
+    val inputBB = ByteBuffer.allocateDirect(input.size)
+    inputBB.put(input.toArrayUnsafe())
+    inputBB.flip()
+    compressingStream.compress(inputBB)
+    val result = ByteString.fromByteBuffer(targetBuffer)
+    targetBuffer.flip()
+    result
+  }
+
+  override def flush(): ByteString = {
+    targetBuffer.flip()
+    val result = ByteString.fromByteBuffer(targetBuffer)
+    targetBuffer.clear()
+    compressingStream.flush()
+    result
+  }
+
+  override def finish(): ByteString = {
+    compressingStream.close()
+    targetBuffer.flip()
+    val arr = Array.ofDim[Byte](targetBuffer.limit())
+    targetBuffer.get(arr)
+    val result = ByteString.fromArrayUnsafe(arr)
+    result
+  }
+
+  override def compressAndFlush(input: ByteString): ByteString = {
+    val inputBB = ByteBuffer.allocateDirect(input.size)
+    inputBB.put(input.toArrayUnsafe())
+    inputBB.flip()
+    compressingStream.compress(inputBB)
+    compressingStream.flush()
+    targetBuffer.flip()
+
+    val arr = new Array[Byte](targetBuffer.limit())
+    targetBuffer.get(arr)
+    targetBuffer.clear()
+    ByteString.fromArrayUnsafe(arr)
+  }
+
+  override def compressAndFinish(input: ByteString): ByteString = {
+    val inputBB = ByteBuffer.allocateDirect(input.size)
+    inputBB.put(input.toArrayUnsafe())
+    inputBB.flip()
+    compressingStream.compress(inputBB)
+    compressingStream.close()
+    targetBuffer.flip()
+
+    val arr = new Array[Byte](targetBuffer.limit())
+    targetBuffer.get(arr)
+    ByteString.fromArrayUnsafe(arr)
+  }
+
+  override def close(): Unit = compressingStream.close()
+}

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/compression/ZstdDecompressor.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/compression/ZstdDecompressor.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.impl.io.compression
+
+import java.nio.ByteBuffer
+
+import scala.util.control.NonFatal
+
+import com.github.luben.zstd.{ Zstd, ZstdDirectBufferDecompressingStreamNoFinalizer }
+
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.io.ByteBufferCleaner
+import pekko.stream.Attributes
+import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
+import pekko.stream.stage.{ GraphStageLogic, InHandler, OutHandler }
+import pekko.util.ByteString
+
+/** INTERNAL API */
+@InternalApi private[pekko] class ZstdDecompressor(maxBytesPerChunk: Int =
+      Zstd.blockSizeMax()) extends SimpleLinearGraphStage[ByteString] {
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+
+      private val sourceBuffer = ByteBuffer.allocateDirect(maxBytesPerChunk)
+
+      // This is initialized here to avoid an allocation per onPush, remember to clear before using
+      private val outputBuffer = ByteBuffer.allocateDirect(maxBytesPerChunk)
+      private val decompressingStream = new ZstdDirectBufferDecompressingStreamNoFinalizer(sourceBuffer)
+
+      override def onPush(): Unit = {
+        sourceBuffer.clear()
+        val inputArray = grab(in).toArrayUnsafe()
+        sourceBuffer.put(inputArray)
+        sourceBuffer.flip()
+        if (sourceBuffer.hasRemaining) {
+          var result = ByteString.empty
+          while (sourceBuffer.hasRemaining) {
+            outputBuffer.clear()
+            decompressingStream.read(outputBuffer)
+            outputBuffer.flip()
+            val outputArray = new Array[Byte](outputBuffer.limit())
+            outputBuffer.get(outputArray)
+            result = result.concat(ByteString.fromArrayUnsafe(outputArray))
+          }
+
+          // Fencepost case, it's possible to still have sourceBuffer.hasRemaining and yet decompression result
+          // not output anything
+          if (result.nonEmpty)
+            push(out, result)
+          else
+            pull(in)
+        } else pull(in)
+        sourceBuffer.flip()
+      }
+
+      override def onPull(): Unit = pull(in)
+
+      override def onUpstreamFinish(): Unit = {
+        sourceBuffer.flip()
+        if (sourceBuffer.hasRemaining) {
+          var result = ByteString.empty
+          while (sourceBuffer.hasRemaining) {
+            outputBuffer.clear()
+            decompressingStream.read(outputBuffer)
+            outputBuffer.flip()
+            val outputArray = new Array[Byte](outputBuffer.limit())
+            outputBuffer.get(outputArray)
+            result = result.concat(ByteString.fromArrayUnsafe(outputArray))
+          }
+          decompressingStream.close()
+
+          // Fencepost case, it's possible to still have sourceBuffer.hasRemaining and yet decompression result
+          // not output anything
+          if (result.nonEmpty)
+            emit(out, result)
+        }
+        completeStage()
+      }
+
+      override def postStop(): Unit = {
+        decompressingStream.close()
+
+        if (ByteBufferCleaner.isSupported)
+          try {
+            ByteBufferCleaner.clean(sourceBuffer)
+            ByteBufferCleaner.clean(outputBuffer)
+          } catch {
+            case NonFatal(_) => /* ok, best effort attempt to cleanup failed */
+          }
+      }
+
+      setHandlers(in, out, this)
+    }
+  }
+
+}

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/compression/ZstdDictionaryImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/compression/ZstdDictionaryImpl.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.impl.io.compression
+
+import org.apache.pekko.annotation.InternalStableApi
+
+@InternalStableApi
+private[pekko] abstract class ZstdDictionaryImpl {
+  def dictionary: Array[Byte]
+  def level: Option[Int]
+  def offset: Option[Int]
+  def length: Option[Int]
+}

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/compression/ZstdDictionary.java
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/compression/ZstdDictionary.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.javadsl.compression;
+
+import org.apache.pekko.annotation.InternalApi;
+import org.apache.pekko.stream.impl.io.compression.ZstdDictionaryImpl;
+import org.apache.pekko.util.ByteString;
+import org.apache.pekko.util.OptionalUtil;
+import scala.Option;
+
+import java.util.OptionalInt;
+
+/**
+ * Configuration class based on the official C zstd library to specify dictionary options for
+ * compression.
+ *
+ * @see <a href="https://github.com/facebook/zstd?tab=readme-ov-file#dictionary-compression-how-to">Zstd dictionary readme</a>
+ * @see <a href="https://facebook.github.io/zstd/zstd_manual.html#Chapter10">Zstd C manual</a>
+ * @since 2.0.0
+ */
+public class ZstdDictionary {
+    byte[] dictionary;
+    private OptionalInt level = OptionalInt.empty();
+    private OptionalInt offset = OptionalInt.empty();
+    private OptionalInt length = OptionalInt.empty();
+
+    public ZstdDictionary(byte[] dictionary) {
+        this.dictionary = dictionary;
+    }
+
+    public ZstdDictionary(byte[] dictionary, int level) {
+        this.dictionary = dictionary;
+        this.level = OptionalInt.of(level);
+    }
+
+    public ZstdDictionary(byte[] dictionary, Integer level) {
+        this.dictionary = dictionary;
+        if (level != null) {
+            this.level = OptionalInt.of(level);
+        }
+    }
+
+    public ZstdDictionary(byte[] dictionary, int level, int offset, int length) {
+        this.dictionary = dictionary;
+        this.level = OptionalInt.of(level);
+        this.offset = OptionalInt.of(offset);
+        this.length = OptionalInt.of(length);
+    }
+
+    public ZstdDictionary(byte[] dictionary, Integer level, Integer offset, Integer length) {
+        this.dictionary = dictionary;
+        if (level != null) {
+            this.level = OptionalInt.of(level);
+        }
+        if (offset != null) {
+            this.offset = OptionalInt.of(offset);
+        }
+        if (length != null) {
+            this.length = OptionalInt.of(length);
+        }
+    }
+
+    public ZstdDictionary(ByteString dictionary) {
+        this(dictionary.toArray());
+    }
+
+    public ZstdDictionary(ByteString dictionary, int level) {
+        this(dictionary.toArray(), level);
+    }
+
+    public ZstdDictionary(ByteString dictionary, Integer level) {
+        this(dictionary.toArray(), level);
+    }
+
+    public ZstdDictionary(ByteString dictionary, int level, int offset, int length) {
+        this(dictionary.toArray(), level, offset, length);
+    }
+
+    public ZstdDictionary(ByteString dictionary, Integer level, Integer offset, Integer length) {
+        this(dictionary.toArray(), level, offset, length);
+    }
+
+    public ZstdDictionary(String dictionary) {
+        this(dictionary.getBytes());
+    }
+
+    public ZstdDictionary(String dictionary, int level) {
+        this(dictionary.getBytes(), level);
+    }
+
+    public ZstdDictionary(String dictionary, Integer level) {
+        this(dictionary.getBytes(), level);
+    }
+
+    public ZstdDictionary(String dictionary, int level, int offset, int length) {
+        this(dictionary.getBytes(), level, offset, length);
+    }
+
+    public ZstdDictionary(String dictionary, Integer level, Integer offset, Integer length) {
+        this(dictionary.getBytes(), level, offset, length);
+    }
+
+    public byte[] getDictionary() {
+        return dictionary;
+    }
+
+    public OptionalInt getLevel() {
+        return level;
+    }
+
+    public OptionalInt getOffset() {
+        return offset;
+    }
+
+    public OptionalInt getLength() {
+        return length;
+    }
+
+    public void setDictionary(byte[] dictionary) {
+        this.dictionary = dictionary;
+    }
+
+    public void setLevel(int level) {
+        this.level = OptionalInt.of(level);
+    }
+
+    public void setLevel(OptionalInt level) {
+        this.level = level;
+    }
+
+    public void setLevel(Integer level) {
+        if (level == null) {
+            this.level = OptionalInt.empty();
+        } else {
+            this.level = OptionalInt.of(level);
+        }
+    }
+
+    public void setOffset(int offset) {
+        this.offset = OptionalInt.of(offset);
+    }
+
+    public void setOffset(Integer offset) {
+        if (offset == null) {
+            this.offset = OptionalInt.empty();
+        } else {
+            this.offset = OptionalInt.of(offset);
+        }
+    }
+
+    public void setOffset(OptionalInt offset) {
+        this.offset = offset;
+    }
+
+    public void setLength(int length) {
+        this.length = OptionalInt.of(length);
+    }
+
+    public void setLength(Integer length) {
+        if (length == null) {
+            this.length = OptionalInt.empty();
+        } else {
+            this.length = OptionalInt.of(length);
+        }
+    }
+
+    public void setLength(OptionalInt length) {
+        this.length = length;
+    }
+
+    @InternalApi
+    public ZstdDictionaryImpl toImpl() {
+        return new ZstdDictionaryImpl() {
+            @Override
+            public byte[] dictionary() {
+                return dictionary;
+            }
+
+            @Override
+            public Option<Object> level() {
+                return OptionalUtil.convertOptionalToScala(level);
+            }
+
+            @Override
+            public Option<Object> offset() {
+                return OptionalUtil.convertOptionalToScala(offset);
+            }
+
+            @Override
+            public Option<Object> length() {
+                return OptionalUtil.convertOptionalToScala(length);
+            }
+        };
+    }
+}

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/compression/ZstdDictionary.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/compression/ZstdDictionary.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.scaladsl.compression
+
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.stream.impl.io.compression.ZstdDictionaryImpl
+import pekko.util.ByteString
+
+/**
+ * Configuration class based on the official C zstd library to specify dictionary options for
+ * compression.
+ *
+ * @see https://github.com/facebook/zstd?tab=readme-ov-file#dictionary-compression-how-to
+ * @see https://facebook.github.io/zstd/zstd_manual.html#Chapter10
+ * @since 2.0.0
+ */
+final case class ZstdDictionary private (dictionary: Array[Byte], level: Option[Int],
+    offset: Option[Int], length: Option[Int]) { clazz =>
+
+  @InternalApi
+  private[pekko] def toImpl: ZstdDictionaryImpl = new ZstdDictionaryImpl {
+    override val dictionary: Array[Byte] = clazz.dictionary
+    override val level: Option[Int] = clazz.level
+    override val offset: Option[Int] = clazz.offset
+    override val length: Option[Int] = clazz.length
+  }
+}
+
+/**
+ * @since 2.0.0
+ */
+object ZstdDictionary {
+
+  def apply(dictionary: Array[Byte]): ZstdDictionary =
+    ZstdDictionary(dictionary, None, None, None)
+
+  def apply(dictionary: Array[Byte], level: Int): ZstdDictionary =
+    ZstdDictionary(dictionary, Some(level), None, None)
+
+  def apply(dictionary: Array[Byte], level: Int, offset: Int, length: Int): ZstdDictionary =
+    ZstdDictionary(dictionary, Some(level), Some(offset), Some(length))
+
+  def apply(dictionary: ByteString): ZstdDictionary =
+    ZstdDictionary(dictionary.toArray, None, None, None)
+
+  def apply(dictionary: ByteString, level: Int)
+      : ZstdDictionary =
+    ZstdDictionary(dictionary.toArray, level)
+
+  def apply(dictionary: ByteString, level: Int, offset: Int, length: Int)
+      : ZstdDictionary =
+    ZstdDictionary(dictionary.toArray, level, offset, length)
+
+  def apply(dictionary: String): ZstdDictionary =
+    ZstdDictionary(dictionary.getBytes)
+
+  def apply(dictionary: String, level: Int): ZstdDictionary =
+    ZstdDictionary(dictionary.getBytes, level)
+
+  def apply(dictionary: String, level: Int, offset: Int, length: Int): ZstdDictionary =
+    ZstdDictionary(dictionary.getBytes, level, offset, length)
+}


### PR DESCRIPTION
Resolves: https://github.com/apache/pekko/issues/2404

This PR adds a zstd compression/decompression stream/flow using [zstd-jni](https://github.com/luben/zstd-jni), this project was chosen because its the only one that has high performance (it uses the [reference zstd implementation](https://github.com/facebook/zstd) via JNI) and also supports at least JDK 17 (its published with JDK 11).

The PR still needs to be completed (documentation needs to be added along with MiMa exclusions) but I am creating a PR now with the necessary barebones so that people can comment on whether the PR is on the right track, tests have been added (there is already a base testing framework for pekko-streams compression flows `CoderSpec`).

The implementation of `ZstdCompressor`/`ZstdDecompressor` uses `ZstdDirectBufferCompressingStreamNoFinalizer`/`ZstdDirectBufferDecompressingStreamNoFinalizer` as these are the abstractions provided by zstd-jni to do streaming compression, note that the versions with `NoFinalizer` just mean that you need to explicitly shutdown the resource (which is what we want since Pekko Streams handles resource cleaning). These compression abstractions need to use a direct `ByteBuffer` in order to handle the shuffling of data between the JNI boundary so that the C implementation can do its work directly in memory,  the [zstd-jni tests](https://github.com/luben/zstd-jni/blob/9c3386d306086078155f58116a4d905e07239db4/src/test/scala/Zstd.scala) was the basis used to write the implementation.

Some extra notes

- `CoderSpec` had to be modified as the test which catches the exception to be thrown on corrupt input was hardcoded to `DataFormatException` where as zstd throws its own bespoke exception on corrupt input
- The `ZstdCompressor` implements the `Compressor` abstraction which does a lot of heavy lifting (especially when it comes to tests) however the `ZstdDecompressor` intentionally does not implement `DeflateDecompressorBase` as the design is heavily tied to Java's deflate/compression API's, instead we use `SimpleLinearGraphStage[ByteString]` backed by `ZstdDirectBufferDecompressingStreamNoFinalizer`
- The current API also allows you to specify a [dictionary](https://github.com/facebook/zstd?tab=readme-ov-file#dictionary-compression-how-to) when doing compression. Note that to do this, you need to pass a `com.github.luben.zstd.ZstdDictCompress` datastructure which is tied to the implementation of zstd-jni. There is an argument to create our own pekko equivalent of `ZstdDictCompress` which will internally map to a `com.github.luben.zstd.ZstdDictCompress`, doing so would allow us to swap to a different implementation of zstd in the future without breaking the API.
  - This is the only part of the API (aside from the `com.github.luben.zstd.ZstdIOException` exception that is thrown on corrupt input) that is tied to the zstd-jni implementation