### PR TITLE
test: await eventual deletion in RemoveInternalClusterShardingDataSpec

### DIFF
--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/RemoveInternalClusterShardingDataSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/RemoveInternalClusterShardingDataSpec.scala
@@ -190,8 +190,11 @@ class RemoveInternalClusterShardingDataSpec
       watch(rm)
       expectMsg(Result(Success(Removals(events = true, snapshots = true))))
       expectTerminated(rm)
-      hasSnapshots("type2") should ===(false)
-      hasEvents("type2") should ===(false)
+      awaitAssert {
+        // deletion may not be visible to a fresh read immediately after the removal completes
+        hasSnapshots("type2") should ===(false)
+        hasEvents("type2") should ===(false)
+      }
     }
   }
 


### PR DESCRIPTION
## Motivation

`RemoveInternalClusterShardingDataSpec` *"must remove all events and snapshots"* is intermittently flaky (#1228), failing with `true did not equal false` at the post-removal `hasSnapshots`/`hasEvents` assertions.

Even though `RemoveOnePersistenceId` has already replied with a successful `Removals` result, a fresh read of the snapshot/event store may not observe the deletion immediately, so the assertion can still see stale data.

## Modification

Wrap the post-removal `hasSnapshots`/`hasEvents` assertions in `awaitAssert` so they retry until the deletion becomes visible — mirroring the `awaitAssert` already used for the pre-removal snapshot-visibility check a few lines above.

## Result

The test tolerates the eventual visibility of deletions; it still passes locally.

```
[info] - must remove all events and snapshots (133 milliseconds)
[info] - must remove all events and snapshots (828 milliseconds)
[info] Tests: succeeded 6, failed 0
[info] All tests passed.
```

## Tests

`cluster-sharding/testOnly org.apache.pekko.cluster.sharding.RemoveInternalClusterShardingDataSpec` — all 6 pass. `scalafmt` run on the changed file. Test-only change.

## References

Fixes #1228