### PR TITLE
test: shut down cluster test systems in reverse order

### DIFF
--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterTestKit.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterTestKit.scala
@@ -109,8 +109,11 @@ trait ClusterTestKit extends TestKitBase {
       actorSystems.contains(actorSystem)
 
     /** Shuts down all registered [[ActorSystem]]s */
+    // Shut down joining nodes before the first seed node so cluster leave and remoting
+    // termination can complete while the seed is still available.
     // The timeout is dilated by TestKit; keep a larger base for virtualized JDK 25 nightly runs.
-    def shutdownAll(): Unit = actorSystems.foreach(sys => shutdown(sys, 30.seconds, verifySystemShutdown = true))
+    def shutdownAll(): Unit =
+      actorSystems.reverse.foreach(sys => shutdown(sys, 30.seconds, verifySystemShutdown = true))
 
     /**
      * Force the passed [[ActorSystem]] to quit the cluster and shutdown.


### PR DESCRIPTION
### Motivation
MixedProtocolClusterSpec nightly runs can pass their cluster join assertions but still fail in shutdownAll when the first seed ActorSystem is stopped before the joining nodes have left. On JDK 25 virtualized dispatcher runs this can leave remoting shutdown waiting until the actor-system-terminate phase times out.

### Modification
Shut down ClusterTestKit actor systems in reverse registration order so joining nodes leave first while the seed is still available.

### Result
Multi-ActorSystem cluster specs using shutdownAll keep the seed alive until dependent nodes have terminated, reducing shutdown timeout flakiness without reducing test coverage or weakening assertions.

### Tests
- JDK 25 nightly-style: `sbt "cluster / Test / testOnly org.apache.pekko.cluster.MixedProtocolClusterSpec"` - 9 tests succeeded / 0 failed
- `scalafmt --mode diff-ref=origin/main`
- `scalafmt --list --mode diff-ref=origin/main`
- `git diff --check`

### References
None - nightly-builds.yml MixedProtocolClusterSpec shutdown timeout