### PR TITLE
test: widen TCK actor-system-terminate phase timeout

### DIFF
--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/ActorSystemLifecycle.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/ActorSystemLifecycle.scala
@@ -42,9 +42,19 @@ trait ActorSystemLifecycle {
 
   def shutdownTimeout: FiniteDuration = Timeouts.actorSystemShutdownTimeoutMillis.millis
 
+  // Always-applied baseline for TCK ActorSystems. The default Pekko
+  // `actor-system-terminate` phase timeout is 10s, which is occasionally too
+  // tight on JDK 25 nightly runs (virtualized dispatchers + heavy stochastic
+  // TCK iterations leave stream actors mid-shutdown). Widening the phase
+  // timeout gives the outer 40s shutdown await (see Timeouts) enough room to
+  // drain leftover materializations cleanly instead of aborting the suite.
+  private def baselineConfig: Config =
+    ConfigFactory.parseString("pekko.coordinated-shutdown.phases.actor-system-terminate.timeout = 30 s")
+
   @BeforeClass
   def createActorSystem(): Unit = {
-    _system = ActorSystem(Logging.simpleName(getClass), additionalConfig.withFallback(PekkoSpec.testConf))
+    val config = additionalConfig.withFallback(baselineConfig).withFallback(PekkoSpec.testConf)
+    _system = ActorSystem(Logging.simpleName(getClass), config)
     _system.eventStream.publish(TestEvent.Mute(EventFilter[RuntimeException]("Test exception")))
   }
 


### PR DESCRIPTION
### Motivation

`FlattenTest` and `FilePublisherTest` abort the TCK suite on JDK 25 nightly runs with:

```
[WARN] CoordinatedShutdown(pekko://FlattenTest) Coordinated shutdown phase
[actor-system-terminate] timed out after 10000 milliseconds
java.lang.RuntimeException: Failed to stop [FlattenTest] within [40000 milliseconds]
  toDie: Actor[pekko://FlattenTest/system/Materializers/StreamSupervisor-4/flow-6-0-flattenMerge#-2133714097]
  at org.apache.pekko.stream.tck.ActorSystemLifecycle.shutdownActorSystem(ActorSystemLifecycle.scala:61)
```

The outer 40s shutdown await scales with `pekko.test.timefactor` (via `Timeouts.actorSystemShutdownTimeoutMillis`), but the inner `CoordinatedShutdown` `actor-system-terminate` phase keeps its default `10s`, which is occasionally too tight on JDK 25 nightlies where virtualized dispatchers + heavy stochastic TCK iterations leave a stream actor mid-shutdown. The phase times out before the last flow actor finishes terminating, even though the outer await still has 30s of headroom.

### Modification

- `ActorSystemLifecycle` now layers a baseline config under `additionalConfig`, widening the `actor-system-terminate` phase timeout from `10s` to `30s` for every TCK `ActorSystem` (Publisher, Subscriber, and IdentityProcessor verifications).
- The baseline is applied via `withFallback` so any subclass `additionalConfig` override that explicitly sets the same key still wins.

### Result

The inner phase now has 30s to drain leftover materializations before the outer 40s await fires (`timeFactor=4` on JDK 25 nightly), removing the abort path observed for `FlattenTest` and `FilePublisherTest` without changing behaviour on local runs (where shutdown completes well under 1s).

### Tests

- `sbt stream-tests-tck/Test/compile` (Scala 2.13) succeeded locally.

### References

- Failing nightly: https://github.com/apache/pekko/actions/runs/26611472055
- Tracking issue: #2573