### PR TITLE
test: clean up TLS edge streams after early cancellation

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/TlsGraphStageEdgeCasesSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/TlsGraphStageEdgeCasesSpec.scala
@@ -68,14 +68,24 @@ class TlsGraphStageEdgeCasesSpec extends StreamSpec(TlsGraphStageEdgeCasesSpec.c
   private def collectExactly(
       stream: Source[SslTlsInbound, NotUsed],
       expectedBytes: Int,
-      timeout: FiniteDuration = 30.seconds): ByteString =
-    Await.result(
-      stream
-        .collect { case SessionBytes(_, b) => b }
-        .scan(ByteString.empty)(_ ++ _)
-        .dropWhile(_.size < expectedBytes)
-        .runWith(Sink.headOption),
-      timeout.dilated).getOrElse(ByteString.empty)
+      timeout: FiniteDuration = 30.seconds): ByteString = {
+    val ((killSwitch, streamDone), result) = stream
+      .viaMat(KillSwitches.single)(Keep.right)
+      .watchTermination(Keep.both)
+      .toMat(
+        Flow[SslTlsInbound]
+          .collect { case SessionBytes(_, b) => b }
+          .scan(ByteString.empty)(_ ++ _)
+          .dropWhile(_.size < expectedBytes)
+          .toMat(Sink.headOption)(Keep.right))(Keep.both)
+      .run()
+
+    try Await.result(result, timeout.dilated).getOrElse(ByteString.empty)
+    finally {
+      killSwitch.shutdown()
+      Await.result(streamDone, timeout.dilated)
+    }
+  }
 
   "TlsGraphStage" must {
 


### PR DESCRIPTION
### Motivation
JDK 25 nightly builds time out in repeated TlsGraphStageEdgeCasesSpec early-cancellation scenarios because earlier materializations can keep draining after the expected bytes have been collected.

### Modification
Materialize collectExactly with a KillSwitch and watch stream termination, then shut down and await the stream in finally after the expected bytes are collected.

### Result
Repeated TLS edge-case checks do not leave prior materializations running in the same actor system.

### Tests
- JDK 25 nightly-style virtualized stream-dispatcher flags: stream-tests / Test / testOnly org.apache.pekko.stream.io.TlsGraphStageEdgeCasesSpec
- scalafmt --mode diff-ref=origin/main --quiet
- scalafmt --list --mode diff-ref=origin/main
- git diff --check

### References
Refs #2994