### PR TITLE
docs: forbid Co-authored-by and AI-assistant trailers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,3 +209,4 @@ Fixes #1234, Refs #1234, or None - <short context>
 - Never omit `Tests`.
 - Never omit `References`.
 - Use `Refs #...`, `Fixes #...`, or `None - <short context>`.
+- Do not add `Co-authored-by` or AI-assistant trailers to commits or PR descriptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,4 @@ Before opening or updating a PR, verify:
 - Commit messages follow the `AGENTS.md` format.
 - PR bodies follow the `AGENTS.md` format.
 - `Tests` and `References` are present.
+- No `Co-authored-by` or AI-assistant trailers are added to commits or PR descriptions.


### PR DESCRIPTION
### Motivation
Align with the scala3 project's recent AGENTS.md update, which forbids
adding `Co-authored-by` or AI-assistant trailers to commits and PR
descriptions. Declaring LLM usage belongs in the PR body, not as a
commit trailer.

### Modification
- Add a rule to `AGENTS.md` (Commit and PR Format section) forbidding
  `Co-authored-by` and AI-assistant trailers.
- Add a matching pre-PR checklist item to `CLAUDE.md`.

### Result
Contributors and agents are explicitly told not to attach co-author or
AI-assistant trailers when committing or opening PRs.

### Tests
- Not run - docs only

### References
None - aligns with scala3 AGENTS.md update