### PR TITLE
docs: add AI licensing rules to AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,18 @@ Follow `CONTRIBUTING.md`. If this file conflicts with `CONTRIBUTING.md`, follow 
 - Read neighboring code before editing.
 - Preserve existing license and copyright notices.
 - Do not add `@author` tags.
+- Follow the Licensing Rules below for every new file.
+
+## Licensing Rules
+
+- Do not hand-write or invent license headers. Let sbt manage them.
+- For new files, run `sbt headerCreateAll` to add the correct header. Do not manually paste header text.
+- Run `sbt +headerCheckAll` to verify all files carry the expected header.
+- Existing files with copyright statements must keep those copyright statements intact. Never delete or rewrite an existing copyright notice; only add information.
+- New files containing new code must use the standard Apache license header. Do not add the special Pekko header that mentions Akka unless you are copying code from an existing Akka-derived file.
+- If you copy code from another file in this repository, preserve that file's original headers in the new file.
+- If you copy code from an external project, do not commit it silently. Note the source in the PR description so maintainers can verify license compatibility and update `LICENSE` if needed.
+- `sbt headerCreateAll` does not know the origin of new code; you must still record copied-code provenance in the PR.
 
 ## PR Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ Before opening or updating a PR, verify:
 - Non-doc-only changes have directional tests.
 - Native `scalafmt` or the sbt scalafmt tasks were run for changed Scala/SBT files, or the missing tool is recorded in `Tests`.
 - `sbt javafmtAll` was run with JDK 17 when relevant.
-- `sbt headerCreateAll` was run.
+- `sbt headerCreateAll` was run to add headers for new files. Never hand-write or invent license headers; let sbt manage them, and preserve existing copyright notices intact.
+- For copied code, the source file or external project is noted in the PR (see Licensing Rules in `AGENTS.md`).
 - Binary compatibility is preserved, and the GitHub `Check / Binary Compatibility` job passes before merge.
 - `sbt +mimaReportBinaryIssues` was run for public API, binary shape, serialization, or MiMa-sensitive internal changes.
 - Commit messages follow the `AGENTS.md` format.


### PR DESCRIPTION
### Motivation
AI assistants have invented or pasted incorrect license headers when creating new files, including putting the Akka-derived header on files that contain no Akka code. The licensing rules already live in `CONTRIBUTING.md` but were not reflected in the agent-facing guides (`AGENTS.md`, `CLAUDE.md`), so agents had no direct cue to follow them.

### Modification
- Add a `Licensing Rules` section to `AGENTS.md` that mirrors the rules in `CONTRIBUTING.md`, instructs agents to use `sbt headerCreateAll` rather than hand-write headers, and requires PR-level disclosure when code is copied from another file or external project.
- Update `CLAUDE.md` to call out the same expectation in the PR checklist and point at the new section.

### Result
Future agent contributions follow the same licensing guidance as human contributors. Headers are generated by sbt instead of fabricated, existing copyright notices are preserved, and copied-code provenance is captured in the PR.

### Tests
- Not run - docs only

### References
None - aligns `AGENTS.md` and `CLAUDE.md` with the licensing rules already documented in `CONTRIBUTING.md`