### PR TITLE
Avoid substream subscription timeout for empty prefixAndTail tails

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/prefixAndTail.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/prefixAndTail.md
@@ -15,6 +15,15 @@ Take up to *n* elements from the stream (less than *n* only if the upstream comp
 Take up to *n* elements from the stream (less than *n* only if the upstream completes before emitting *n* elements)
 and returns a pair containing a strict sequence of the taken element and a stream representing the remaining elements.
 
+After the prefix has been emitted, `prefixAndTail` issues a single speculative pull on its upstream so that an empty
+tail (the upstream completes before producing any further element) is detected immediately. If the emitted tail
+`Source` is intentionally discarded and the substream happens to be empty, the stage completes without waiting for
+the configured `pekko.stream.materializer.subscription-timeout`.
+
+If the speculative pull delivers an element before the tail `Source` is materialized, that element is buffered and
+forwarded as the first element to whoever materializes the tail. Tails that are discarded by downstream while
+upstream still has elements continue to be governed by the configured subscription timeout.
+
 ## Reactive Streams semantics
 
 @@@div { .callout }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrefixAndTailSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrefixAndTailSpec.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.stream.scaladsl
 import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.Await
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
@@ -287,6 +288,60 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
       tailPub.subscribe(sub)
       sub.expectSubscriptionAndComplete()
+    }
+
+    "complete promptly on empty tail without waiting for subscription timeout (akka #20008)" in {
+      // Reproduces https://github.com/akka/akka/issues/20008. Default StreamSubscriptionTimeout
+      // is 5 seconds; without the speculative pre-pull in PrefixAndTail this would take
+      // >15 seconds (three discarded empty tails). The test must finish well under that.
+      import system.dispatcher
+      val fut = Source(List("2", "a", "b", "0", "3", "a", "b", "c", "0", "1", "a"))
+        .splitWhen(_.matches("\\d+"))
+        .prefixAndTail(1)
+        .mapAsync(1) {
+          case (Seq("0"), _) =>
+            // Intentionally discard the tail Source for known-empty groups.
+            Future.successful("")
+          case (Seq(_), elements) =>
+            elements.runWith(Sink.seq).map(_.mkString)
+        }
+        .concatSubstreams
+        .runWith(Sink.seq)
+
+      Await.result(fut, 3.seconds.dilated) should ===(Seq("ab", "", "abc", "", "a"))
+    }
+
+    "deliver buffered tail element when tail is materialized after upstream emitted one" in {
+      // Directional test for the speculative pre-pull buffer: after the prefix is emitted,
+      // PrefixAndTail eagerly pulls upstream. If upstream pushes a single element before the
+      // tail Source is materialized, that element must be buffered and delivered as the
+      // first element when the tail finally subscribes (akka #20008).
+      val publisher = TestPublisher.manualProbe[Int]()
+      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
+
+      Source.fromPublisher(publisher).prefixAndTail(1).to(Sink.fromSubscriber(subscriber)).run()
+
+      val upstream = publisher.expectSubscription()
+      val downstream = subscriber.expectSubscription()
+
+      downstream.request(1)
+      upstream.expectRequest()
+      upstream.sendNext(1)
+
+      val (prefix, tail) = subscriber.expectNext()
+      prefix should ===(Seq(1))
+      subscriber.expectComplete()
+
+      // The speculative pre-pull lets the buffered element arrive before the tail is materialized.
+      upstream.sendNext(2)
+      upstream.sendComplete()
+
+      val tailSubscriber = TestSubscriber.manualProbe[Int]()
+      tail.to(Sink.fromSubscriber(tailSubscriber)).run()
+      val tailSub = tailSubscriber.expectSubscription()
+      tailSub.request(10)
+      tailSubscriber.expectNext(2)
+      tailSubscriber.expectComplete()
     }
 
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
@@ -284,6 +284,13 @@ import pekko.util.OptionVal
     builder.sizeHint(left)
 
     private var tailSource: SubSourceOutlet[T] = null
+    // Buffer for at most one element fetched by the speculative pre-pull issued in
+    // openSubstream(): it lets us discover an empty tail (upstream finishes before
+    // emitting any further element) without waiting for the substream subscription
+    // timeout when downstream intentionally discards the tail Source. See akka/akka#20008.
+    private var pendingElement: T = _
+    private var hasPendingElement = false
+    private var upstreamFinished = false
 
     private val SubscriptionTimer = "SubstreamSubscriptionTimer"
 
@@ -312,8 +319,19 @@ import pekko.util.OptionVal
       override def onPull(): Unit = {
         setKeepGoing(false)
         cancelTimer(SubscriptionTimer)
-        pull(in)
         tailSource.setHandler(() => pull(in))
+        if (hasPendingElement) {
+          val elem = pendingElement
+          pendingElement = null.asInstanceOf[T]
+          hasPendingElement = false
+          tailSource.push(elem)
+          if (upstreamFinished) {
+            tailSource.complete()
+            completeStage()
+          }
+        } else if (!hasBeenPulled(in) && !isClosed(in)) {
+          pull(in)
+        }
       }
     }
 
