### PR TITLE
optimize ByteStrings startswith/endswith

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -2230,9 +2230,13 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       ByteString1C(Array[Byte](1, 2, 3)).map(inc) should ===(ByteString(Array[Byte](2, 3, 4)))
       // ByteString1 with offset
       ByteString1(Array[Byte](0, 1, 2, 3, 4), 1, 3).map(inc) should ===(ByteString(Array[Byte](2, 3, 4)))
-      // ByteStrings
+      // ByteStrings (2 segments)
       val bss = ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))
       bss.map(b => (b + 1).toByte) should ===(ByteString("bcde"))
+      // ByteStrings (3 segments, including negative byte values)
+      val bss3 = ByteString1(Array[Byte](-1, -2)) ++ ByteString1(Array[Byte](0, 1)) ++ ByteString1(
+        Array[Byte](126, 127))
+      bss3.map(b => (b + 1).toByte) should ===(ByteString(Array[Byte](0, -1, 1, 2, 127, -128)))
       // empty
       ByteString.empty.map(inc) should ===(ByteString.empty)
     }
@@ -2247,9 +2251,12 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       collect(ByteString1C(Array[Byte](10, 20, 30))) should ===(Seq[Byte](10, 20, 30))
       // ByteString1 with internal offset
       collect(ByteString1(Array[Byte](0, 10, 20, 30, 40), 1, 3)) should ===(Seq[Byte](10, 20, 30))
-      // ByteStrings (multi-segment)
+      // ByteStrings (multi-segment, 2 segments)
       collect(ByteStrings(ByteString1.fromString("ab"), ByteString1.fromString("cd"))) should ===(
         Seq[Byte]('a', 'b', 'c', 'd'))
+      // ByteStrings (multi-segment, 3+ segments, including negative byte values)
+      val bss3 = ByteString1(Array[Byte](-1, -128)) ++ ByteString1(Array[Byte](0)) ++ ByteString1(Array[Byte](127))
+      collect(bss3) should ===(Seq[Byte](-1, -128, 0, 127))
       // empty
       collect(ByteString.empty) should ===(Seq.empty[Byte])
     }

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -402,6 +402,24 @@ object ByteString {
       java.util.Arrays.equals(this.bytes, hIdx, hIdx + (needleLen - nIdx), bytes, nIdx, needleLen)
     }
 
+    /**
+     * INTERNAL API: compare `len` bytes from this ByteString starting at `haystackOffset`
+     * against `needle[needleOffset..needleOffset+len)`.
+     */
+    private[pekko] def matchesAt(haystackOffset: Int, needle: Array[Byte], needleOffset: Int, len: Int): Boolean = {
+      var hIdx = haystackOffset
+      var nIdx = needleOffset
+      var remaining = len
+      while (remaining >= 8) {
+        if (SWARUtil.getLong(bytes, hIdx, ByteOrder.BIG_ENDIAN) !=
+            SWARUtil.getLong(needle, nIdx, ByteOrder.BIG_ENDIAN)) return false
+        hIdx += 8
+        nIdx += 8
+        remaining -= 8
+      }
+      java.util.Arrays.equals(bytes, hIdx, hIdx + remaining, needle, nIdx, nIdx + remaining)
+    }
+
     override def slice(from: Int, until: Int): ByteString =
       if (from <= 0 && until >= length) this
       else if (from >= length || until <= 0 || from >= until) ByteString.empty
@@ -786,6 +804,24 @@ object ByteString {
         nIdx += 8
       }
       java.util.Arrays.equals(this.bytes, hIdx, hIdx + (needleLen - nIdx), bytes, nIdx, needleLen)
+    }
+
+    /**
+     * INTERNAL API: compare `len` bytes from this ByteString starting at logical `haystackOffset`
+     * against `needle[needleOffset..needleOffset+len)`.
+     */
+    private[pekko] def matchesAt(haystackOffset: Int, needle: Array[Byte], needleOffset: Int, len: Int): Boolean = {
+      var hIdx = startIndex + haystackOffset
+      var nIdx = needleOffset
+      var remaining = len
+      while (remaining >= 8) {
+        if (SWARUtil.getLong(bytes, hIdx, ByteOrder.BIG_ENDIAN) !=
+            SWARUtil.getLong(needle, nIdx, ByteOrder.BIG_ENDIAN)) return false
+        hIdx += 8
+        nIdx += 8
+        remaining -= 8
+      }
+      java.util.Arrays.equals(bytes, hIdx, hIdx + remaining, needle, nIdx, nIdx + remaining)
     }
 
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
@@ -1197,6 +1233,71 @@ object ByteString {
 
         find(byteStringsLast, math.min(end, length - 1), length)
       }
