### PR TITLE
test: retry temporary port bind in RemotingSpec lazy-connect test

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/classic/RemotingSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/RemotingSpec.scala
@@ -836,17 +836,10 @@ class RemotingSpec extends PekkoSpec(RemotingSpec.cfg) with ImplicitSender with 
       try {
         muteSystem(thisSystem)
         val thisProbe = new TestProbe(thisSystem)
-        val thisSender = thisProbe.ref
         thisSystem.actorOf(Props[Echo2](), "echo")
-        val otherAddress = temporaryServerAddress()
-        val otherConfig = ConfigFactory.parseString(s"""
-              pekko.remote.classic.netty.tcp.port = ${otherAddress.getPort}
-              """).withFallback(config)
-        val otherSelection =
-          thisSystem.actorSelection(s"pekko.tcp://other-system@localhost:${otherAddress.getPort}/user/echo")
-        otherSelection.tell("ping", thisSender)
-        thisProbe.expectNoMessage(1.seconds)
-        val otherSystem = ActorSystem("other-system", otherConfig)
+        // selectionAndBind retries on a fresh port, since the temporaryServerAddress can be taken
+        // by the time the new actor system binds (see #1679)
+        val (otherSystem, _) = selectionAndBind(config, thisSystem, thisProbe)
         try {
           muteSystem(otherSystem)
           thisProbe.expectNoMessage(2.seconds)


### PR DESCRIPTION
## Motivation

`RemotingSpec` *"allow other system to connect even if it's not there at first"* intermittently fails at `ActorSystem` startup with **Address already in use** (#1679).

The test allocates a port via `temporaryServerAddress()` and then binds a new `ActorSystem` to it; the port can be claimed by another process between allocation and bind.

## Modification

Reuse the existing `selectionAndBind` helper — already used by the sibling *"be able to connect to system even if it's not there at first"* test — which retries on a fresh port when the bind fails with `Failed to bind`.

## Result

The lazy-connect test no longer races temporary port allocation; it still passes locally.

```
[info] - must allow other system to connect even if it's not there at first (5 seconds, 454 milliseconds)
[info] Tests: succeeded 1, failed 0
[info] All tests passed.
```

## Tests

`remote/testOnly org.apache.pekko.remote.classic.RemotingSpec -- -z "allow other system to connect even if"` — passes. `scalafmt` run on the changed file. Test-only change.

## References

Fixes #1679