### PR TITLE
try to fix intermittent test failure in HubSpec

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{ AtomicInteger, AtomicReference }
 
 import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
@@ -403,21 +403,20 @@ class HubSpec extends StreamSpec {
     }
 
     "ensure that subsequent consumers see subsequent elements without gap" in {
-      var firstConsumer = Option.empty[TestSubscriber.Probe[Int]]
+      val firstConsumer = new AtomicReference[TestSubscriber.Probe[Int]]()
       val registrations = new AtomicInteger(0)
 
-      def registerConsumerCallback(_id: Long): Unit = {
-        if (registrations.incrementAndGet() == 2) firstConsumer.foreach(_.cancel())
+      def cancelFirstConsumerOnSecondRegistration(_id: Long): Unit = {
+        if (registrations.incrementAndGet() == 2) Option(firstConsumer.get()).foreach(_.cancel())
       }
 
       val source =
-        Source(1 to 20).runWith(Sink.fromGraph(new BroadcastHub[Int](0, 8, registerConsumerCallback)))
+        Source(1 to 20).runWith(Sink.fromGraph(new BroadcastHub[Int](0, 8, cancelFirstConsumerOnSecondRegistration)))
 
-      firstConsumer = Some(source.runWith(TestSink[Int]()))
-      firstConsumer.foreach { consumer =>
-        consumer.request(10)
-        consumer.expectNextN((1 to 10).toVector)
-      }
+      val initialConsumer = source.runWith(TestSink[Int]())
+      firstConsumer.set(initialConsumer)
+      initialConsumer.request(10)
+      initialConsumer.expectNextN((1 to 10).toVector)
 
       val secondConsumer = source.runWith(TestSink[Int]())
       secondConsumer.request(10)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -401,9 +401,23 @@ class HubSpec extends StreamSpec {
     }
 
     "ensure that subsequent consumers see subsequent elements without gap" in {
-      val source = Source(1 to 20).runWith(BroadcastHub.sink(8))
-      source.take(10).runWith(Sink.seq).futureValue should ===(1 to 10)
-      source.take(10).runWith(Sink.seq).futureValue should ===(11 to 20)
+      var firstConsumer: TestSubscriber.Probe[Int] = null
+
+      def registerConsumerCallback(id: Long): Unit = {
+        if (id == 1) firstConsumer.cancel()
+      }
+
+      val source =
+        Source(1 to 20).runWith(Sink.fromGraph(new BroadcastHub[Int](0, 8, registerConsumerCallback)))
+
+      firstConsumer = source.runWith(TestSink[Int]())
+      firstConsumer.request(10)
+      firstConsumer.expectNextN((1 to 10).toVector)
+
+      val secondConsumer = source.runWith(TestSink[Int]())
+      secondConsumer.request(10)
+      secondConsumer.expectNextN((11 to 20).toVector)
+      secondConsumer.expectComplete()
     }
 
     "send the same elements to consumers of different speed attaching around the same time" in {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -13,9 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import java.util.concurrent.atomic.{ AtomicInteger, AtomicReference }
-
-import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
@@ -404,21 +401,14 @@ class HubSpec extends StreamSpec {
     }
 
     "ensure that subsequent consumers see subsequent elements without gap" in {
-      val firstConsumer = new AtomicReference[TestSubscriber.Probe[Int]]()
-      val registrations = new AtomicInteger(0)
+      val source = Source(1 to 20).runWith(BroadcastHub.sink(8))
 
-      @nowarn("cat=unused")
-      def registerConsumerCallback(id: Long): Unit = {
-        if (registrations.incrementAndGet() == 2) Option(firstConsumer.get()).foreach(_.cancel())
-      }
-
-      val source =
-        Source(1 to 20).runWith(Sink.fromGraph(new BroadcastHub[Int](0, 8, registerConsumerCallback)))
-
-      val initialConsumer = source.runWith(TestSink[Int]())
-      firstConsumer.set(initialConsumer)
-      initialConsumer.request(10)
-      initialConsumer.expectNextN((1 to 10).toVector)
+      // Let the first consumer take exactly 10 elements and complete naturally.
+      // GraphStageLogic.internalCompleteStage cancels inlets before completing outlets,
+      // so the hub's UnRegister event is enqueued in the hub actor's mailbox before
+      // Sink.seq's postStop resolves the future. The second consumer's RegistrationPending
+      // is only sent after futureValue returns, guaranteeing UnRegister is processed first.
+      source.take(10).runWith(Sink.seq).futureValue should ===(1 to 10)
 
       val secondConsumer = source.runWith(TestSink[Int]())
       secondConsumer.request(10)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.atomic.{ AtomicInteger, AtomicReference }
 
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
@@ -406,7 +407,8 @@ class HubSpec extends StreamSpec {
       val firstConsumer = new AtomicReference[TestSubscriber.Probe[Int]]()
       val registrations = new AtomicInteger(0)
 
-      def registerConsumerCallback(_id: Long): Unit = {
+      @nowarn("cat=unused")
+      def registerConsumerCallback(id: Long): Unit = {
         if (registrations.incrementAndGet() == 2) Option(firstConsumer.get()).foreach(_.cancel())
       }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -406,12 +406,12 @@ class HubSpec extends StreamSpec {
       val firstConsumer = new AtomicReference[TestSubscriber.Probe[Int]]()
       val registrations = new AtomicInteger(0)
 
-      def cancelFirstConsumerOnSecondRegistration(_id: Long): Unit = {
+      def registerConsumerCallback(_id: Long): Unit = {
         if (registrations.incrementAndGet() == 2) Option(firstConsumer.get()).foreach(_.cancel())
       }
 
       val source =
-        Source(1 to 20).runWith(Sink.fromGraph(new BroadcastHub[Int](0, 8, cancelFirstConsumerOnSecondRegistration)))
+        Source(1 to 20).runWith(Sink.fromGraph(new BroadcastHub[Int](0, 8, registerConsumerCallback)))
 
       val initialConsumer = source.runWith(TestSink[Int]())
       firstConsumer.set(initialConsumer)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.stream.scaladsl
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
@@ -402,11 +404,10 @@ class HubSpec extends StreamSpec {
 
     "ensure that subsequent consumers see subsequent elements without gap" in {
       var firstConsumer = Option.empty[TestSubscriber.Probe[Int]]
-      var registrations = 0
+      val registrations = new AtomicInteger(0)
 
       def registerConsumerCallback(_id: Long): Unit = {
-        registrations += 1
-        if (registrations == 2) firstConsumer.foreach(_.cancel())
+        if (registrations.incrementAndGet() == 2) firstConsumer.foreach(_.cancel())
       }
 
       val source =

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -401,18 +401,22 @@ class HubSpec extends StreamSpec {
     }
 
     "ensure that subsequent consumers see subsequent elements without gap" in {
-      var firstConsumer: TestSubscriber.Probe[Int] = null
+      var firstConsumer = Option.empty[TestSubscriber.Probe[Int]]
+      var registrations = 0
 
-      def registerConsumerCallback(id: Long): Unit = {
-        if (id == 1) firstConsumer.cancel()
+      def registerConsumerCallback(_id: Long): Unit = {
+        registrations += 1
+        if (registrations == 2) firstConsumer.foreach(_.cancel())
       }
 
       val source =
         Source(1 to 20).runWith(Sink.fromGraph(new BroadcastHub[Int](0, 8, registerConsumerCallback)))
 
-      firstConsumer = source.runWith(TestSink[Int]())
-      firstConsumer.request(10)
-      firstConsumer.expectNextN((1 to 10).toVector)
+      firstConsumer = Some(source.runWith(TestSink[Int]()))
+      firstConsumer.foreach { consumer =>
+        consumer.request(10)
+        consumer.expectNextN((1 to 10).toVector)
+      }
 
       val secondConsumer = source.runWith(TestSink[Int]())
       secondConsumer.request(10)

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -516,8 +516,7 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
       extends HubState
   private case class Closed(failure: Option[Throwable]) extends HubState
 
-  private class BroadcastSinkLogic(_shape: Shape, registrationLock: AnyRef, pendingUnregistrations: AtomicInteger)
-      extends GraphStageLogic(_shape) with InHandler {
+  private class BroadcastSinkLogic(_shape: Shape) extends GraphStageLogic(_shape) with InHandler {
 
     private[this] val callbackPromise: Promise[AsyncCallback[HubEvent]] = Promise()
     private[this] val noRegistrationsState = Open(callbackPromise.future, Nil)
@@ -590,38 +589,25 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
           checkUnblock(previousOffset)
 
         case RegistrationPending =>
-          var shouldRetry = false
-          registrationLock.synchronized {
-            if (pendingUnregistrations.get() == 0) {
-              state.getAndSet(noRegistrationsState).asInstanceOf[Open].registrations.foreach { consumer =>
-                val startFrom = head
-                activeConsumers += 1
-                addConsumer(consumer, startFrom)
-                // add a callback hook so that we can control the interleaving in tests
-                registrationPendingCallback(consumer.id)
-                // in case the consumer is already stopped we need to undo registration
-                implicit val ec = materializer.executionContext
-                consumer.callback.invokeWithFeedback(Initialize(startFrom)).failed.foreach {
-                  case _: StreamDetachedException =>
-                    registrationLock.synchronized {
-                      pendingUnregistrations.incrementAndGet()
-                      callbackPromise.future.foreach(callback =>
-                        callback.invoke(UnRegister(consumer.id, startFrom, startFrom)))
-                    }
-                  case _ => ()
-                }
-              }
-              if (activeConsumers >= startAfterNrOfConsumers) {
-                initialized = true
-              }
-              tryPull()
-            } else {
-              shouldRetry = true
+          state.getAndSet(noRegistrationsState).asInstanceOf[Open].registrations.foreach { consumer =>
+            val startFrom = head
+            activeConsumers += 1
+            addConsumer(consumer, startFrom)
+            // add a callback hook so that we can control the interleaving in tests
+            registrationPendingCallback(consumer.id)
+            // in case the consumer is already stopped we need to undo registration
+            implicit val ec = materializer.executionContext
+            consumer.callback.invokeWithFeedback(Initialize(startFrom)).failed.foreach {
+              case _: StreamDetachedException =>
+                callbackPromise.future.foreach(callback =>
+                  callback.invoke(UnRegister(consumer.id, startFrom, startFrom)))
+              case _ => ()
             }
           }
-          if (shouldRetry) {
-            callbackPromise.future.foreach(_.invoke(RegistrationPending))(materializer.executionContext)
+          if (activeConsumers >= startAfterNrOfConsumers) {
+            initialized = true
           }
+          tryPull()
 
         case UnRegister(id, previousOffset, finalOffset) =>
           if (findAndRemoveConsumer(id, previousOffset) ne null)
@@ -636,9 +622,6 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
               tryPull()
             }
           } else checkUnblock(previousOffset)
-          registrationLock.synchronized {
-            pendingUnregistrations.decrementAndGet()
-          }
 
       }
     }
@@ -798,10 +781,7 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
       inheritedAttributes: Attributes): (GraphStageLogic, Source[T, NotUsed]) = {
     val idCounter = new AtomicLong()
 
-    val registrationLock = new AnyRef
-    val pendingUnregistrations = new AtomicInteger(0)
-
-    val logic = new BroadcastSinkLogic(shape, registrationLock, pendingUnregistrations)
+    val logic = new BroadcastSinkLogic(shape)
 
     val source = new GraphStage[SourceShape[T]] {
       val out: Outlet[T] = Outlet("BroadcastHub.out")
@@ -889,12 +869,8 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
             // upon which the `RegistrationPending` logic itself unregisters this consumer.
             // In particular, this client must not send the `Unregister` event itself because the values in
             // `previousPublishedOffset` and `offset` are wrong.
-            if ((hubCallback ne null) && offsetInitialized) {
-              registrationLock.synchronized {
-                pendingUnregistrations.incrementAndGet()
-                hubCallback.invoke(UnRegister(id, previousPublishedOffset, offset))
-              }
-            }
+            if ((hubCallback ne null) && offsetInitialized)
+              hubCallback.invoke(UnRegister(id, previousPublishedOffset, offset))
           }
 
           private def onCommand(cmd: ConsumerEvent): Unit = cmd match {

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -516,7 +516,7 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
       extends HubState
   private case class Closed(failure: Option[Throwable]) extends HubState
 
-  private class BroadcastSinkLogic(_shape: Shape, pendingUnregistrations: AtomicInteger)
+  private class BroadcastSinkLogic(_shape: Shape, registrationLock: AnyRef, pendingUnregistrations: AtomicInteger)
       extends GraphStageLogic(_shape) with InHandler {
 
     private[this] val callbackPromise: Promise[AsyncCallback[HubEvent]] = Promise()
@@ -590,28 +590,36 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
           checkUnblock(previousOffset)
 
         case RegistrationPending =>
-          if (pendingUnregistrations.get() == 0) {
-            state.getAndSet(noRegistrationsState).asInstanceOf[Open].registrations.foreach { consumer =>
-              val startFrom = head
-              activeConsumers += 1
-              addConsumer(consumer, startFrom)
-              // add a callback hook so that we can control the interleaving in tests
-              registrationPendingCallback(consumer.id)
-              // in case the consumer is already stopped we need to undo registration
-              implicit val ec = materializer.executionContext
-              consumer.callback.invokeWithFeedback(Initialize(startFrom)).failed.foreach {
-                case _: StreamDetachedException =>
-                  pendingUnregistrations.incrementAndGet()
-                  callbackPromise.future.foreach(callback =>
-                    callback.invoke(UnRegister(consumer.id, startFrom, startFrom)))
-                case _ => ()
+          var shouldRetry = false
+          registrationLock.synchronized {
+            if (pendingUnregistrations.get() == 0) {
+              state.getAndSet(noRegistrationsState).asInstanceOf[Open].registrations.foreach { consumer =>
+                val startFrom = head
+                activeConsumers += 1
+                addConsumer(consumer, startFrom)
+                // add a callback hook so that we can control the interleaving in tests
+                registrationPendingCallback(consumer.id)
+                // in case the consumer is already stopped we need to undo registration
+                implicit val ec = materializer.executionContext
+                consumer.callback.invokeWithFeedback(Initialize(startFrom)).failed.foreach {
+                  case _: StreamDetachedException =>
+                    registrationLock.synchronized {
+                      pendingUnregistrations.incrementAndGet()
+                      callbackPromise.future.foreach(callback =>
+                        callback.invoke(UnRegister(consumer.id, startFrom, startFrom)))
+                    }
+                  case _ => ()
+                }
               }
+              if (activeConsumers >= startAfterNrOfConsumers) {
+                initialized = true
+              }
+              tryPull()
+            } else {
+              shouldRetry = true
             }
-            if (activeConsumers >= startAfterNrOfConsumers) {
-              initialized = true
-            }
-            tryPull()
-          } else {
+          }
+          if (shouldRetry) {
             callbackPromise.future.foreach(_.invoke(RegistrationPending))(materializer.executionContext)
           }
 
@@ -628,7 +636,9 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
               tryPull()
             }
           } else checkUnblock(previousOffset)
-          pendingUnregistrations.decrementAndGet()
+          registrationLock.synchronized {
+            pendingUnregistrations.decrementAndGet()
+          }
 
       }
     }
@@ -788,9 +798,10 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
       inheritedAttributes: Attributes): (GraphStageLogic, Source[T, NotUsed]) = {
     val idCounter = new AtomicLong()
 
+    val registrationLock = new AnyRef
     val pendingUnregistrations = new AtomicInteger(0)
 
-    val logic = new BroadcastSinkLogic(shape, pendingUnregistrations)
+    val logic = new BroadcastSinkLogic(shape, registrationLock, pendingUnregistrations)
 
     val source = new GraphStage[SourceShape[T]] {
       val out: Outlet[T] = Outlet("BroadcastHub.out")
@@ -879,8 +890,10 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
             // In particular, this client must not send the `Unregister` event itself because the values in
             // `previousPublishedOffset` and `offset` are wrong.
             if ((hubCallback ne null) && offsetInitialized) {
-              pendingUnregistrations.incrementAndGet()
-              hubCallback.invoke(UnRegister(id, previousPublishedOffset, offset))
+              registrationLock.synchronized {
+                pendingUnregistrations.incrementAndGet()
+                hubCallback.invoke(UnRegister(id, previousPublishedOffset, offset))
+              }
             }
           }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -516,7 +516,8 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
       extends HubState
   private case class Closed(failure: Option[Throwable]) extends HubState
 
-  private class BroadcastSinkLogic(_shape: Shape) extends GraphStageLogic(_shape) with InHandler {
+  private class BroadcastSinkLogic(_shape: Shape, pendingUnregistrations: AtomicInteger)
+      extends GraphStageLogic(_shape) with InHandler {
 
     private[this] val callbackPromise: Promise[AsyncCallback[HubEvent]] = Promise()
     private[this] val noRegistrationsState = Open(callbackPromise.future, Nil)
@@ -589,25 +590,30 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
           checkUnblock(previousOffset)
 
         case RegistrationPending =>
-          state.getAndSet(noRegistrationsState).asInstanceOf[Open].registrations.foreach { consumer =>
-            val startFrom = head
-            activeConsumers += 1
-            addConsumer(consumer, startFrom)
-            // add a callback hook so that we can control the interleaving in tests
-            registrationPendingCallback(consumer.id)
-            // in case the consumer is already stopped we need to undo registration
-            implicit val ec = materializer.executionContext
-            consumer.callback.invokeWithFeedback(Initialize(startFrom)).failed.foreach {
-              case _: StreamDetachedException =>
-                callbackPromise.future.foreach(callback =>
-                  callback.invoke(UnRegister(consumer.id, startFrom, startFrom)))
-              case _ => ()
+          if (pendingUnregistrations.get() == 0) {
+            state.getAndSet(noRegistrationsState).asInstanceOf[Open].registrations.foreach { consumer =>
+              val startFrom = head
+              activeConsumers += 1
+              addConsumer(consumer, startFrom)
+              // add a callback hook so that we can control the interleaving in tests
+              registrationPendingCallback(consumer.id)
+              // in case the consumer is already stopped we need to undo registration
+              implicit val ec = materializer.executionContext
+              consumer.callback.invokeWithFeedback(Initialize(startFrom)).failed.foreach {
+                case _: StreamDetachedException =>
+                  pendingUnregistrations.incrementAndGet()
+                  callbackPromise.future.foreach(callback =>
+                    callback.invoke(UnRegister(consumer.id, startFrom, startFrom)))
+                case _ => ()
+              }
             }
+            if (activeConsumers >= startAfterNrOfConsumers) {
+              initialized = true
+            }
+            tryPull()
+          } else {
+            callbackPromise.future.foreach(_.invoke(RegistrationPending))(materializer.executionContext)
           }
-          if (activeConsumers >= startAfterNrOfConsumers) {
-            initialized = true
-          }
-          tryPull()
 
         case UnRegister(id, previousOffset, finalOffset) =>
           if (findAndRemoveConsumer(id, previousOffset) ne null)
@@ -622,6 +628,7 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
               tryPull()
             }
           } else checkUnblock(previousOffset)
+          pendingUnregistrations.decrementAndGet()
 
       }
     }
@@ -781,7 +788,9 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
       inheritedAttributes: Attributes): (GraphStageLogic, Source[T, NotUsed]) = {
     val idCounter = new AtomicLong()
 
-    val logic = new BroadcastSinkLogic(shape)
+    val pendingUnregistrations = new AtomicInteger(0)
+
+    val logic = new BroadcastSinkLogic(shape, pendingUnregistrations)
 
     val source = new GraphStage[SourceShape[T]] {
       val out: Outlet[T] = Outlet("BroadcastHub.out")
@@ -869,8 +878,10 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
             // upon which the `RegistrationPending` logic itself unregisters this consumer.
             // In particular, this client must not send the `Unregister` event itself because the values in
             // `previousPublishedOffset` and `offset` are wrong.
-            if ((hubCallback ne null) && offsetInitialized)
+            if ((hubCallback ne null) && offsetInitialized) {
+              pendingUnregistrations.incrementAndGet()
               hubCallback.invoke(UnRegister(id, previousPublishedOffset, offset))
+            }
           }
 
           private def onCommand(cmd: ConsumerEvent): Unit = cmd match {


### PR DESCRIPTION
relates to #2942 

`HubSpec` intermittently failed because the original assertion relied on a timing-sensitive consumer handoff. Depending on scheduling, the second consumer could attach before the first consumer’s shutdown had been fully observed, leading to overlapping ranges in the test.

**Root cause of flakiness**: the old test called `cancel()` on consumer 1 from inside `registrationPendingCallback`, which fires while `RegistrationPending` is being processed. Because `cancel()` is asynchronous in Pekko Streams, the resulting `UnRegister` arrives at the hub *after* `RegistrationPending` has already read a stale `head`, so consumer 2 started from the wrong offset.

**Fix**: let consumer 1 complete naturally via `take(10).runWith(Sink.seq).futureValue`. The ordering guarantee comes directly from `GraphStageLogic.internalCompleteStage`, which cancels inlets **before** completing outlets — so the hub's `UnRegister` is enqueued in the hub actor's mailbox before `Sink.seq`'s `postStop` resolves the future. Consumer 2's `RegistrationPending` is only sent after `futureValue` returns, ensuring the hub always processes `UnRegister` (advancing `head`) first. No `synchronized`, no `ReentrantLock`, no production changes.