### PR TITLE
perf: fast path getShort/Int/Long in MultiByteArrayIterator

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteIteratorSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteIteratorSpec.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.util
 
+import java.nio.ByteOrder
+
 import org.apache.pekko.util.ByteIterator.ByteArrayIterator
 
 import org.scalatest.matchers.should.Matchers
@@ -42,6 +44,47 @@ class ByteIteratorSpec extends AnyWordSpec with Matchers {
       otherIndexOf(freshIterator(), 0x20, 1) should be(1)
       otherIndexOf(freshIterator(), 0x10, 1) should be(2)
       otherIndexOf(freshIterator(), 0x10, 3) should be(5)
+    }
+
+    "match ByteArrayIterator semantics for getShort/Int/Long across both fast and cross-fragment paths" in {
+      // 16 bytes is large enough to fit a long (8B) entirely inside one fragment for the fast
+      // path AND to span every possible split for the cross-fragment path.
+      val bytes = Array.tabulate[Byte](16)(i => ((i * 31 + 7) & 0xFF).toByte)
+
+      def reference(off: Int, byteOrder: ByteOrder): (Short, Int, Long) = {
+        val it = ByteArrayIterator(bytes).drop(off)
+        val s = it.clone().getShort(byteOrder)
+        val i = it.clone().getInt(byteOrder)
+        val l = it.clone().getLong(byteOrder)
+        (s, i, l)
+      }
+
+      // Build a multi-fragment ByteString for every split point and read at every offset.
+      // Splits 1..15 produce two non-empty fragments; the .iterator on the result is a
+      // MultiByteArrayIterator. Reads where (off, off+primitiveSize) lies entirely inside
+      // a single fragment exercise the fast path; reads that straddle exercise super.
+      for (split <- 1 until bytes.length) {
+        val left = ByteString.fromArray(bytes, 0, split)
+        val right = ByteString.fromArray(bytes, split, bytes.length - split)
+        val combined = left ++ right
+
+        for (byteOrder <- Seq(ByteOrder.BIG_ENDIAN, ByteOrder.LITTLE_ENDIAN)) {
+          implicit val bo: ByteOrder = byteOrder
+          for (off <- 0 to bytes.length - java.lang.Long.BYTES) {
+            val (refS, refI, refL) = reference(off, byteOrder)
+
+            withClue(s"split=$split, off=$off, byteOrder=$byteOrder, getShort: ") {
+              combined.iterator.drop(off).getShort shouldEqual refS
+            }
+            withClue(s"split=$split, off=$off, byteOrder=$byteOrder, getInt: ") {
+              combined.iterator.drop(off).getInt shouldEqual refI
+            }
+            withClue(s"split=$split, off=$off, byteOrder=$byteOrder, getLong: ") {
+              combined.iterator.drop(off).getLong shouldEqual refL
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/actor/src/main/scala-2.13/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-2.13/org/apache/pekko/util/ByteIterator.scala
@@ -254,6 +254,36 @@ object ByteIterator {
       result
     }
 
+    // Fast path: when the current fragment has enough bytes for the requested primitive, delegate
+    // to the current ByteArrayIterator (which uses SWARUtil for a single read) instead of falling
+    // back to the byte-by-byte super impl. Cross-fragment reads keep the byte-by-byte path.
+    override def getShort(implicit byteOrder: ByteOrder): Short = {
+      val cur = current
+      if (cur.len >= java.lang.Short.BYTES) {
+        val r = cur.getShort(byteOrder)
+        normalize()
+        r
+      } else super.getShort(byteOrder)
+    }
+
+    override def getInt(implicit byteOrder: ByteOrder): Int = {
+      val cur = current
+      if (cur.len >= java.lang.Integer.BYTES) {
+        val r = cur.getInt(byteOrder)
+        normalize()
+        r
+      } else super.getInt(byteOrder)
+    }
+
+    override def getLong(implicit byteOrder: ByteOrder): Long = {
+      val cur = current
+      if (cur.len >= java.lang.Long.BYTES) {
+        val r = cur.getLong(byteOrder)
+        normalize()
+        r
+      } else super.getLong(byteOrder)
+    }
+
     final override def len: Int = iterators.foldLeft(0) { _ + _.len }
 
     final override def size: Int = {

--- a/actor/src/main/scala-3/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/ByteIterator.scala
@@ -250,6 +250,36 @@ object ByteIterator {
       result
     }
 
+    // Fast path: when the current fragment has enough bytes for the requested primitive, delegate
+    // to the current ByteArrayIterator (which uses SWARUtil for a single read) instead of falling
+    // back to the byte-by-byte super impl. Cross-fragment reads keep the byte-by-byte path.
+    override def getShort(implicit byteOrder: ByteOrder): Short = {
+      val cur = current
+      if (cur.len >= java.lang.Short.BYTES) {
+        val r = cur.getShort(byteOrder)
+        normalize()
+        r
+      } else super.getShort(byteOrder)
+    }
+
+    override def getInt(implicit byteOrder: ByteOrder): Int = {
+      val cur = current
+      if (cur.len >= java.lang.Integer.BYTES) {
+        val r = cur.getInt(byteOrder)
+        normalize()
+        r
+      } else super.getInt(byteOrder)
+    }
+
+    override def getLong(implicit byteOrder: ByteOrder): Long = {
+      val cur = current
+      if (cur.len >= java.lang.Long.BYTES) {
+        val r = cur.getLong(byteOrder)
+        normalize()
+        r
+      } else super.getLong(byteOrder)
+    }
+
     final override def len: Int = iterators.foldLeft(0) { _ + _.len }
 
     final override def size: Int = {


### PR DESCRIPTION
### Motivation

`MultiByteArrayIterator` (the iterator returned by multi-fragment `ByteString`s such as `ByteStrings` and the new `ByteString2`) inherits its `getShort/Int/Long` from `ByteIterator`, which always reads byte-by-byte through `getByte`. This skips the SWAR fast path that `ByteArrayIterator` already implements for the common case where the read fits entirely inside the current fragment.

For callers that hold a `MultiByteArrayIterator` and pull several primitives from it (codecs, framing parsers), every read pays the byte-loop overhead even though most reads do not actually cross a fragment boundary.

### Modification

Override `getShort`, `getInt`, and `getLong` on `MultiByteArrayIterator`:

- If the current `ByteArrayIterator` has at least the requested primitive's `BYTES` available, delegate to its SWAR-backed read and then call `normalize()` to advance over any now-empty current iterator.
- Otherwise fall back to `super.getShort/Int/Long`, which already handles cross-fragment reads correctly.

Mirrored to both `actor/src/main/scala-2.13/.../ByteIterator.scala` and `actor/src/main/scala-3/.../ByteIterator.scala`.

### Result

Reused multi-fragment iterators avoid the byte-by-byte loop when the read does not cross a fragment boundary. Cross-fragment reads keep the existing semantics. No public surface change; pure internal override of an existing method.

### Tests

Added `ByteIteratorSpec` case `match ByteArrayIterator semantics for getShort/Int/Long across both fast and cross-fragment paths` which, for a 16-byte source and every split point in `1..15`, asserts that `combined.iterator.drop(off).getShort/Int/Long` equals the `ByteArrayIterator` reference value at every offset and in both byte orders. This exercises both the new fast path (read fits in current fragment) and the inherited byte-by-byte path (read straddles fragments).

```
sbt 'project actor-tests' 'testOnly org.apache.pekko.util.ByteIteratorSpec'
[info] - should correctly implement indexOf
[info] - should match ByteArrayIterator semantics for getShort/Int/Long across both fast and cross-fragment paths
[info] Tests: succeeded 2, failed 0
```

`sbt 'project actor' 'mimaReportBinaryIssues'` clean.
`sbt scalafmtAll` and `sbt headerCreateAll` clean.

### References

Refs #2924 - follow-up extracted from the ByteString2 PR review.