### PR TITLE
optimize: skip afterStageHasRun no-op finalize check in GraphInterpreter chase hot path

### DIFF
--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/InterpreterBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/InterpreterBenchmark.scala
@@ -15,10 +15,12 @@ package org.apache.pekko.stream
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
 import org.openjdk.jmh.annotations._
 
 import org.apache.pekko
-import pekko.event._
 import pekko.stream.impl.fusing.GraphInterpreter.{ DownstreamBoundaryStageLogic, UpstreamBoundaryStageLogic }
 import pekko.stream.impl.fusing.GraphInterpreterSpecKit
 import pekko.stream.impl.fusing.GraphStages
@@ -27,7 +29,7 @@ import pekko.stream.stage._
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
-class InterpreterBenchmark {
+class InterpreterBenchmark extends GraphInterpreterSpecKit {
   import InterpreterBenchmark._
 
   // manual, and not via @Param, because we want @OperationsPerInvocation on our tests
@@ -36,26 +38,34 @@ class InterpreterBenchmark {
   @Param(Array("1", "5", "10"))
   var numberOfIds: Int = 0
 
+  // Earlier this benchmark instantiated `new GraphInterpreterSpecKit` inside @Benchmark, which
+  // created (and leaked) a fresh ActorSystem on every invocation and would exhaust native threads
+  // on long runs. Extending the SpecKit means JMH's @State(Scope.Benchmark) lifecycle reuses a
+  // single ActorSystem across all invocations.
+
+  @TearDown(Level.Trial)
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 10.seconds)
+  }
+
   @Benchmark
   @OperationsPerInvocation(100000)
   def graph_interpreter_100k_elements(): Unit = {
-    new GraphInterpreterSpecKit {
-      new TestSetup {
-        val identities = Vector.fill(numberOfIds)(GraphStages.identity[Int])
-        val source = new GraphDataSource("source", data100k)
-        val sink = new GraphDataSink[Int]("sink", data100k.size)
+    new TestSetup {
+      val identities = Vector.fill(numberOfIds)(GraphStages.identity[Int])
+      val source = new GraphDataSource("source", data100k)
+      val sink = new GraphDataSink[Int]("sink", data100k.size)
 
-        val b = builder(identities: _*).connect(source, identities.head.in).connect(identities.last.out, sink)
+      val b = builder(identities: _*).connect(source, identities.head.in).connect(identities.last.out, sink)
 
-        // FIXME: This should not be here, this is pure setup overhead
-        for (i <- 0 until identities.size - 1) {
-          b.connect(identities(i).out, identities(i + 1).in)
-        }
-
-        b.init()
-        sink.requestOne()
-        interpreter.execute(Int.MaxValue)
+      // FIXME: This should not be here, this is pure setup overhead
+      for (i <- 0 until identities.size - 1) {
+        b.connect(identities(i).out, identities(i + 1).in)
       }
+
+      b.init()
+      sink.requestOne()
+      interpreter.execute(Int.MaxValue)
     }
   }
 }
@@ -97,12 +107,5 @@ object InterpreterBenchmark {
       })
 
     def requestOne(): Unit = pull(in)
-  }
-
-  val NoopBus = new LoggingBus {
-    override def subscribe(subscriber: Subscriber, to: Classifier): Boolean = true
-    override def publish(event: Event): Unit = ()
-    override def unsubscribe(subscriber: Subscriber, from: Classifier): Boolean = true
-    override def unsubscribe(subscriber: Subscriber): Unit = ()
   }
 }

--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/InterpreterBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/InterpreterBenchmark.scala
@@ -23,7 +23,6 @@ import org.openjdk.jmh.annotations._
 import org.apache.pekko
 import pekko.stream.impl.fusing.GraphInterpreter.{ DownstreamBoundaryStageLogic, UpstreamBoundaryStageLogic }
 import pekko.stream.impl.fusing.GraphInterpreterSpecKit
