### PR TITLE
test: avoid pre-materialized substream in SplitWhen TCK

### DIFF
--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/SplitWhenTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/SplitWhenTest.scala
@@ -13,11 +13,7 @@
 
 package org.apache.pekko.stream.tck
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import org.apache.pekko
-import pekko.stream.impl.EmptyPublisher
 import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
 
@@ -26,12 +22,6 @@ import org.reactivestreams.Publisher
 class SplitWhenTest extends PekkoPublisherVerification[Int] {
 
   def createPublisher(elements: Long): Publisher[Int] =
-    if (elements == 0) EmptyPublisher[Int]
-    else {
-      val futureSource =
-        Source(iterable(elements)).splitWhen(_ => false).prefixAndTail(0).map(_._2).concatSubstreams.runWith(Sink.head)
-      val source = Await.result(futureSource, 3.seconds)
-      source.runWith(Sink.asPublisher(false))
-    }
+    Source(iterable(elements)).splitWhen(_ => false).concatSubstreams.runWith(Sink.asPublisher(false))
 
 }


### PR DESCRIPTION
### Motivation
SplitWhenTest can time out in the reactive-streams stochastic completion check on JDK 25 when the publisher is created from a pre-materialized tail substream.

### Modification
Create the TCK publisher directly from splitWhen followed by concatSubstreams, avoiding the intermediate Sink.head materialization and cancellation of the outer stream.

### Result
The publisher exercises splitWhen while keeping completion tied to the returned publisher stream.

### Tests
- JDK 25 Scala 3.3.6 with nightly-style virtualized dispatcher flags: stream-tests-tck / Test / testOnly org.apache.pekko.stream.tck.SplitWhenTest
- scalafmt --mode diff-ref=origin/main --quiet
- scalafmt --list --mode diff-ref=origin/main
- git diff --check

### References
Refs #2994