### PR TITLE
test: relax SendQueue fuzzing deadlines

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/artery/SendQueueSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/SendQueueSpec.scala
@@ -28,6 +28,7 @@ import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.testkit.ImplicitSender
 import pekko.testkit.PekkoSpec
+import pekko.testkit.TestDuration
 
 object SendQueueSpec {
 
@@ -129,7 +130,7 @@ class SendQueueSpec extends PekkoSpec("""
           if (!sendQueue.offer(round * 1000 + n))
             fail(s"offer failed at round $round message $n")
         }
-        downstream.expectNext((1 to burstSize).map(_ + round * 1000).toList)
+        downstream.expectNext(30.seconds.dilated, (1 to burstSize).map(_ + round * 1000).toList)
         downstream.request(1)
       }
 
@@ -178,14 +179,14 @@ class SendQueueSpec extends PekkoSpec("""
             Source.fromGraph(new SendQueue[String](sendToDeadLetters)).toMat(TestSink())(Keep.both).run()
 
           f(queue, sendQueue, downstream)
-          downstream.expectNext("a")
+          downstream.expectNext(15.seconds.dilated, "a")
 
           sendQueue.offer("b")
-          downstream.expectNext("b")
+          downstream.expectNext(15.seconds.dilated, "b")
           sendQueue.offer("c")
           sendQueue.offer("d")
-          downstream.expectNext("c")
-          downstream.expectNext("d")
+          downstream.expectNext(15.seconds.dilated, "c")
+          downstream.expectNext(15.seconds.dilated, "d")
           downstream.cancel()
         }
       }


### PR DESCRIPTION
### Motivation
SendQueueSpec preserves high-volume wakeup coverage but its default per-expect timeout is too tight under fuzzing-mode and virtualized nightly/CI runners. Recent failures timed out while waiting for a burst or the next element even though the stress workload itself should remain unchanged.

### Modification
Keep the existing burst size, 100000 rounds, and first-message ordering variants, but use explicit dilated deadlines for the slow fuzzing assertions.

### Result
The test still exercises the same SendQueue wakeup scenarios while allowing scheduler jitter on constrained JDK 25 and Scala 3 CI runners. This does not reduce the test workload or weaken message-order assertions.

### Tests
- JDK 25 nightly-style: `sbt "remote / Test / testOnly org.apache.pekko.remote.artery.SendQueueSpec"` - 5 tests succeeded / 0 failed
- JDK 25 nightly-style Scala 3.3.7: `sbt "++ 3.3.7" "remote / Test / testOnly org.apache.pekko.remote.artery.SendQueueSpec"` - 5 tests succeeded / 0 failed
- `scalafmt --mode diff-ref=origin/main`
- `scalafmt --list --mode diff-ref=origin/main`
- `git diff --check`

### References
None - nightly-builds.yml and PR Scala 3 SendQueueSpec timeout