### PR TITLE
chore: add Java external shard allocation factory

### DIFF
--- a/cluster-sharding-typed/src/test/java/jdocs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
+++ b/cluster-sharding-typed/src/test/java/jdocs/org/apache/pekko/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
@@ -15,7 +15,6 @@ package jdocs.org.apache.pekko.cluster.sharding.typed;
 
 import static jdocs.org.apache.pekko.cluster.sharding.typed.ShardingCompileOnlyTest.Counter;
 
-import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.Address;
@@ -43,8 +42,7 @@ public class ExternalShardAllocationCompileOnlyTest {
         sharding.init(
             Entity.of(typeKey, ctx -> Counter.create(ctx.getEntityId()))
                 .withAllocationStrategy(
-                    ExternalShardAllocationStrategy.create(
-                        system, typeKey.name(), Duration.ofSeconds(5))));
+                    ExternalShardAllocationStrategy.create(system, typeKey.name())));
     // #entity
 
     // #client

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -64,6 +64,12 @@ object ExternalShardAllocationStrategy {
   /**
    * Java API: Create an [[ExternalShardAllocationStrategy]]
    */
+  def create(systemProvider: ClassicActorSystemProvider, typeName: String): ExternalShardAllocationStrategy =
+    this.apply(systemProvider, typeName)
+
+  /**
+   * Java API: Create an [[ExternalShardAllocationStrategy]]
+   */
   def create(systemProvider: ClassicActorSystemProvider, typeName: String, timeout: java.time.Duration)
       : ExternalShardAllocationStrategy =
     this.apply(systemProvider, typeName, timeout.toScala)


### PR DESCRIPTION
### Motivation

Port upstream A commit https://github.com/akka/akka-core/commit/25dd5f7edaa72a28d4e5e26eb12f8f03b8803396, which is now Apache licensed. Java users should be able to create an `ExternalShardAllocationStrategy` with the default timeout just like the Scala API.

### Modification

Added `ExternalShardAllocationStrategy.create(systemProvider, typeName)` for Java callers and updated the Java compile-only example to use it.

### Result

Java and Scala factory APIs are aligned for the default-timeout case. Existing timeout-taking APIs remain unchanged.

### Tests

- `git diff --check` / passed
- `scalafmt --mode diff-ref=origin/main` / passed
- `scalafmt --list --mode diff-ref=origin/main` / passed
- JDK 17 `sbt "cluster-sharding-typed / javafmtAll"` / passed
- `sbt "cluster-sharding / Test / compile" "cluster-sharding-typed / Test / compile" "cluster-sharding / mimaReportBinaryIssues"` / passed
- `sbt "+ cluster-sharding / mimaReportBinaryIssues"` / passed

### References

Refs https://github.com/akka/akka-core/commit/25dd5f7edaa72a28d4e5e26eb12f8f03b8803396
