### PR TITLE
optimize: remove unnecessary DelayCancellation stage from RestartFlow

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartFlow.scala
@@ -106,10 +106,18 @@ private final class RestartWithBackoffFlow[In, Out](
         val sourceOut: SubSourceOutlet[In] = createSubOutlet(in)
         val sinkIn: SubSinkInlet[Out] = createSubInlet(out)
 
-        val graph = Source
-          .fromGraph(sourceOut.source)
-          // Temp fix while waiting cause of cancellation. See #23909
-          .via(RestartWithBackoffFlow.delayCancellation[In](delay))
+        val sourceWithCancellation =
+          if (onlyOnFailures) {
+            // Delay cancellation to handle race condition where cancellation arrives
+            // before failure signal in onlyOnFailures mode. See #23909
+            Source
+              .fromGraph(sourceOut.source)
+              .via(RestartWithBackoffFlow.delayCancellation[In](delay))
+          } else {
+            Source.fromGraph(sourceOut.source)
+          }
+
+        val graph = sourceWithCancellation
           .via(flowFactory())
           .to(sinkIn.sink)
         subFusingMaterializer.materialize(graph, inheritedAttributes)


### PR DESCRIPTION
### Motivation

RestartFlow had ~3x less throughput than RetryFlow due to an unnecessary `DelayCancellation` stage in the inner flow graph. This stage added per-element overhead (extra `grab`/`push`/`pull` operations) even when not needed.

See: https://github.com/akka/akka-core/issues/31225

### Modification

Only apply the `DelayCancellation` stage when `onlyOnFailures` mode is enabled. For the common `RestartFlow.withBackoff` case, the stage is removed, eliminating the per-element overhead.

The `DelayCancellation` stage was a workaround for a race condition (see #23909) where cancellation could arrive before a failure signal in `onlyOnFailures` mode. For the non-`onlyOnFailures` case, the `SubSourceOutlet.onDownstreamFinish` handler already schedules a restart, so the delay is unnecessary.

### Result

Significantly improved throughput for `RestartFlow.withBackoff`. The `onFailuresWithBackoff` path retains the `DelayCancellation` stage for correctness.

### Tests

- All 38 existing `RestartSpec` tests pass

### Refs

Refs https://github.com/akka/akka-core/issues/31225