### PR TITLE
test: make InputStreamSource TCK publisher finite

### DIFF
--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/InputStreamSourceTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/InputStreamSourceTest.scala
@@ -25,17 +25,20 @@ import org.reactivestreams.Publisher
 class InputStreamSourceTest extends PekkoPublisherVerification[ByteString] {
 
   def createPublisher(elements: Long): Publisher[ByteString] = {
+    def inputStream = new InputStream {
+      private var remaining = elements
+      override def read(): Int = {
+        if (remaining > 0) {
+          remaining -= 1
+          1
+        } else -1
+      }
+    }
+
     StreamConverters
-      .fromInputStream(() =>
-        new InputStream {
-          @volatile var num = 0
-          override def read(): Int = {
-            num += 1
-            num
-          }
-        })
+      // The TCK counts publisher elements, so emit one byte per ByteString.
+      .fromInputStream(() => inputStream, chunkSize = 1)
       .withAttributes(ActorAttributes.dispatcher("pekko.test.stream-dispatcher"))
-      .take(elements)
       .runWith(Sink.asPublisher(false))
   }
 }


### PR DESCRIPTION
### Motivation
JDK 25 nightly builds abort InputStreamSourceTest when the Reactive Streams TCK cancellation scenario waits for completion from an infinite, CPU-busy InputStream publisher.

### Modification
Make the test publisher finite and emit one byte per ByteString so the TCK element count maps directly to stream elements without relying on take(elements) to stop a busy reader.

### Result
The TCK publisher completes deterministically under JDK 25 nightly-style virtualized stream-dispatcher settings.

### Tests
- JDK 25 nightly-style virtualized stream-dispatcher flags: stream-tests-tck / Test / testOnly org.apache.pekko.stream.tck.InputStreamSourceTest
- scalafmt --mode diff-ref=origin/main --quiet
- scalafmt --list --mode diff-ref=origin/main
- git diff --check

### References
Refs #2994