### PR TITLE
test: fix InterpreterBenchmark so it produces trustworthy numbers

### DIFF
--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/InterpreterBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/InterpreterBenchmark.scala
@@ -15,10 +15,12 @@ package org.apache.pekko.stream
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
 import org.openjdk.jmh.annotations._
 
 import org.apache.pekko
-import pekko.event._
 import pekko.stream.impl.fusing.GraphInterpreter.{ DownstreamBoundaryStageLogic, UpstreamBoundaryStageLogic }
 import pekko.stream.impl.fusing.GraphInterpreterSpecKit
 import pekko.stream.impl.fusing.GraphStages
@@ -27,7 +29,7 @@ import pekko.stream.stage._
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
-class InterpreterBenchmark {
+class InterpreterBenchmark extends GraphInterpreterSpecKit {
   import InterpreterBenchmark._
 
   // manual, and not via @Param, because we want @OperationsPerInvocation on our tests
@@ -36,26 +38,34 @@ class InterpreterBenchmark {
   @Param(Array("1", "5", "10"))
   var numberOfIds: Int = 0
 
+  // Earlier this benchmark instantiated `new GraphInterpreterSpecKit` inside @Benchmark, which
+  // created (and leaked) a fresh ActorSystem on every invocation and would exhaust native threads
+  // on long runs. Extending the SpecKit means JMH's @State(Scope.Benchmark) lifecycle reuses a
+  // single ActorSystem across all invocations.
+
+  @TearDown(Level.Trial)
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 10.seconds)
+  }
+
   @Benchmark
   @OperationsPerInvocation(100000)
   def graph_interpreter_100k_elements(): Unit = {
-    new GraphInterpreterSpecKit {
-      new TestSetup {
-        val identities = Vector.fill(numberOfIds)(GraphStages.identity[Int])
-        val source = new GraphDataSource("source", data100k)
-        val sink = new GraphDataSink[Int]("sink", data100k.size)
+    new TestSetup {
+      val identities = Vector.fill(numberOfIds)(GraphStages.identity[Int])
+      val source = new GraphDataSource("source", data100k)
+      val sink = new GraphDataSink[Int]("sink", data100k.size)
 
-        val b = builder(identities: _*).connect(source, identities.head.in).connect(identities.last.out, sink)
+      val b = builder(identities: _*).connect(source, identities.head.in).connect(identities.last.out, sink)
 
-        // FIXME: This should not be here, this is pure setup overhead
-        for (i <- 0 until identities.size - 1) {
-          b.connect(identities(i).out, identities(i + 1).in)
-        }
-
-        b.init()
-        sink.requestOne()
-        interpreter.execute(Int.MaxValue)
+      // FIXME: This should not be here, this is pure setup overhead
+      for (i <- 0 until identities.size - 1) {
+        b.connect(identities(i).out, identities(i + 1).in)
       }
+
+      b.init()
+      sink.requestOne()
+      interpreter.execute(Int.MaxValue)
     }
   }
 }
@@ -97,12 +107,5 @@ object InterpreterBenchmark {
       })
 
     def requestOne(): Unit = pull(in)
-  }
-
-  val NoopBus = new LoggingBus {
-    override def subscribe(subscriber: Subscriber, to: Classifier): Boolean = true
-    override def publish(event: Event): Unit = ()
-    override def unsubscribe(subscriber: Subscriber, from: Classifier): Boolean = true
-    override def unsubscribe(subscriber: Subscriber): Unit = ()
   }
 }

--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/InterpreterBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/InterpreterBenchmark.scala
@@ -23,7 +23,6 @@ import org.openjdk.jmh.annotations._
 import org.apache.pekko
 import pekko.stream.impl.fusing.GraphInterpreter.{ DownstreamBoundaryStageLogic, UpstreamBoundaryStageLogic }
 import pekko.stream.impl.fusing.GraphInterpreterSpecKit
-import pekko.stream.impl.fusing.GraphStages
 import pekko.stream.stage._
 
 @State(Scope.Benchmark)
