### PR TITLE
Enhance DurableStateStore TCK with OCC, serialization, and soft-delete tests

### DIFF
--- a/docs/src/main/paradox/persistence-journals.md
+++ b/docs/src/main/paradox/persistence-journals.md
@@ -134,6 +134,14 @@ Scala
 Java
 :  @@snip [LambdaPersistencePluginDocTest.java](/docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java) { #snapshot-store-tck-java }
 
+To include the `DurableStateStore` TCK tests in your test suite simply extend the provided @scala[`DurableStateStoreSpec`]@java[`JavaDurableStateStoreSpec`]:
+
+Scala
+:  @@snip [PersistencePluginDocSpec.scala](/docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala) { #durable-state-tck-scala }
+
+Java
+:  @@snip [LambdaPersistencePluginDocTest.java](/docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java) { #durable-state-tck-java }
+
 In case your plugin requires some setting up (starting a mock database, removing temporary files etc.) you can override the
 `beforeAll` and `afterAll` methods to hook into the tests lifecycle:
 

--- a/docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
+++ b/docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
@@ -27,6 +27,7 @@ import org.apache.pekko.actor.*;
 import org.apache.pekko.persistence.*;
 import org.apache.pekko.persistence.japi.journal.JavaJournalSpec;
 import org.apache.pekko.persistence.japi.snapshot.JavaSnapshotStoreSpec;
+import org.apache.pekko.persistence.japi.state.JavaDurableStateStoreSpec;
 import org.apache.pekko.persistence.journal.japi.*;
 import org.apache.pekko.persistence.journal.leveldb.SharedLeveldbJournal;
 import org.apache.pekko.persistence.journal.leveldb.SharedLeveldbStore;
@@ -170,6 +171,30 @@ public class LambdaPersistencePluginDocTest {
           }
         }
         // #snapshot-store-tck-java
+      };
+
+  static Object o3b =
+      new Object() {
+        // #durable-state-tck-java
+        class MyDurableStateStoreTest extends JavaDurableStateStoreSpec {
+
+          public MyDurableStateStoreTest() {
+            super(
+                ConfigFactory.parseString(
+                    "pekko.persistence.state.plugin = \"my.durable-state.plugin\""));
+          }
+
+          @Override
+          public CapabilityFlag supportsDeleteWithRevisionCheck() {
+            return CapabilityFlag.on();
+          }
+
+          @Override
+          public CapabilityFlag supportsUpsertWithRevisionCheck() {
+            return CapabilityFlag.on();
+          }
+        }
+        // #durable-state-tck-java
       };
 
   static Object o4 =

--- a/docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
@@ -222,6 +222,27 @@ object PersistenceTCKDoc {
     }
     // #snapshot-store-tck-scala
   }