@@ -324,12 +342,27 @@ import pekko.util.OptionVal
       setKeepGoing(true)
       scheduleOnce(SubscriptionTimer, timeout)
       builder = null
+      // Speculative pre-pull: lets us observe an empty tail (upstream finish before any
+      // further element) immediately, instead of holding the substream open until the
+      // subscription timeout fires when downstream discards the tail Source.
+      // Deferred via getAsyncCallback to avoid synchronous cascade when called inside
+      // a push() handler (e.g. when PrefixAndTail is used inside a Split operator).
+      if (!hasBeenPulled(in) && !isClosed(in)) {
+        getAsyncCallback[Unit](_ => if (!hasBeenPulled(in) && !isClosed(in)) pull(in)).invoke(())
+      }
       Source.fromGraph(tailSource.source)
     }
 
     override def onPush(): Unit = {
       if (prefixComplete) {
-        tailSource.push(grab(in))
+        if (tailSource.isAvailable) {
+          tailSource.push(grab(in))
+        } else {
+          // Speculative pre-pull delivered an element before the SubSource was materialized;
+          // buffer it until the first subHandler.onPull arrives.
+          pendingElement = grab(in)
+          hasPendingElement = true
+        }
       } else {
         builder += grab(in)
         left -= 1
@@ -352,6 +385,12 @@ import pekko.util.OptionVal
         val prefix = builder.result();
         builder = null // free for GC
         emit(out, (prefix, Source.empty), () => completeStage())
+      } else if (hasPendingElement) {
+        // Wait for the SubSource to be materialized so we can deliver the buffered element
+        // and the completion together. If the SubSource never gets materialized the
+        // subscription timer will eventually close the stage.
+        upstreamFinished = true
+        if (tailSource.isClosed) completeStage()
       } else {
         if (!tailSource.isClosed) tailSource.complete()
         completeStage()


### PR DESCRIPTION
### Motivation

`prefixAndTail` emits `(prefix, tailSource)` and then waits for the `tailSource` to be materialized before pulling upstream again. When a downstream consumer intentionally discards the tail Source — a common pattern in protocol parsers using `splitWhen` + `prefixAndTail` + `mapAsync` where a known-empty substream is skipped — the stage holds the substream open until the configured `pekko.stream.materializer.subscription-timeout` fires (default 5 s), silently stalling the rest of the pipeline.

Reproduces the long-standing [akka/akka#20008](https://github.com/akka/akka/issues/20008):

```scala
Source(List("2", "a", "b", "0", "3", "a", "b", "c", "0", "1", "a"))
  .splitWhen(_.matches("\\d+"))
  .prefixAndTail(1)
  .mapAsync(1) {
    case (Seq("0"), _)             => Future.successful("")   // intentionally drop tail
    case (Seq(_),   elements)      => elements.runWith(Sink.seq).map(_.mkString)
  }
  .concatSubstreams
  .runWith(Sink.seq)
```

Without the fix every discarded empty tail adds a 5 s wait before the next group is emitted.

### Modification

`PrefixAndTail` now issues a single speculative `pull(in)` from `openSubstream()` as soon as the tail `Source` has been emitted:

- If upstream finishes before any further element arrives, the stage completes immediately instead of waiting for the substream subscription timer.
- If upstream pushes an element before the tail `Source` has been materialized, the element is buffered in a one-element slot and delivered as the first element on the first downstream pull of the tail; upstream finish that arrives while the buffer is occupied is deferred and replayed together with the buffered element when the tail finally subscribes.
- Subscription-timeout behaviour for tails that are not subscribed but still have unread upstream elements is unchanged.

Operator docs updated to describe the new pre-pull / one-element-buffer semantics.

### Result

Discarding a tail `Source` from `prefixAndTail` no longer blocks the parent flow for the subscription-timeout window when the tail is empty. The directional test for the issue scenario now completes in ~60 ms instead of ~15 s.

### Tests

- ` sbt \"stream-tests/Test/testOnly org.apache.pekko.stream.scaladsl.FlowPrefixAndTailSpec\"` – 18/18 passed locally (incl. new \"complete promptly on empty tail without waiting for subscription timeout (akka #20008)\" and \"deliver buffered tail element when tail is materialized after upstream emitted one\").
- Verified the new directional test fails against the pre-fix implementation by stashing the impl change and re-running the same `testOnly`.
- `scalafmt --list` – clean for the changed files.
- Full `stream-tests/Test/test` and `+mimaReportBinaryIssues` – Not run locally, deferred to CI (`Check / Binary Compatibility` should cover MiMa).

### References

Refs [akka/akka#20008](https://github.com/akka/akka/issues/20008)