### PR TITLE
test: ignore late identities while awaiting rotating-keys ping

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/ssl/RotatingKeysSSLEngineProviderSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/ssl/RotatingKeysSSLEngineProviderSpec.scala
@@ -302,7 +302,10 @@ abstract class RotatingKeysSSLEngineProviderSpec(extraConfig: String)
     val ref = targetRef.getOrElse(
       fail(s"Timed out waiting for ActorIdentity from $toPath after $maxAttempts attempts"))
     ref.tell("ping-1", senderOnSource.ref)
-    senderOnSource.expectMsg("ping-1")
+    senderOnSource.fishForMessage(identifyTimeout, hint = "waiting for ping-1") {
+      case "ping-1"            => true
+      case ActorIdentity(_, _) => false
+    }
   }
 
   /**


### PR DESCRIPTION
### Motivation
RotatingKeysSSLEngineProviderSpec can receive a delayed ActorIdentity from an earlier Identify attempt after the target actor ref has already been resolved. Nightly retry policy still fails builds when that stale identity arrives before the ping reply.

### Modification
Wait for the expected ping with fishForMessage and ignore late ActorIdentity messages while keeping the same per-attempt timeout budget.

### Result
The test accepts the intended ping reply without being failed by harmless delayed Identify responses.

### Tests
- JDK 21: remote / Test / testOnly org.apache.pekko.remote.artery.tcp.ssl.RotatingProviderWithChangingKeysSpec
- JDK 25: remote / Test / testOnly org.apache.pekko.remote.artery.tcp.ssl.RotatingProviderWithChangingKeysSpec (fails on existing JDK 25 EKU certificate validation behavior)
- scalafmt --mode diff-ref=origin/main --quiet
- scalafmt --list --mode diff-ref=origin/main
- git diff --check

### References
Refs #2994