### PR TITLE
fix: restore acquire semantics for AbstractNodeQueue node reads

### DIFF
--- a/actor/src/main/java/org/apache/pekko/dispatch/AbstractBoundedNodeQueue.java
+++ b/actor/src/main/java/org/apache/pekko/dispatch/AbstractBoundedNodeQueue.java
@@ -50,7 +50,10 @@ public abstract class AbstractBoundedNodeQueue<T> {
     }
 
     private Node<T> getEnq() {
-        return (Node<T>) enqHandle.get(this);
+        // Volatile read: this field is published across threads via casEnq; a plain read
+        // (VarHandle.get) carries no ordering even on a volatile field and may observe a
+        // stale node or be hoisted out of the spin loops in peekNode/pollNode.
+        return (Node<T>) enqHandle.getVolatile(this);
     }
 
     private boolean casEnq(Node<T> old, Node<T> nju) {
@@ -62,7 +65,8 @@ public abstract class AbstractBoundedNodeQueue<T> {
     }
 
     private Node<T> getDeq() {
-        return (Node<T>) deqHandle.get(this);
+        // Volatile read: see getEnq. Published across threads via casDeq.
+        return (Node<T>) deqHandle.getVolatile(this);
     }
 
     private boolean casDeq(Node<T> old, Node<T> nju) {
@@ -75,6 +79,9 @@ public abstract class AbstractBoundedNodeQueue<T> {
           final Node<T> next = deq.next();
           if (next != null || getEnq() == deq)
             return next;
+          // spinning until the producer that already advanced enq finishes linking next;
+          // onSpinWait reduces busy-wait power/pipeline cost and yields to an SMT sibling.
+          Thread.onSpinWait();
         }
     }
 
@@ -204,7 +211,13 @@ public abstract class AbstractBoundedNodeQueue<T> {
 
         @SuppressWarnings("unchecked")
         public final Node<T> next() {
-            return (Node<T>) nextHandle.get(this);
+            // Acquire load to pair with the release store in setNext: it establishes the
+            // happens-before that publishes the node and prevents the read from being hoisted
+            // out of the spin loops in peekNode/pollNode (a plain VarHandle.get carries no
+            // ordering even on a volatile field and may be hoisted, yielding an endless spin).
+            // getAcquire is sufficient here (release/acquire pairing) and is no costlier than
+            // getVolatile for a load, so the stronger sequential consistency is not needed.
+            return (Node<T>) nextHandle.getAcquire(this);
         }
 
         protected final void setNext(final Node<T> newNext) {

--- a/actor/src/main/java/org/apache/pekko/dispatch/AbstractNodeQueue.java
+++ b/actor/src/main/java/org/apache/pekko/dispatch/AbstractNodeQueue.java
@@ -54,12 +54,15 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
      */
     @SuppressWarnings("unchecked")
     protected final Node<T> peekNode() {
-        final Node<T> tail = (Node<T>) tailHandle.get(this);
+        final Node<T> tail = (Node<T>) tailHandle.getAcquire(this);
         Node<T> next = tail.next();
         if (next == null && get() != tail) {
             // if tail != head this is not going to change until producer makes progress
-            // we can avoid reading the head and just spin on next until it shows up
+            // we can avoid reading the head and just spin on next until it shows up.
+            // onSpinWait hints the CPU we are busy-waiting: it cuts spin power/pipeline cost
+            // and yields the core to an SMT sibling (which may be the producer linking next).
             do {
+                Thread.onSpinWait();
                 next = tail.next();
             } while (next == null);
         }
@@ -110,7 +113,7 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
      * @return true if queue was empty at some point in the past
      */
     public final boolean isEmpty() {
-        return tailHandle.get(this) == get();
+        return tailHandle.getAcquire(this) == get();
     }
 
     /**
@@ -126,7 +129,7 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
     public final int count() {
         int count = 0;
         final Node<T> head = get();
-        for(Node<T> n = ((Node<T>) tailHandle.get(this)).next();
+        for(Node<T> n = ((Node<T>) tailHandle.getAcquire(this)).next();
             n != null && count < Integer.MAX_VALUE; 
             n = n.next()) {
           ++count;
@@ -162,12 +165,15 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
      */
     @SuppressWarnings("unchecked")
     public final Node<T> pollNode() {
-      final Node<T> tail = (Node<T>) tailHandle.get(this);
+      final Node<T> tail = (Node<T>) tailHandle.getAcquire(this);
       Node<T> next = tail.next();
       if (next == null && get() != tail) {
           // if tail != head this is not going to change until producer makes progress
-          // we can avoid reading the head and just spin on next until it shows up
+          // we can avoid reading the head and just spin on next until it shows up.
+          // onSpinWait hints the CPU we are busy-waiting: it cuts spin power/pipeline cost
+          // and yields the core to an SMT sibling (which may be the producer linking next).
           do {
+              Thread.onSpinWait();
               next = tail.next();
           } while (next == null);
       }
@@ -208,7 +214,13 @@ public abstract class AbstractNodeQueue<T> extends AtomicReference<AbstractNodeQ
         }
 
         public final Node<T> next() {
-            return (Node<T>) nextHandle.get(this);
+            // Acquire load to pair with the release store in setNext: it establishes the
+            // happens-before that publishes the node and prevents the read from being hoisted
+            // out of the spin loops in peekNode/pollNode (a plain VarHandle.get carries no
+            // ordering even on a volatile field and may be hoisted, yielding an endless spin).
+            // getAcquire is sufficient here (release/acquire pairing) and is no costlier than
+            // getVolatile for a load, so the stronger sequential consistency is not needed.
+            return (Node<T>) nextHandle.getAcquire(this);
         }
 
         protected final void setNext(final Node<T> newNext) {


### PR DESCRIPTION
### Motivation

JDK 25 nightly stream tests hang for the full test timeout (the recurring failures behind #2573 / #2870). A local reproduction — the full `stream-tests` run with the nightly `virtualize=on` + `timefactor=4` options on JDK 25 — pins it down:

- one `...-pekko.test.stream-dispatcher-CarrierThread-N` consumes **~97% CPU** (cpu time ≈ elapsed time) stuck in `AbstractNodeQueue.pollNode`,
- every other carrier is idle in `ForkJoinPool.awaitWork`,
- a full virtual-thread dump shows **no producer thread anywhere**.

The spinning consumer is a virtual thread, so the unbounded CPU spin pins its carrier permanently; the stream never progresses and the test's `futureValue` never completes. Every affected test passes in isolation (~100ms) even with the full nightly JVM options — the hang only appears under sustained load, because it is a JIT-state-dependent data race.

### Root cause

PR #1990 (*avoid sun.misc.Unsafe by using VarHandles*) mapped the **producer writes** correctly (`Unsafe.putOrderedObject` → `VarHandle.setRelease`) but **downgraded every consumer read** from `Unsafe.getObjectVolatile` (a volatile/acquire load) to `VarHandle.get` — which has **plain** memory semantics even when the field is declared `volatile`.

A plain read is not ordered against the producer's release store, so it establishes no happens-before with the published node. Inside the busy-spin loops in `peekNode`/`pollNode`:

```java
do { next = tail.next(); } while (next == null);
```

the JIT may hoist the plain load out of the loop, producing an unbounded spin that never observes the linked next node. JDK 25's C2 makes this manifest reliably, and virtual-thread carriers turn the transient spin into a permanent 100% CPU pin.

This is the same memory ordering that lock-free MPSC queues such as JCTools use (consumer-side `lvNext` / load-acquire on the next pointer); the original Unsafe code matched it, and #1990 inadvertently broke it.

### Modification

- `Node.next()` and the four `tailHandle` reads (`peekNode`, `pollNode`, `isEmpty`, `count`) now use `getAcquire`, restoring the volatile-read semantics the code had before #1990 and pairing with the existing `setRelease` writes.
- Added `Thread.onSpinWait()` to both busy-spin loops as standard spin-wait hygiene.

### Performance

This **restores** the pre-#1990 memory semantics rather than adding new cost:

| Arch | plain `get` (since #1990) | `getAcquire` (this PR / original Unsafe `getObjectVolatile`) |
|------|---------------------------|-------------------------------------------------------------|
| x86-64 | `MOV` | `MOV` (all x86 loads already have acquire semantics) — **zero difference** |
| AArch64 | `LDR` | `LDAR` (single instruction) — **same as pre-#1990** |

Net effect versus the original Unsafe-based design is zero on x86-64 and negligible on AArch64; it only removes the broken plain-read micro-optimization the VarHandle migration introduced. Method signatures are unchanged → no binary-compatibility impact.

### Result

With the fix, the previously hanging `HubSpec "work with long streams if one of the producers is slower"` completes in ~2.7s (was stuck for the full timeout), and the full `stream-tests` run proceeds past the point where it previously hung (1800+ tests, no hang) under the same nightly `virtualize=on` + `timefactor=4` JVM options on JDK 25.

### Tests

- `sbt actor/compile` succeeds.
- Local full `stream-tests` run with nightly JVM options (`virtualize=on`, `minimum-runnable=8`, `timefactor=4`) on JDK 25.0.1 no longer hangs at HubSpec and proceeds normally; the specific previously-hanging test now passes in ~2.7s.
- Signatures unchanged, so MiMa is unaffected.

### References

- https://github.com/apache/pekko/issues/2870
- https://github.com/apache/pekko/issues/2573
- Regression introduced in #1990