### PR TITLE
refactor: inline onEvent into MergeHub.tryProcessNext

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -201,21 +201,6 @@ private[pekko] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Bo
 
     setHandler(out, this)
 
-    // Returns true when we have not consumed demand, false otherwise
-    private def onEvent(ev: Event): Boolean = ev match {
-      case Element(id, elem) =>
-        demands(id).onElement()
-        push(out, elem)
-        false
-      case Register(id, callback) =>
-        demands.put(id, new InputState(callback))
-        true
-      case Deregister(id) =>
-        demands.remove(id)
-        if (drainingEnabled && draining) tryCompleteOnDraining()
-        true
-    }
-
     private def tryCompleteOnDraining(): Unit = {
       if (demands.isEmpty && (queue.peek() eq null)) {
         completeStage()
@@ -235,7 +220,19 @@ private[pekko] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Bo
       // queue, but then we will eventually reach the Deregister message, too.
       if (nextElem ne null) {
         needWakeup = false
-        if (onEvent(nextElem)) tryProcessNext(firstAttempt = true)
+        nextElem match {
+          case Element(id, elem) =>
+            demands(id).onElement()
+            push(out, elem)
+          // demand consumed by push — exit and wait for the next onPull
+          case Register(id, callback) =>
+            demands.put(id, new InputState(callback))
+            tryProcessNext(firstAttempt = true)
+          case Deregister(id) =>
+            demands.remove(id)
+            if (drainingEnabled && draining) tryCompleteOnDraining()
+            tryProcessNext(firstAttempt = true)
+        }
       } else {
         needWakeup = true
         // additional poll() to grab any elements that might missed the needWakeup


### PR DESCRIPTION
## Summary
- Inline the `Boolean`-returning `onEvent` helper directly into `MergedSourceLogic.tryProcessNext`
- Pattern-match the event in place: `Element` pushes and exits, `Register`/`Deregister` continue the `@tailrec` loop to drain control messages from the queue
- Same wakeup protocol, same demand handling — purely a clarity refactor

## Motivation
`onEvent` returned a `Boolean` flag whose only purpose was to tell `tryProcessNext` whether to continue looping. Folding the dispatch into the call site removes the indirection and makes the loop / exit conditions read in one place.

## Test plan
- [x] `sbt scalafmtAll`
- [x] `sbt stream/compile` — `@tailrec` accepted, no warnings
- [x] `sbt "stream-tests/testOnly org.apache.pekko.stream.scaladsl.HubSpec"` — 48/48 in 18s