### PR TITLE
test: widen HandshakeRetrySpec buffered-message timeout

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/artery/HandshakeRetrySpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/HandshakeRetrySpec.scala
@@ -45,7 +45,10 @@ class HandshakeRetrySpec extends ArteryMultiNodeSpec(HandshakeRetrySpec.commonCo
         newRemoteSystem(name = Some("systemB"), extraConfig = Some(s"pekko.remote.artery.canonical.port = $portB"))
       systemB.actorOf(TestActors.echoActorProps, "echo")
 
-      expectMsg("hello")
+      // The first message is buffered while the outbound handshake is retried and is only
+      // delivered once the handshake completes, which can take up to handshake-timeout (10s).
+      // The default expect timeout is too tight under CI load, so wait well beyond it.
+      expectMsg(15.seconds, "hello")
 
       sel ! Identify(None)
       val remoteRef = expectMsgType[ActorIdentity].ref.get


### PR DESCRIPTION
## Motivation

`HandshakeRetrySpec` *"be retried during handshake-timeout (no message loss)"* is intermittently flaky in CI, timing out at `expectMsg` while waiting for `"hello"` (#560, #634, #276).

The first message is sent **before** `systemB` exists, so it is buffered while the outbound handshake is retried, and is only delivered once the handshake completes. With `handshake-timeout = 10s`, delivery can legitimately take longer than the default expect timeout (`single-expect-default`, ~6s under `timefactor = 2` in CI), so the assertion fires before the message arrives — even though no message is actually lost.

## Modification

Wait for the buffered `"hello"` with an explicit `15s` timeout (dilated by `pekko.test.timefactor`), comfortably above the `10s` `handshake-timeout`.

## Result

The test no longer races the handshake window under CI load; it still passes locally.

```
[info] HandshakeRetrySpec:
[info] - must be retried during handshake-timeout (no message loss) (1 second, 241 milliseconds)
[info] All tests passed.
```

## Tests

`remote/testOnly org.apache.pekko.remote.artery.HandshakeRetrySpec` — passes. `scalafmt` run on the changed file. Test-only change.

## References

Fixes #560
Fixes #634
Fixes #276