### PR TITLE
docs: document serializer constructor alternatives

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/serialization/Serializer.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/Serializer.scala
@@ -34,15 +34,19 @@ import pekko.util.ClassLoaderObjectInputStream
  * A Serializer represents a bimap between an object and an array of bytes representing that object.
  *
  * Serializers are loaded using reflection during [[pekko.actor.ActorSystem]]
- * start-up, where two constructors are tried in order:
+ * start-up, where constructors are tried in order:
  *
  * <ul>
  * <li>taking exactly one argument of type [[pekko.actor.ExtendedActorSystem]];
  * this should be the preferred one because all reflective loading of classes
  * during deserialization should use ExtendedActorSystem.dynamicAccess (see
- * [[pekko.actor.DynamicAccess]]), and</li>
- * <li>without arguments, which is only an option if the serializer does not
- * load classes using reflection.</li>
+ * [[pekko.actor.DynamicAccess]])</li>
+ * <li>taking exactly one argument of type [[pekko.actor.ActorSystem]]</li>
+ * <li>taking exactly one argument of type [[pekko.actor.ClassicActorSystemProvider]]</li>
+ * <li>without arguments</li>
+ * <li>taking two arguments of type [[pekko.actor.ExtendedActorSystem]] and `String`, where the second argument is the binding name</li>
+ * <li>taking two arguments of type [[pekko.actor.ActorSystem]] and `String`, where the second argument is the binding name</li>
+ * <li>taking two arguments of type [[pekko.actor.ClassicActorSystemProvider]] and `String`, where the second argument is the binding name</li>
  * </ul>
  *
  * <b>Be sure to always use the </b>[[pekko.actor.DynamicAccess]]<b> for loading classes!</b> This is necessary to
@@ -114,11 +118,19 @@ object Serializers {
  * you used `includeManifest=true`, otherwise it will be the empty string.
  *
  * Serializers are loaded using reflection during [[pekko.actor.ActorSystem]]
- * start-up, where two constructors are tried in order:
+ * start-up, where constructors are tried in order:
  *
  * <ul>
- * <li>taking exactly one argument of type [[pekko.actor.ExtendedActorSystem]], and</li>
+ * <li>taking exactly one argument of type [[pekko.actor.ExtendedActorSystem]];
+ * this should be the preferred one because all reflective loading of classes
+ * during deserialization should use ExtendedActorSystem.dynamicAccess (see
+ * [[pekko.actor.DynamicAccess]])</li>
+ * <li>taking exactly one argument of type [[pekko.actor.ActorSystem]]</li>
+ * <li>taking exactly one argument of type [[pekko.actor.ClassicActorSystemProvider]]</li>
  * <li>without arguments</li>
+ * <li>taking two arguments of type [[pekko.actor.ExtendedActorSystem]] and `String`, where the second argument is the binding name</li>
+ * <li>taking two arguments of type [[pekko.actor.ActorSystem]] and `String`, where the second argument is the binding name</li>
+ * <li>taking two arguments of type [[pekko.actor.ClassicActorSystemProvider]] and `String`, where the second argument is the binding name</li>
  * </ul>
  *
  * <b>Be sure to always use the </b>[[pekko.actor.DynamicAccess]]<b> for loading classes!</b> This is necessary to


### PR DESCRIPTION
Motivation:
Pekko already supports additional serializer constructor shapes, but the public Scaladoc still documented only the older constructor alternatives.

Modification:
Update Serializer and SerializerWithStringManifest documentation to list the supported constructor shapes in the same order as the current loading implementation.

Result:
The serializer API documentation now matches the behavior covered by the existing constructor tests.

Tests:
- scalafmt --mode diff-ref=origin/main / passed
- scalafmt --list --mode diff-ref=origin/main / passed
- git diff --check / passed
- sbt "actor / Test / compile" "actor-tests / Test / testOnly org.apache.pekko.serialization.SerializeSpec" / passed

References:
Upstream commit: https://github.com/akka/akka-core/commit/a2ab65d501a94d93a592445df569f76825a78704, which is now Apache licensed
Refs #29765