### PR TITLE
optimize: avoid Holder allocation in ordered mapAsync for already-completed futures

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -1319,19 +1319,30 @@ private[stream] object Collect {
       override def onPush(): Unit = {
         try {
           val future = f(grab(in))
-          val holder = new Holder[Out](NotYetThere, futureCB)
-          buffer.enqueue(holder)
-
           future.value match {
-            case None    => future.onComplete(holder)(scala.concurrent.ExecutionContext.parasitic)
+            // Not-yet-completed future: reserve this element's ordered slot with a Holder. Listed first so
+            // the pending path costs only a single type check and never evaluates the fast-path guard below
+            // (behaviourally and cost-wise identical to before this fast path was introduced).
+            case None =>
+              val holder = new Holder[Out](NotYetThere, futureCB)
+              buffer.enqueue(holder)
+              future.onComplete(holder)(scala.concurrent.ExecutionContext.parasitic)
+            // Zero-allocation fast path: the future is already completed with a non-null element and
+            // nothing is buffered ahead of it, so ordering is already satisfied and downstream demand is
+            // present. Push straight through, skipping the Holder allocation and the buffer round-trip.
+            case Some(Success(elem)) if (elem != null) && buffer.isEmpty && isAvailable(out) =>
+              push(out, elem)
             case Some(v) =>
+              val holder = new Holder[Out](NotYetThere, futureCB)
+              buffer.enqueue(holder)
               // #20217 the future is already here, optimization: avoid scheduling it on the dispatcher and
               // run the logic directly on this thread
               holder.setElem(v)
               v match {
                 // this optimization also requires us to stop the stage to fail fast if the decider says so:
-                case Failure(ex) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop => failStage(ex)
-                case _                                                                              => pushNextIfPossible()
+                case Failure(ex) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop =>
+                  failStage(ex)
+                case _ => pushNextIfPossible()
               }
           }
 


### PR DESCRIPTION
## Motivation

Ordered `MapAsync` allocates a `Holder` and performs a buffer enqueue/dequeue round-trip for **every** element, even when the future returned by the user function is already completed successfully and could be emitted immediately. With a synchronously-completing function (caching, `Future.successful`, conditional async, ...) this is pure per-element garbage.

Note: `mapAsync(1)` delegates to `mapAsyncUnordered(1)` (Flow.scala), and `MapAsyncUnordered` already pushes completed results straight through without a `Holder`. The allocation only existed in the **ordered** stage at `parallelism >= 2`.

## Modification

In `MapAsync.onPush`, add a zero-allocation fast path: when the future is already completed with a non-null element, nothing is buffered ahead of it (so ordering is already satisfied) and downstream demand is present, push the element straight through without allocating a `Holder` or touching the buffer.

The not-yet-completed (`None`) case is matched **first**, so the pending path is unchanged: a single type check that never evaluates the fast-path guard (behaviourally and cost-wise identical to before).

## Result

JMH `MapAsyncBenchmark` (`parallelism=4`, `spawn=false`): **18.0M -> 20.3M ops/s (+12%)**, with the per-element `Holder` allocation eliminated (confirmed via async-profiler alloc profile: `Holder` disappears; remaining allocation is the user's `Success` box from `Future.successful`). No regression on the asynchronous path (`spawn=true`, within run-to-run noise).

## Tests

- `sbt "stream-tests/testOnly *FlowMapAsyncSpec"` — 27/27 green. Existing coverage already exercises the fast path: "produce future elements in order" mixes `Future.successful` with async futures, and `mapAsync(2)(Future.successful(_))` drives ordered + already-completed.
- `sbt stream/Compile/compile`, `stream/scalafmt`, `stream/headerCheck`, `stream/mimaReportBinaryIssues` — all green (binary compatible, internal API only).

## References

- bench-jmh `MapAsyncBenchmark`
- Relates to the existing already-completed-future optimization (#20217).