+  object example2b {
+    import org.apache.pekko.persistence.state.DurableStateStoreSpec
+
+    // #durable-state-tck-scala
+    class MyDurableStateStoreSpec
+        extends DurableStateStoreSpec(
+          config = ConfigFactory.parseString("""
+        pekko.persistence.state.plugin = "my.durable-state.plugin"
+        """)) {
+
+      override def supportsDeleteWithRevisionCheck: CapabilityFlag =
+        true // or CapabilityFlag.on
+
+      override def supportsUpsertWithRevisionCheck: CapabilityFlag =
+        true // or CapabilityFlag.on
+
+      override def supportsSerialization: CapabilityFlag =
+        true // or CapabilityFlag.on
+    }
+    // #durable-state-tck-scala
+  }
   object example3 {
     import java.io.File
 

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/CapabilityFlags.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/CapabilityFlags.scala
@@ -86,3 +86,14 @@ trait SnapshotStoreCapabilityFlags extends CapabilityFlags {
   protected def supportsMetadata: CapabilityFlag
 }
 //#snapshot-store-flags
+
+//#durable-state-store-flags
+trait DurableStateStoreCapabilityFlags extends CapabilityFlags {
+
+  /**
+   * When `true` enables tests which check if the durable state store properly rejects
+   * a `deleteObject` call when the revision does not match the stored revision.
+   */
+  protected def supportsDeleteWithRevisionCheck: CapabilityFlag
+}
+//#durable-state-store-flags

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/CapabilityFlags.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/CapabilityFlags.scala
@@ -95,5 +95,24 @@ trait DurableStateStoreCapabilityFlags extends CapabilityFlags {
    * a `deleteObject` call when the revision does not match the stored revision.
    */
   protected def supportsDeleteWithRevisionCheck: CapabilityFlag
+
+  /**
+   * When `true` enables tests which check if the durable state store properly rejects
+   * an `upsertObject` call when the revision is stale (does not match the expected next revision).
+   * This is the optimistic concurrency check on writes.
+   */
+  protected def supportsUpsertWithRevisionCheck: CapabilityFlag
+
+  /**
+   * When `true` enables tests which check if the durable state store properly serializes
+   * and deserializes values via the configured Pekko serializer infrastructure.
+   */
+  protected def supportsSerialization: CapabilityFlag
+
+  /**
+   * When `true` enables tests which check the deprecated single-argument `deleteObject(persistenceId)`
+   * overload, which deletes regardless of the current revision.
+   */
+  protected def supportsSoftDelete: CapabilityFlag
 }
 //#durable-state-store-flags

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
@@ -7,6 +7,10 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
+/*
+ * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package org.apache.pekko.persistence.japi.state
 
 import scala.collection.immutable

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package org.apache.pekko.persistence.japi.state
+
+import scala.collection.immutable
+
+import org.apache.pekko
+import pekko.persistence.CapabilityFlag
+import pekko.persistence.state.DurableStateStoreSpec
+
+import org.scalatest.{ Args, ConfigMap, Filter, Status, Suite, TestData }
+
+import com.typesafe.config.Config
+
+/**
+ * JAVA API
+ *
+ * This spec aims to verify custom pekko-persistence [[pekko.persistence.state.DurableStateStore]]
+ * implementations.
+ * Plugin authors are highly encouraged to include it in their plugin's test suites.
+ *
+ * In case your durable state store plugin needs some kind of setup or teardown, override the
+ * `beforeAll` or `afterAll` methods (don't forget to call `super` in your overridden methods).
+ *
+ * @see [[pekko.persistence.state.DurableStateStoreSpec]]
+ */
+class JavaDurableStateStoreSpec(config: Config) extends DurableStateStoreSpec(config) {
+  override protected def supportsDeleteWithRevisionCheck: CapabilityFlag = CapabilityFlag.off()
+
+  override def runTests(testName: Option[String], args: Args): Status =
+    super.runTests(testName, args)
+
+  override def runTest(testName: String, args: Args): Status =
+    super.runTest(testName, args)
+
+  override def run(testName: Option[String], args: Args): Status =
+    super.run(testName, args)
+
+  override def testDataFor(testName: String, theConfigMap: ConfigMap): TestData =
+    super.testDataFor(testName, theConfigMap)
+
+  override def testNames: Set[String] =
+    super.testNames
+
+  override def tags: Map[String, Set[String]] =
+    super.tags
+
+  override def rerunner: Option[String] =
+    super.rerunner
+
+  override def expectedTestCount(filter: Filter): Int =
+    super.expectedTestCount(filter)
+
+  override def suiteId: String =
+    super.suiteId
+
+  override def suiteName: String =
+    super.suiteName
+
+  override def runNestedSuites(args: Args): Status =
+    super.runNestedSuites(args)
+
+  override def nestedSuites: immutable.IndexedSeq[Suite] =
+    super.nestedSuites
+}

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
@@ -8,7 +8,7 @@
  */
 
 /*
- * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package org.apache.pekko.persistence.japi.state

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
@@ -38,6 +38,10 @@ import com.typesafe.config.Config
 class JavaDurableStateStoreSpec(config: Config) extends DurableStateStoreSpec(config) {
   override protected def supportsDeleteWithRevisionCheck: CapabilityFlag = CapabilityFlag.off()
 
+  override protected def supportsUpsertWithRevisionCheck: CapabilityFlag = CapabilityFlag.off()
+
+  override protected def supportsSoftDelete: CapabilityFlag = CapabilityFlag.off()
+
   override def runTests(testName: Option[String], args: Args): Status =
     super.runTests(testName, args)
 

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
@@ -7,6 +7,10 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
+/*
+ * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package org.apache.pekko.persistence.state
 
 import scala.concurrent.Await

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package org.apache.pekko.persistence.state
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.persistence.CapabilityFlag
+import pekko.persistence.DurableStateStoreCapabilityFlags
+import pekko.persistence.PluginSpec
+import pekko.persistence.scalatest.{ MayVerb, OptionalTests }
+import pekko.persistence.state.scaladsl.DurableStateUpdateStore
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+object DurableStateStoreSpec {
+  val config: Config = ConfigFactory.empty()
+}
+
+/**
+ * This spec aims to verify custom pekko-persistence [[DurableStateStore]] implementations.
+ * Plugin authors are highly encouraged to include it in their plugin's test suites.
+ *
+ * In case your durable state store plugin needs some kind of setup or teardown, override the `beforeAll`
+ * or `afterAll` methods (don't forget to call `super` in your overridden methods).
+ *
+ * For a Java and JUnit consumable version of the TCK please refer to
+ * [[pekko.persistence.japi.state.JavaDurableStateStoreSpec]].
+ *
+ * @see [[pekko.persistence.japi.state.JavaDurableStateStoreSpec]]
+ */
+abstract class DurableStateStoreSpec(config: Config)
+    extends PluginSpec(config)
+    with MayVerb
+    with OptionalTests
+    with DurableStateStoreCapabilityFlags {
+
+  implicit lazy val system: ActorSystem =
+    ActorSystem("DurableStateStoreSpec", config.withFallback(DurableStateStoreSpec.config))
+
+  override protected def supportsDeleteWithRevisionCheck: CapabilityFlag = CapabilityFlag.off()
+
+  /**
+   * Returns the `DurableStateUpdateStore` under test. By default, this uses the plugin
+   * configured under `pekko.persistence.state.plugin` in the provided config.
+   */
+  def durableStateStore(): DurableStateUpdateStore[Any] =
+    DurableStateStoreRegistry(system).durableStateStoreFor[DurableStateUpdateStore[Any]]("")
+
+  private val timeout = 3.seconds
+
+  "A durable state store" must {
+    "not find a non-existing object" in {
+      val result = Await.result(durableStateStore().getObject(pid), timeout)
+      result.value shouldBe None
+    }
+
+    "persist a state and retrieve it" in {
+      val value = s"state-${pid}"
+      Await.result(durableStateStore().upsertObject(pid, 1L, value, ""), timeout)
+      val result = Await.result(durableStateStore().getObject(pid), timeout)
+      result.value shouldBe Some(value)
+      result.revision shouldBe 1L
+    }
+
+    "update a state" in {
+      val store = durableStateStore()
+      val value1 = s"state-1-${pid}"
+      val value2 = s"state-2-${pid}"
+      Await.result(store.upsertObject(pid, 1L, value1, ""), timeout)
+      Await.result(store.upsertObject(pid, 2L, value2, ""), timeout)
+      val result = Await.result(store.getObject(pid), timeout)
+      result.value shouldBe Some(value2)
+      result.revision shouldBe 2L
+    }
+
+    "delete a state" in {
+      val store = durableStateStore()
+      val value = s"state-${pid}"
+      Await.result(store.upsertObject(pid, 1L, value, ""), timeout)
+      Await.result(store.deleteObject(pid, 2L), timeout)
+      val result = Await.result(store.getObject(pid), timeout)
+      result.value shouldBe None
+    }
+
+    "handle different persistence IDs independently" in {
+      val store = durableStateStore()
+      val pid2 = pid + "-2"
+      val value1 = s"state-${pid}"
+      val value2 = s"state-${pid2}"
+      Await.result(store.upsertObject(pid, 1L, value1, ""), timeout)
+      Await.result(store.upsertObject(pid2, 1L, value2, ""), timeout)
+
+      val result1 = Await.result(store.getObject(pid), timeout)
+      val result2 = Await.result(store.getObject(pid2), timeout)
+
+      result1.value shouldBe Some(value1)
+      result2.value shouldBe Some(value2)
+    }
+  }
+
+  "A durable state store optionally".may {
+    optional(flag = supportsDeleteWithRevisionCheck) {
+      "fail to delete a state when the revision does not match" in {
+        val store = durableStateStore()
+        val value = s"state-${pid}"
+        Await.result(store.upsertObject(pid, 1L, value, ""), timeout)
+        val deleteResult = store.deleteObject(pid, 99L)
+        intercept[Exception] {
+          Await.result(deleteResult, timeout)
+        }
+        // The original state should still be accessible
+        val result = Await.result(store.getObject(pid), timeout)
+        result.value shouldBe Some(value)
+        result.revision shouldBe 1L
+      }
+    }
+  }
+}

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
@@ -71,7 +71,7 @@ abstract class DurableStateStoreSpec(config: Config)
 
     "persist a state and retrieve it" in {
       val value = s"state-${pid}"
-      Await.result(durableStateStore().upsertObject(pid, 1L, value, ""), timeout)
+      Await.result(durableStateStore().upsertObject(pid, 1L, value, "test-tag"), timeout)
       val result = Await.result(durableStateStore().getObject(pid), timeout)
       result.value shouldBe Some(value)
       result.revision shouldBe 1L
@@ -81,8 +81,8 @@ abstract class DurableStateStoreSpec(config: Config)
       val store = durableStateStore()
       val value1 = s"state-1-${pid}"
       val value2 = s"state-2-${pid}"
-      Await.result(store.upsertObject(pid, 1L, value1, ""), timeout)
-      Await.result(store.upsertObject(pid, 2L, value2, ""), timeout)
+      Await.result(store.upsertObject(pid, 1L, value1, "test-tag"), timeout)
+      Await.result(store.upsertObject(pid, 2L, value2, "test-tag"), timeout)
       val result = Await.result(store.getObject(pid), timeout)
       result.value shouldBe Some(value2)
       result.revision shouldBe 2L
@@ -91,7 +91,7 @@ abstract class DurableStateStoreSpec(config: Config)
     "delete a state" in {
       val store = durableStateStore()
       val value = s"state-${pid}"
-      Await.result(store.upsertObject(pid, 1L, value, ""), timeout)
+      Await.result(store.upsertObject(pid, 1L, value, "test-tag"), timeout)
       Await.result(store.deleteObject(pid, 2L), timeout)
       val result = Await.result(store.getObject(pid), timeout)
       result.value shouldBe None
@@ -102,8 +102,8 @@ abstract class DurableStateStoreSpec(config: Config)
       val pid2 = pid + "-2"
       val value1 = s"state-${pid}"
       val value2 = s"state-${pid2}"
-      Await.result(store.upsertObject(pid, 1L, value1, ""), timeout)
-      Await.result(store.upsertObject(pid2, 1L, value2, ""), timeout)
+      Await.result(store.upsertObject(pid, 1L, value1, "test-tag"), timeout)
+      Await.result(store.upsertObject(pid2, 1L, value2, "test-tag"), timeout)
 
       val result1 = Await.result(store.getObject(pid), timeout)
       val result2 = Await.result(store.getObject(pid2), timeout)
@@ -118,7 +118,7 @@ abstract class DurableStateStoreSpec(config: Config)
       "fail to delete a state when the revision does not match" in {
         val store = durableStateStore()
         val value = s"state-${pid}"
-        Await.result(store.upsertObject(pid, 1L, value, ""), timeout)
+        Await.result(store.upsertObject(pid, 1L, value, "test-tag"), timeout)
         val deleteResult = store.deleteObject(pid, 99L)
         intercept[Exception] {
           Await.result(deleteResult, timeout)

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
@@ -8,7 +8,7 @@
  */
 
 /*
- * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package org.apache.pekko.persistence.state

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
@@ -13,22 +13,31 @@
 
 package org.apache.pekko.persistence.state
 
+import scala.annotation.nowarn
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.actor.ActorSystem
-import pekko.persistence.CapabilityFlag
-import pekko.persistence.DurableStateStoreCapabilityFlags
-import pekko.persistence.PluginSpec
+import pekko.persistence._
 import pekko.persistence.scalatest.{ MayVerb, OptionalTests }
 import pekko.persistence.state.scaladsl.DurableStateUpdateStore
+import pekko.testkit.TestProbe
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
 object DurableStateStoreSpec {
-  val config: Config = ConfigFactory.empty()
+  val config: Config = ConfigFactory.parseString(s"""
+    pekko.actor {
+      serializers {
+        durable-state-tck-test = "${classOf[TestSerializer].getName}"
+      }
+      serialization-bindings {
+        "${classOf[TestPayload].getName}" = durable-state-tck-test
+      }
+    }
+    """)
 }
 
 /**
@@ -54,6 +63,25 @@ abstract class DurableStateStoreSpec(config: Config)
 
   override protected def supportsDeleteWithRevisionCheck: CapabilityFlag = CapabilityFlag.off()
 
+  override protected def supportsUpsertWithRevisionCheck: CapabilityFlag = CapabilityFlag.off()
+
+  override protected def supportsSerialization: CapabilityFlag = CapabilityFlag.on()
+
+  override protected def supportsSoftDelete: CapabilityFlag = CapabilityFlag.off()
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    preparePersistenceId(pid)
+  }
+
+  /**
+   * Overridable hook that is called before each test case.
+   * `pid` is the `persistenceId` that will be used in the test.
+   * This method may be needed to clean any pre-existing state from the store,
+   * for example when running against a shared external database.
+   */
+  def preparePersistenceId(@nowarn("msg=never used") pid: String): Unit = ()
+
   /**
    * Returns the `DurableStateUpdateStore` under test. By default, this uses the plugin
    * configured under `pekko.persistence.state.plugin` in the provided config.
@@ -61,7 +89,7 @@ abstract class DurableStateStoreSpec(config: Config)
   def durableStateStore(): DurableStateUpdateStore[Any] =
     DurableStateStoreRegistry(system).durableStateStoreFor[DurableStateUpdateStore[Any]]("")
 
-  private val timeout = 3.seconds
+  protected val timeout: FiniteDuration = 5.seconds
 
   "A durable state store" must {
     "not find a non-existing object" in {
@@ -111,6 +139,18 @@ abstract class DurableStateStoreSpec(config: Config)
       result1.value shouldBe Some(value1)
       result2.value shouldBe Some(value2)
     }
+
+    "upsert again after a deletion" in {
+      val store = durableStateStore()
+      val original = s"state-${pid}"
+      val recreated = s"state-${pid}-v2"
+      Await.result(store.upsertObject(pid, 1L, original, "test-tag"), timeout)
+      Await.result(store.deleteObject(pid, 2L), timeout)
+      Await.result(store.upsertObject(pid, 3L, recreated, "test-tag"), timeout)
+      val result = Await.result(store.getObject(pid), timeout)
+      result.value shouldBe Some(recreated)
+      result.revision shouldBe 3L
+    }
   }
 
   "A durable state store optionally".may {
@@ -127,6 +167,49 @@ abstract class DurableStateStoreSpec(config: Config)
         val result = Await.result(store.getObject(pid), timeout)
         result.value shouldBe Some(value)
         result.revision shouldBe 1L
+      }
+    }
+
+    optional(flag = supportsUpsertWithRevisionCheck) {
+      "fail to upsert a state when the revision is stale" in {
+        val store = durableStateStore()
+        val original = s"state-${pid}"
+        val stale = s"state-${pid}-stale"
+        Await.result(store.upsertObject(pid, 1L, original, "test-tag"), timeout)
+        // Re-using revision 1 should be rejected; the next valid revision is 2.
+        val staleUpsert = store.upsertObject(pid, 1L, stale, "test-tag")
+        intercept[Exception] {
+          Await.result(staleUpsert, timeout)
+        }
+        // The original state should still be accessible
+        val result = Await.result(store.getObject(pid), timeout)
+        result.value shouldBe Some(original)
+        result.revision shouldBe 1L
+      }
+    }
+
+    optional(flag = supportsSerialization) {
+      "serialize and deserialize values via the configured serializer" in {
+        val store = durableStateStore()
+        val probe = TestProbe()
+        val value = TestPayload(probe.ref)
+        Await.result(store.upsertObject(pid, 1L, value, "test-tag"), timeout)
+        val result = Await.result(store.getObject(pid), timeout)
+        result.value shouldBe Some(value)
+        result.revision shouldBe 1L
+      }
+    }
+
+    optional(flag = supportsSoftDelete) {
+      "delete a state via the deprecated deleteObject overload" in {
+        val store = durableStateStore()
+        val value = s"state-${pid}"
+        Await.result(store.upsertObject(pid, 1L, value, "test-tag"), timeout)
+        @nowarn("cat=deprecation")
+        val deleteResult = store.deleteObject(pid)
+        Await.result(deleteResult, timeout)
+        val result = Await.result(store.getObject(pid), timeout)
+        result.value shouldBe None
       }
     }
   }

--- a/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreTCKSpec.scala
+++ b/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreTCKSpec.scala
@@ -1,10 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.pekko.persistence.testkit.state.scaladsl

--- a/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreTCKSpec.scala
+++ b/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreTCKSpec.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package org.apache.pekko.persistence.testkit.state.scaladsl
+
+import org.apache.pekko
+import pekko.persistence.CapabilityFlag
+import pekko.persistence.state.DurableStateStoreSpec
+import pekko.persistence.testkit.PersistenceTestKitDurableStateStorePlugin
+
+import com.typesafe.config.ConfigFactory
+
+object PersistenceTestKitDurableStateStoreTCKSpec {
+  val config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString("""
+    pekko.loglevel = DEBUG
+    """))
+}
+
+class PersistenceTestKitDurableStateStoreTCKSpec
+    extends DurableStateStoreSpec(PersistenceTestKitDurableStateStoreTCKSpec.config) {
+  override protected def supportsDeleteWithRevisionCheck: CapabilityFlag = CapabilityFlag.off()
+}

--- a/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreTCKSpec.scala
+++ b/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreTCKSpec.scala
@@ -33,4 +33,5 @@ object PersistenceTestKitDurableStateStoreTCKSpec {
 class PersistenceTestKitDurableStateStoreTCKSpec
     extends DurableStateStoreSpec(PersistenceTestKitDurableStateStoreTCKSpec.config) {
   override protected def supportsDeleteWithRevisionCheck: CapabilityFlag = CapabilityFlag.off()
+  override protected def supportsSerialization: CapabilityFlag = CapabilityFlag.off()
 }


### PR DESCRIPTION
## Summary

Enhances the AI-drafted `DurableStateStore` TCK from #2833 to address the gaps
discussed in #2831 — specifically optimistic-concurrency checks, serialization
roundtrip, and the deprecated soft-delete overload.

This PR supersedes #2833. The first three commits are @pjfanning's original
work cherry-picked unchanged; the fourth commit layers the enhancements on top.

## Changes

### Capability flags (`CapabilityFlags.scala`)

`DurableStateStoreCapabilityFlags` extended with three new flags:

- **`supportsUpsertWithRevisionCheck`** — when on, asserts that an upsert with
  a stale revision is rejected and the prior state is preserved.
- **`supportsSerialization`** — when on, asserts that values roundtrip through
  the configured Pekko serializer using the same `TestPayload(probe.ref)`
  pattern as `JournalSpec`. Defaults to **`on`** in `DurableStateStoreSpec` to
  match the `JournalSpec` convention; the in-memory testkit reference TCK
  explicitly overrides to `off` since the testkit holds raw refs.
- **`supportsSoftDelete`** — when on, asserts the deprecated single-argument
  `deleteObject(persistenceId)` overload deletes regardless of revision.

### Spec additions (`DurableStateStoreSpec.scala`)

- New required test: **"upsert again after a deletion"** — ensures the store
  accepts a fresh upsert at a higher revision after a delete.
- New optional tests behind each new capability flag.
- New `preparePersistenceId(pid: String)` hook called from `beforeEach`,
  mirroring `JournalSpec`. Plugins backed by external state (JDBC, NATS, etc.)
  can override this to clean residual records between tests.
- Test `timeout` promoted to `protected` so subclasses can override for slow
  stores.

### Reference TCK (`PersistenceTestKitDurableStateStoreTCKSpec.scala`)

Added an explicit `supportsSerialization = off` override since the in-memory
testkit doesn't serialize values.

### Docs (`persistence-journals.md` + doc-test files)

Added a brief subsection in the `## Plugin TCK` section mirroring the
Journal/Snapshot pattern, with `#durable-state-tck-scala` and
`#durable-state-tck-java` snippet markers.

## Deferred for follow-up

These ideas surfaced during this work but were deliberately scoped out:

- **Query-by-tag roundtrip** — verify a tag passed to `upsertObject` is
  retrievable via `DurableStateStoreQuery.changes(...)`. Requires extending the
  TCK to cover the read-side query SPI.
- **Get-after-delete revision contract** — current tests assert `value=None`
  after delete but not what `revision` should be (impls differ; needs a
  committer decision).
- **Idempotent upsert** — repeating `upsertObject(pid, N, sameValue, tag)` for
  replay safety.
- **Slice-based query roundtrip** (`DurableStateStoreBySliceQuery`).
- **Paged persistence-ID enumeration** (`DurableStateStorePagedPersistenceIdsQuery`).

Happy to open follow-up PRs once this lands.

## Test plan

- [x] `sbt scalafmtCheckAll` — clean
- [x] `sbt persistence-tck/Test/compile docs/Test/compile` — clean
- [x] `sbt "persistence-testkit/Test/testOnly *PersistenceTestKitDurableStateStoreTCKSpec"` —
  6/6 required tests pass; 4 optional skip as expected (testkit doesn't enforce
  OCC, doesn't serialize, has a no-op `deleteObject(pid)`).

Closes #2831.