### PR TITLE
fix: complete MapAsyncPartitioned ordered stage after trailing resumed failures

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
@@ -398,6 +398,26 @@ class FlowMapAsyncPartitionedSpec extends StreamSpec with WithLogCapturing {
       expected.futureValue should contain theSameElementsInOrderAs (1 to 10).filter(_ % 4 == 3)
     }
 
+    "resume (unordered) after multiple failures if resume supervision is in place" in {
+      implicit val ec: ExecutionContext = system.dispatcher
+
+      // Mirrors the ordered case: the final elements (8, 9, 10) all fail under the resuming
+      // decider, so the stage must still complete once the buffer drains after upstream finish.
+      // Guards the unordered completion path against the regression fixed for the ordered path.
+      val expected =
+        Source(1 to 10)
+          .mapAsyncPartitionedUnordered(4)(_ % 3) { (elem, _) =>
+            Future {
+              if (elem % 4 < 3) throw new TE("BOOM!")
+              else elem
+            }
+          }
+          .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+          .runWith(Sink.seq)
+
+      expected.futureValue should contain theSameElementsAs (1 to 10).filter(_ % 4 == 3)
+    }
+
     "ignore null-completed futures" in {
       val shouldBeNull = {
         val n = scala.util.Random.nextInt(10) + 1

--- a/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
@@ -209,6 +209,11 @@ private[stream] final class MapAsyncPartitioned[In, Out, Partition](
             }
           }
           drainQueue()
+          // The while-loop's Failure (resume) branch dequeues elements without calling pullIfNeeded(),
+          // so when the final buffered elements are resumed failures the buffer empties here without any
+          // completion check. pullIfNeeded() is the only path that runs completeStage() once upstream has
+          // finished, so it must run after draining or the stage hangs forever (mirrors the unordered branch).
+          pullIfNeeded()
         }
 
       private def pushNextIfPossibleUnordered(): Unit =


### PR DESCRIPTION
Closes #2903

## Motivation

`FlowMapAsyncPartitionedSpec` *"resume after multiple failures if resume supervision is in place"* intermittently hung for 60s and failed with a `ScalaFutures` timeout:

```
A timeout occurred waiting for a future to complete. Waited 60000000000 nanoseconds. (FlowMapAsyncPartitionedSpec.scala:398)
```

This is the same completion-path family as the `drainQueue` concurrent-modification race fixed in #2899 — see #2903. #2899 fixed the race but left this completion branch unaddressed.

## Modification

`pushNextIfPossibleOrdered`'s non-empty-`partitionsInProgress` branch ended with only `drainQueue()`, never calling `pullIfNeeded()`. Inside its `while` loop, only the `Success` branch calls `pullIfNeeded()` (which holds the sole `completeStage()` check on the push path); the `Failure`/`Supervision.Resume` branch dequeues elements **without** any completion check.

As a result, when the **final** buffered elements are resumed failures, the buffer empties while upstream has already finished, but `completeStage()` is never invoked — the stage hangs and the downstream future never completes.

The fix adds a trailing `pullIfNeeded()` after `drainQueue()` in the ordered branch, mirroring `pushNextIfPossibleUnordered` which already had it. `pullIfNeeded()` is O(1), allocation-free and runs once per async callback (outside the per-element loop), so there is no hot-path or JIT impact. `tryPull` is guarded by `!isClosed(in)`, so calling `pullIfNeeded()` after upstream close is safe (no-op pull, only the `completeStage()` check fires).

This explains why only this test triggered it: `resume after failed future` (1→5) ends with a success (element 5 → `Success` branch → completes), whereas `resume after multiple failures` (1→10) ends with elements 8/9/10 all failing (`%4 < 3`), so the last dequeue is a resumed failure.

## Tests

- The previously timing-out ordered test now passes in ~1ms and is deterministic (5 consecutive green runs).
- Added `resume (unordered) after multiple failures if resume supervision is in place` to guard the symmetric unordered completion path against future regressions.

```
- must resume after multiple failures if resume supervision is in place (1 millisecond)
- must resume (unordered) after multiple failures if resume supervision is in place (1 millisecond)
Tests: succeeded 19, failed 0, canceled 0, ignored 0, pending 0
```

`sbt "stream-tests/testOnly org.apache.pekko.stream.scaladsl.FlowMapAsyncPartitionedSpec"`; scalafmt run on changed Scala sources.

Internal API only (`@InternalApi private[stream]`); no public API / binary-compatibility impact.

## References

- #2903
- #2899