### PR TITLE
chore: adjust snapshot retention warning

### DIFF
--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/BehaviorSetup.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/BehaviorSetup.scala
@@ -113,12 +113,11 @@ private[pekko] final class BehaviorSetup[C, E, S](
       case SnapshotCountRetentionCriteriaImpl(_, keepNSnapshots, _) if keepNSnapshots > 1 =>
         // not using internalLogger because it's probably not good to use mdc from the constructor
         internalLoggerFactory().warn(
-          "Retention has been defined with keepNSnapshots [{}] for persistenceId [{}]," +
-          "but the snapshot store [{}] will only keep one snapshot. You can silence this warning and benefit from " +
+          "Retention has been defined with keepNSnapshots [{}] for persistenceId [{}], " +
+          "but the snapshot store will only keep one snapshot. You can silence this warning and benefit from " +
           "a performance optimization by defining the retention criteria without the keepNSnapshots parameter.",
           keepNSnapshots,
-          persistenceId,
-          settings.snapshotPluginId)
+          persistenceId)
       case _ =>
     }
   }


### PR DESCRIPTION
### Motivation

Port upstream A commit https://github.com/akka/akka-core/commit/c8d9fb3e46cca930186d72de66100acf29b850fd, which is now Apache licensed. The warning for snapshot retention with a one-snapshot store had a small wording issue.

### Modification

Adjusted the warning text in `BehaviorSetup` so the sentence spacing is correct and the message no longer includes the snapshot store id placeholder.

### Result

The warning is clearer. There is no API or behavior change.

### Tests

- `git diff --check` / passed
- `scalafmt --mode diff-ref=origin/main` / passed
- `scalafmt --list --mode diff-ref=origin/main` / passed
- `sbt "persistence-typed / Test / compile"` / passed

### References

Refs https://github.com/akka/akka-core/commit/c8d9fb3e46cca930186d72de66100acf29b850fd