+    }
+
+    override def startsWith(bytes: Array[Byte], offset: Int): Boolean = {
+      val needleLen = bytes.length
+      if (length - offset < needleLen) return false
+      if (needleLen == 0) return true
+      // Locate the fragment that contains position `offset`
+      var fragIdx = 0
+      var fragOffset = offset
+      while (fragIdx < bytestrings.length && fragOffset >= bytestrings(fragIdx).length) {
+        fragOffset -= bytestrings(fragIdx).length
+        fragIdx += 1
+      }
+      // Compare needle against consecutive fragments without compacting
+      var nIdx = 0
+      while (nIdx < needleLen) {
+        val frag = bytestrings(fragIdx)
+        val toCmp = math.min(needleLen - nIdx, frag.length - fragOffset)
+        if (!frag.matchesAt(fragOffset, bytes, nIdx, toCmp)) return false
+        nIdx += toCmp
+        fragIdx += 1
+        fragOffset = 0
+      }
+      true
+    }
+
+    override def endsWith(bytes: Array[Byte]): Boolean = {
+      val needleLen = bytes.length
+      if (length < needleLen) return false
+      if (needleLen == 0) return true
+      // Locate the fragment that contains position `length - needleLen`
+      var fragIdx = 0
+      var fragOffset = length - needleLen
+      while (fragIdx < bytestrings.length && fragOffset >= bytestrings(fragIdx).length) {
+        fragOffset -= bytestrings(fragIdx).length
+        fragIdx += 1
+      }
+      // Compare needle against consecutive fragments without compacting
+      var nIdx = 0
+      while (nIdx < needleLen) {
+        val frag = bytestrings(fragIdx)
+        val toCmp = math.min(needleLen - nIdx, frag.length - fragOffset)
+        if (!frag.matchesAt(fragOffset, bytes, nIdx, toCmp)) return false
+        nIdx += toCmp
+        fragIdx += 1
+        fragOffset = 0
+      }
+      true
+    }
+
+    override def foreach[@specialized U](f: Byte => U): Unit =
+      bytestrings.foreach(_.foreach(f))
+
+    override def map[A](f: Byte => Byte): ByteString = {
+      val result = new Array[Byte](length)
+      var pos = 0
+      bytestrings.foreach { bs =>
+        var i = 0
+        while (i < bs.length) {
+          result(pos) = f(bs(i))
+          pos += 1
+          i += 1
+        }
+      }
+      ByteString1C(result)
     }
 
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -1263,13 +1263,15 @@ object ByteString {
       val needleLen = bytes.length
       if (length < needleLen) return false
       if (needleLen == 0) return true
-      // Locate the fragment that contains position `length - needleLen`
-      var fragIdx = 0
-      var fragOffset = length - needleLen
-      while (fragIdx < bytestrings.length && fragOffset >= bytestrings(fragIdx).length) {
-        fragOffset -= bytestrings(fragIdx).length
-        fragIdx += 1
+      // Locate the fragment containing `length - needleLen` by walking backward from the last
+      // fragment, so only the suffix fragments are touched (O(suffix fragments), not O(all fragments)).
+      var fragIdx = bytestrings.length - 1
+      var bytesFromTail = needleLen
+      while (fragIdx > 0 && bytesFromTail > bytestrings(fragIdx).length) {
+        bytesFromTail -= bytestrings(fragIdx).length
+        fragIdx -= 1
       }
+      var fragOffset = bytestrings(fragIdx).length - bytesFromTail
       // Compare needle against consecutive fragments without compacting
       var nIdx = 0
       while (nIdx < needleLen) {


### PR DESCRIPTION
Some more copilot suggestions. The changes that have been added so far have mainly targeted the byte array backed ByteString implementations but the implementation for the concatenated ByteStrings can still exhibit O(n^2) issues due to the use of apply(int) function which is inefficient for that implementation.
Without this change, users are best advised to to compact their ByteString if they need startsWith/endsWith and suspect that they might be dealing with a concatenated ByteString.
 
```
With Changes
Benchmark                (cellCount)   Mode  Cnt    Score    Error  Units
[info] Benchmark                                          Mode  Cnt         Score           Error  Units
[info] ByteString_startEnd_Benchmark.bs_endsWith         thrpt    3  41146243.815 ±  89199318.989  ops/s
[info] ByteString_startEnd_Benchmark.bs_endsWithBytes    thrpt    3  57772963.058 ± 113861001.097  ops/s
[info] ByteString_startEnd_Benchmark.bs_startsWith       thrpt    3  51618538.730 ±  50209295.437  ops/s
[info] ByteString_startEnd_Benchmark.bs_startsWithBytes  thrpt    3  61139506.870 ±  43826147.198  ops/s
[info] ByteString_startEnd_Benchmark.bss_endsWith        thrpt    3   3763017.312 ±   1874477.984  ops/s
[info] ByteString_startEnd_Benchmark.bss_startsWith      thrpt    3  22659830.804 ±   4867250.514  ops/s

Without Changes
[info] Benchmark                                          Mode  Cnt         Score          Error  Units
[info] ByteString_startEnd_Benchmark.bs_endsWith         thrpt    3  42643024.729 ± 39682206.774  ops/s
[info] ByteString_startEnd_Benchmark.bs_endsWithBytes    thrpt    3  48849001.581 ± 36760529.610  ops/s
[info] ByteString_startEnd_Benchmark.bs_startsWith       thrpt    3  41864132.036 ± 57823779.206  ops/s
[info] ByteString_startEnd_Benchmark.bs_startsWithBytes  thrpt    3  54296545.089 ± 33013510.355  ops/s
[info] ByteString_startEnd_Benchmark.bss_endsWith        thrpt    3   3428387.507 ±  1458843.947  ops/s
[info] ByteString_startEnd_Benchmark.bss_startsWith      thrpt    3  14300744.704 ±   369312.100  ops/s
```