### PR TITLE
Operator docs: add description and example for StreamConverters.javaCollector

### DIFF
--- a/docs/src/main/paradox/stream/operators/StreamConverters/javaCollector.md
+++ b/docs/src/main/paradox/stream/operators/StreamConverters/javaCollector.md
@@ -1,6 +1,6 @@
 # StreamConverters.javaCollector
 
-Create a sink which materializes into a @scala[`Future`] @java[`CompletionStage`] which will be completed with a result of the Java 8 `Collector` transformation and reduction operations.
+Create a sink which materializes into a @scala[`Future`] @java[`CompletionStage`] which will be completed with a result of the Java `Collector` transformation and reduction operations.
 
 @ref[Additional Sink and Source converters](../index.md#additional-sink-and-source-converters)
 

--- a/docs/src/main/paradox/stream/operators/StreamConverters/javaCollector.md
+++ b/docs/src/main/paradox/stream/operators/StreamConverters/javaCollector.md
@@ -11,4 +11,25 @@ Create a sink which materializes into a @scala[`Future`] @java[`CompletionStage`
 
 ## Description
 
-TODO: We would welcome help on contributing descriptions and examples, see: https://github.com/akka/akka/issues/25646
+`javaCollector` creates a @apidoc[Sink] that accepts a Java 8 @javadoc[java.util.stream.Collector](java.util.stream.Collector)
+factory. The `Collector` accumulates incoming elements into a mutable container as downstream demand is
+triggered, and after the stream completes, an optional finisher transforms the accumulated result. The sink
+materializes into a @scala[`Future`]@java[`CompletionStage`] holding the final result. All processing
+happens sequentially on the stream's materialized execution context.
+
+Since each materialization of the sink must start with a fresh accumulator, the factory is invoked once per
+materialization. Use @ref:[javaCollectorParallelUnordered](javaCollectorParallelUnordered.md) if parallel
+collection is needed.
+
+@ref:[`Sink.collect`](../Sink/collect.md) provides a simpler API for common collection scenarios.
+
+## Example
+
+In this example, `StreamConverters.javaCollector` uses ``Collectors.toList`` to gather stream elements
+into a ``List``.
+
+Scala
+:   @@snip [JavaCollectorDocExample.scala](/docs/src/test/scala/docs/stream/operators/JavaCollectorDocExample.scala) { #javaCollector }
+
+Java
+:   @@snip [JavaCollectorDocExamples.java](/docs/src/test/java/jdocs/stream/operators/JavaCollectorDocExamples.java) { #javaCollector }

--- a/docs/src/test/java/jdocs/stream/operators/JavaCollectorDocExamples.java
+++ b/docs/src/test/java/jdocs/stream/operators/JavaCollectorDocExamples.java
@@ -1,10 +1,10 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
+ * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * the License. You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/docs/src/test/java/jdocs/stream/operators/JavaCollectorDocExamples.java
+++ b/docs/src/test/java/jdocs/stream/operators/JavaCollectorDocExamples.java
@@ -32,8 +32,7 @@ public class JavaCollectorDocExamples {
     ActorSystem system = null;
 
     // #javaCollector
-    Source<String, NotUsed> source =
-        Source.from(Arrays.asList("Apache", "Pekko", "Streams"));
+    Source<String, NotUsed> source = Source.from(Arrays.asList("Apache", "Pekko", "Streams"));
 
     CompletionStage<List<String>> result =
         source.runWith(StreamConverters.javaCollector(Collectors::toList), system);

--- a/docs/src/test/java/jdocs/stream/operators/JavaCollectorDocExamples.java
+++ b/docs/src/test/java/jdocs/stream/operators/JavaCollectorDocExamples.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package jdocs.stream.operators;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.stream.javadsl.StreamConverters;
+
+public class JavaCollectorDocExamples {
+
+  static void example() {
+    ActorSystem system = null;
+
+    // #javaCollector
+    Source<String, NotUsed> source =
+        Source.from(Arrays.asList("Apache", "Pekko", "Streams"));
+
+    CompletionStage<List<String>> result =
+        source.runWith(StreamConverters.javaCollector(Collectors::toList), system);
+    // #javaCollector
+  }
+}

--- a/docs/src/test/java/jdocs/stream/operators/JavaCollectorDocExamples.java
+++ b/docs/src/test/java/jdocs/stream/operators/JavaCollectorDocExamples.java
@@ -1,10 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package jdocs.stream.operators;

--- a/docs/src/test/scala/docs/stream/operators/JavaCollectorDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/JavaCollectorDocExample.scala
@@ -1,10 +1,10 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
+ * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * the License. You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/docs/src/test/scala/docs/stream/operators/JavaCollectorDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/JavaCollectorDocExample.scala
@@ -1,10 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package docs.stream.operators

--- a/docs/src/test/scala/docs/stream/operators/JavaCollectorDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/JavaCollectorDocExample.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package docs.stream.operators
+
+import java.util.stream.Collectors
+
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.StreamConverters
+
+object JavaCollectorDocExample {
+
+  // #javaCollector
+  val source: Source[String, NotUsed] =
+    Source(List("Apache", "Pekko", "Streams"))
+
+  val sink: Sink[String, _] =
+    StreamConverters.javaCollector(() => Collectors.toList[String]())
+  // #javaCollector
+}


### PR DESCRIPTION
### Motivation
The `javaCollector` operator doc page had a TODO placeholder instead of documentation.

### Modification
- Replace TODO with a Description section explaining how `javaCollector`  works (sequential collection, per-materialization factory, finisher step)
- Add references to `javaCollectorParallelUnordered` and `Sink.collect`
- Add Scala `JavaCollectorDocExample.scala` and Java  `JavaCollectorDocExamples.java` code examples using `Collectors.toList`

### Result
The `StreamConverters.javaCollector` operator docs are now complete with description and runnable examples.

### Tests
sbt "docs/Test/compile"  -- passed