### PR TITLE
test: scale TCK Await timeouts by pekko.test.timefactor

### DIFF
--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/GroupByTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/GroupByTest.scala
@@ -30,7 +30,7 @@ class GroupByTest extends PekkoPublisherVerification[Int] {
     else {
       val futureGroupSource =
         Source(iterable(elements)).groupBy(1, _ => "all").prefixAndTail(0).map(_._2).concatSubstreams.runWith(Sink.head)
-      val groupSource = Await.result(futureGroupSource, 3.seconds)
+      val groupSource = Await.result(futureGroupSource, Timeouts.materializerTimeoutMillis.millis)
       groupSource.runWith(Sink.asPublisher(false))
 
     }

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PrefixAndTailTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PrefixAndTailTest.scala
@@ -26,7 +26,7 @@ class PrefixAndTailTest extends PekkoPublisherVerification[Int] {
 
   def createPublisher(elements: Long): Publisher[Int] = {
     val futureTailSource = Source(iterable(elements)).prefixAndTail(0).map { case (_, tail) => tail }.runWith(Sink.head)
-    val tailSource = Await.result(futureTailSource, 3.seconds)
+    val tailSource = Await.result(futureTailSource, Timeouts.materializerTimeoutMillis.millis)
     tailSource.runWith(Sink.asPublisher(false))
   }
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/Timeouts.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/Timeouts.scala
@@ -22,12 +22,20 @@ object Timeouts {
   private val timeFactor: Double =
     sys.props.get("pekko.test.timefactor").map(_.toDouble).getOrElse(1.0)
 
-  def publisherShutdownTimeoutMillis: Int = 3000
+  def publisherShutdownTimeoutMillis: Int = math.ceil(3000 * timeFactor).toInt
 
   def defaultTimeoutMillis: Int = (800 * timeFactor).toInt
 
   def defaultNoSignalsTimeoutMillis: Int = (200 * timeFactor).toInt
 
   def actorSystemShutdownTimeoutMillis: Int = math.ceil(10000 * timeFactor).toInt
+
+  // Used by TCK Test classes that need to materialize an intermediate stream to
+  // obtain the Publisher under test (e.g. groupBy, prefixAndTail). The base 3s
+  // is the historical hardcoded value; scaling by timeFactor keeps it stable on
+  // JDK 25 nightly runs where compounded GC + ForkJoinPool pressure occasionally
+  // pushes a single materialization beyond 3s during 100-iteration stochastic
+  // tests, which previously caused the TCK suite to abort with "signalled 0".
+  def materializerTimeoutMillis: Int = math.ceil(3000 * timeFactor).toInt
 
 }


### PR DESCRIPTION
### Motivation

`GroupByTest` and `PrefixAndTailTest` abort the TCK suite on JDK 25 nightly runs with:

```
java.lang.AssertionError: Failed in iteration 18 of 100.
Expected completion signal after signalling 10 elements (signalled 0),
yet did not receive it within 32000 ms
  at org.reactivestreams.tck.PublisherVerification.stochastic_spec103_mustSignalOnMethodsSequentially(...)
```

after roughly 18 iterations of `stochastic_spec103_mustSignalOnMethodsSequentially`.

Both `createPublisher` implementations materialize an intermediate stream and call `Await.result(future, 3.seconds)` to obtain the `Source` wrapped by the test `Publisher`. The `3.seconds` value is a hardcoded constant that does not honour `pekko.test.timefactor`, so the JDK 25 nightly's compounded GC + ForkJoinPool pressure can push a single materialization beyond 3s during the 100-iteration stochastic test, which surfaces as a `Publisher` that signals zero elements (and then aborts the whole TCK suite).

`Timeouts` already scales every other field by `timeFactor`. `publisherShutdownTimeoutMillis` is the only existing field that wasn't scaled.

### Modification

- Add `Timeouts.materializerTimeoutMillis`, scaled by `timeFactor`.
- Route the `Await.result` calls in `GroupByTest` and `PrefixAndTailTest` through the new helper instead of the hardcoded `3.seconds`.
- Apply the same `timeFactor` scaling to the existing `publisherShutdownTimeoutMillis` so the whole `Timeouts` object behaves consistently.

### Result

On local runs (`timeFactor=1`) the effective budget stays at 3s, so the test still flags genuine materialization regressions. On the JDK 25 nightly (`timeFactor=4`) the budget grows to 12s, which covers the observed worst-case materialization delays without masking real bugs.

### Tests

- `sbt stream-tests-tck/Test/compile` (Scala 2.13) succeeded locally.

### References

- Failing nightly: https://github.com/apache/pekko/actions/runs/26571377673
- Failing nightly: https://github.com/apache/pekko/actions/runs/26611472055
- Tracking issue: #2573