@@ -52,7 +51,7 @@ class InterpreterBenchmark extends GraphInterpreterSpecKit {
   @OperationsPerInvocation(100000)
   def graph_interpreter_100k_elements(): Unit = {
     new TestSetup {
-      val identities = Vector.fill(numberOfIds)(GraphStages.identity[Int])
+      val identities = Vector.fill(numberOfIds)(new IdentityStage[Int])
       val source = new GraphDataSource("source", data100k)
       val sink = new GraphDataSink[Int]("sink", data100k.size)
 
@@ -71,6 +70,25 @@ class InterpreterBenchmark extends GraphInterpreterSpecKit {
 }
 
 object InterpreterBenchmark {
+
+  /**
+   * Per-instance identity stage. Cannot reuse [[GraphStages.identity]] because it is a singleton
+   * whose Inlet/Outlet shape is shared across all references — chaining N copies of the singleton
+   * collapses to a single shape and mis-wires the assembly (manifests as `Cannot pull port twice`).
+   */
+  final class IdentityStage[T] extends GraphStage[FlowShape[T, T]] {
+    val in = Inlet[T]("Identity.in")
+    val out = Outlet[T]("Identity.out")
+    override val shape: FlowShape[T, T] = FlowShape(in, out)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) with InHandler with OutHandler {
+        override def onPush(): Unit = push(out, grab(in))
+        override def onPull(): Unit = pull(in)
+        setHandler(in, this)
+        setHandler(out, this)
+      }
+  }
 
   case class GraphDataSource[T](override val toString: String, data: Vector[T]) extends UpstreamBoundaryStageLogic[T] {
     var idx: Int = 0


### PR DESCRIPTION
### Motivation
`InterpreterBenchmark` had two independent bugs that made its results unreliable, which becomes a problem the moment anyone wants to evaluate a `GraphInterpreter`-touching change against it.

1. The benchmark body was `new GraphInterpreterSpecKit { new TestSetup { ... } }`. Because that ran inside `@Benchmark`, every invocation built (and never tore down) a fresh `ActorSystem`. Long iterations exhausted native threads and JMH ended up reporting empty results once the JVM ran out of resources.
2. Inside the assembly we used `GraphStages.identity[Int]` once per slot, but `GraphStages.identity` is a singleton whose `Inlet`/`Outlet` shape is shared across every reference. Chaining N copies (`numberOfIds = 5/10`) collapses to a single shape and mis-wires the connections; the run logged a flood of `Cannot pull port twice` errors and ended up reporting nonsense throughput (5/10-stage configs faster than the 1-stage one).

### Modification
- Make `InterpreterBenchmark` itself extend `GraphInterpreterSpecKit` so JMH's `@State(Scope.Benchmark)` lifecycle reuses one `ActorSystem` across invocations, and add `@TearDown(Level.Trial)` to terminate it cleanly.
- Define a local `IdentityStage[T]` with its own `Inlet`/`Outlet` per instance and use `Vector.fill(numberOfIds)(new IdentityStage[Int])` so each slot in the chain is a distinct stage with a distinct shape.

No changes to production code — this PR only fixes the benchmark.

### Result
The benchmark now runs to completion without leaking actor systems and produces stable, monotonic numbers (throughput decreases as `numberOfIds` grows, as expected). This restores it as a usable baseline for subsequent `GraphInterpreter` work.

JMH on this branch (JDK 25, G1, single thread, `-i 5 -wi 3 -f 1 -t 1`):

```
Benchmark                                             (numberOfIds)   Mode  Cnt      Score      Error   Units
InterpreterBenchmark.graph_interpreter_100k_elements              1  thrpt    5  45238.227 ± 3143.242  ops/ms
InterpreterBenchmark.graph_interpreter_100k_elements              5  thrpt    5  10526.376 ±  151.239  ops/ms
InterpreterBenchmark.graph_interpreter_100k_elements             10  thrpt    5   5350.558 ±  192.965  ops/ms
```

Pre-fix the 5/10-stage rows were both higher than the 1-stage row (i.e. wrong direction) because the singleton-shape bug meant the chain wasn't actually N stages long.

This is a benchmark-correctness fix, not a performance improvement. There is no production-code change here.

### Tests
- `sbt 'bench-jmh/compile'`
- `sbt 'bench-jmh/headerCheck; bench-jmh/scalafmtCheck'`
- `sbt 'bench-jmh/Jmh/run -i 5 -wi 3 -f 1 -t 1 -rf json -rff /tmp/jmh.json .*InterpreterBenchmark.*'` — completes cleanly, scores above.

### References
None - benchmark-only fix surfaced while preparing to evaluate `GraphInterpreter` micro-optimizations against a trustworthy baseline.