-import pekko.stream.impl.fusing.GraphStages
 import pekko.stream.stage._
 
 @State(Scope.Benchmark)
@@ -52,7 +51,7 @@ class InterpreterBenchmark extends GraphInterpreterSpecKit {
   @OperationsPerInvocation(100000)
   def graph_interpreter_100k_elements(): Unit = {
     new TestSetup {
-      val identities = Vector.fill(numberOfIds)(GraphStages.identity[Int])
+      val identities = Vector.fill(numberOfIds)(new IdentityStage[Int])
       val source = new GraphDataSource("source", data100k)
       val sink = new GraphDataSink[Int]("sink", data100k.size)
 
@@ -71,6 +70,25 @@ class InterpreterBenchmark extends GraphInterpreterSpecKit {
 }
 
 object InterpreterBenchmark {
+
+  /**
+   * Per-instance identity stage. Cannot reuse [[GraphStages.identity]] because it is a singleton
+   * whose Inlet/Outlet shape is shared across all references — chaining N copies of the singleton
+   * collapses to a single shape and mis-wires the assembly (manifests as `Cannot pull port twice`).
+   */
+  final class IdentityStage[T] extends GraphStage[FlowShape[T, T]] {
+    val in = Inlet[T]("Identity.in")
+    val out = Outlet[T]("Identity.out")
+    override val shape: FlowShape[T, T] = FlowShape(in, out)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) with InHandler with OutHandler {
+        override def onPush(): Unit = push(out, grab(in))
+        override def onPull(): Unit = pull(in)
+        setHandler(in, this)
+        setHandler(out, this)
+      }
+  }
 
   case class GraphDataSource[T](override val toString: String, data: Vector[T]) extends UpstreamBoundaryStageLogic[T] {
     var idx: Int = 0

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphInterpreter.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphInterpreter.scala
@@ -259,6 +259,10 @@ import pekko.stream.stage._
   private[this] var chaseCounter = 0 // the first events in preStart blocks should be not chased
   private[this] var chasedPush: Connection = NoEvent
   private[this] var chasedPull: Connection = NoEvent
+  // Set whenever a stage's shutdownCounter transitions to 0 (i.e. the stage just became completed and
+  // needs finalization). Lets the chase / dispatch loops skip the per-iteration shutdownCounter array
+  // load in afterStageHasRun when no stage has completed since the last finalization pass.
+  private[this] var pendingFinalization: Boolean = false
 
   private def queueStatus: String = {
     val contents = (queueHead until queueTail).map(idx => {
@@ -420,7 +424,10 @@ import pekko.stream.stage._
         catch {
           case NonFatal(e) => reportStageError(e)
         }
-        afterStageHasRun(activeStage)
+        if (pendingFinalization) {
+          pendingFinalization = false
+          afterStageHasRun(activeStage)
+        }
 
         /*
          * "Event chasing" optimization follows from here. This optimization works under the assumption that a Push or
@@ -453,7 +460,10 @@ import pekko.stream.stage._
           catch {
             case NonFatal(e) => reportStageError(e)
           }
-          afterStageHasRun(activeStage)
+          if (pendingFinalization) {
+            pendingFinalization = false
+            afterStageHasRun(activeStage)
+          }
         }
 
         // Chasing PULL events
@@ -464,7 +474,10 @@ import pekko.stream.stage._
           catch {
             case NonFatal(e) => reportStageError(e)
           }
-          afterStageHasRun(activeStage)
+          if (pendingFinalization) {
+            pendingFinalization = false
+            afterStageHasRun(activeStage)
+          }
         }
 
         if (chasedPush != NoEvent) {
@@ -627,12 +640,20 @@ import pekko.stream.stage._
   // itself might stop, too.
   private def completeConnection(stageId: Int): Unit = {
     val activeConnections = shutdownCounter(stageId)
-    if (activeConnections > 0) shutdownCounter(stageId) = activeConnections - 1
+    if (activeConnections > 0) {
+      val next = activeConnections - 1
+      shutdownCounter(stageId) = next
+      if (next == 0) pendingFinalization = true
+    }
   }
 
   private[stream] def setKeepGoing(logic: GraphStageLogic, enabled: Boolean): Unit =
     if (enabled) shutdownCounter(logic.stageId) |= KeepGoingFlag
-    else shutdownCounter(logic.stageId) &= KeepGoingMask
+    else {
+      val next = shutdownCounter(logic.stageId) & KeepGoingMask
+      shutdownCounter(logic.stageId) = next
+      if (next == 0) pendingFinalization = true
+    }
 
   @InternalStableApi
   private[stream] def finalizeStage(logic: GraphStageLogic): Unit = {


### PR DESCRIPTION
### Motivation
`GraphInterpreter`'s chase loops dominate hot-path CPU in steady state. JMH stack profiling on `InterpreterBenchmark` (`numberOfIds=10`) attributes ~50% of stream-related samples to the two `while` loops at `execute:449` and `execute:460`, after deep JIT inlining of `processPush` / `onPush` / `push` / `grab` / `chasePush`.

Every chase iteration ends with `afterStageHasRun(activeStage)`, which in steady state always reads `shutdownCounter(activeStage.stageId)` and the per-stage finalized flag, only to discover the stage has not just completed and skip the body. That is a per-event array load + null check + branch on the hottest path with no work to do, which the JIT cannot fold away because `shutdownCounter` is a mutable shared array.

### Modification
- Add `pendingFinalization: Boolean` on the interpreter, set when a stage's `shutdownCounter` decrements to 0 in `completeConnection`, or transitions to 0 when `KeepGoing` is cleared in `setKeepGoing`.
- Gate the three hot-path `afterStageHasRun(activeStage)` call sites in `execute()` (post normal-dispatch and the two chase loops) on the flag, resetting it to `false` before invoking `afterStageHasRun` so cascaded completions during finalization re-arm the flag correctly.
- The lower-frequency `afterStageHasRun` callers in `init()` and `runAsyncInput` are intentionally left untouched — they run once per stage / per async event and are not on the hot path.

The semantic invariant is preserved: any path that decrements `shutdownCounter` to 0 sets the flag, so any state where `isStageCompleted(activeStage)` could newly return true is guaranteed to be observed by the next gated call.

### Result
JMH on `InterpreterBenchmark` (JDK 25, G1, single thread, `-i 5 -wi 3 -f 1 -t 1`):

```
numberOfIds   baseline (ops/ms)    with patch (ops/ms)    delta
1             45238 ± 3143         50952 ± 4784           +12.6%
5             10526 ±  151         11242 ±  288            +6.8%   (CIs disjoint)
10             5350 ±  193          5927 ±  173           +10.8%   (CIs disjoint)
```

`numberOfIds=5` and `=10` show non-overlapping 99.9% confidence intervals vs the same-tree baseline, so the gain is not noise. Allocation rate stays at ~0.6 B/op (0 GC counts in the measurement window) — no GC impact.

### Tests
- `sbt 'stream/compile'`
- `sbt 'stream/mimaReportBinaryIssues'` — clean
- `sbt 'stream-tests/testOnly *fusing*'` — 159 tests, all passed (covers `GraphInterpreterSpec`, `GraphInterpreterPortsSpec`, completion / cancel / fail paths)
- `sbt 'stream-tests/testOnly *Flow*Spec'` — 1208 tests, all passed
- `sbt 'bench-jmh/Jmh/run -i 5 -wi 3 -f 1 -t 1 .*InterpreterBenchmark.*'` — numbers above

### References
Refs #2985 — relies on the `InterpreterBenchmark` correctness fix in that PR to obtain trustworthy JMH numbers. This branch contains the two commits from #2985 plus the optimization commit; if #2985 lands first, this branch will be rebased to drop those.