### PR TITLE
fix: guard against int overflow in supervisor strategy and frequency sketch

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/SupervisorSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/SupervisorSpec.scala
@@ -613,4 +613,30 @@ class SupervisorSpec
     killExpectNoRestart(pingpong)
   }
 
+  "respects maxNrOfRetries with withinTimeRange whose toMillis exceeds Int.MaxValue (OneForOneStrategy)" in {
+    // 30 days = 2,592,000,000 ms which silently overflowed to a negative Int before the fix,
+    // causing retriesInWindowOkay to always return true (unlimited restarts)
+    val supervisor = system.actorOf(Props(
+      new Supervisor(OneForOneStrategy(maxNrOfRetries = 2, withinTimeRange = 30.days)(classOf[Exception] :: Nil))))
+
+    val pingpong = child(supervisor, Props(new PingPongActor(testActor)))
+
+    kill(pingpong)
+    kill(pingpong)
+    killExpectNoRestart(pingpong)
+  }
+
+  "respects maxNrOfRetries with withinTimeRange whose toMillis exceeds Int.MaxValue (AllForOneStrategy)" in {
+    // 30 days = 2,592,000,000 ms which silently overflowed to a negative Int before the fix,
+    // causing retriesInWindowOkay to always return true (unlimited restarts)
+    val supervisor = system.actorOf(Props(
+      new Supervisor(AllForOneStrategy(maxNrOfRetries = 2, withinTimeRange = 30.days)(classOf[Exception] :: Nil))))
+
+    val pingpong = child(supervisor, Props(new PingPongActor(testActor)))
+
+    kill(pingpong)
+    kill(pingpong)
+    killExpectNoRestart(pingpong)
+  }
+
 }

--- a/actor-tests/src/test/scala/org/apache/pekko/util/FrequencySketchSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/FrequencySketchSpec.scala
@@ -283,7 +283,8 @@ class FrequencySketchSpec extends AnyWordSpec with Matchers {
     }
 
     "reject capacity that would cause width to overflow Int with custom widthMultiplier" in {
-      an[IllegalArgumentException] should be thrownBy FrequencySketch[String](capacity = 100, widthMultiplier = Int.MaxValue)
+      an[IllegalArgumentException] should be thrownBy
+      FrequencySketch[String](capacity = 100, widthMultiplier = Int.MaxValue)
     }
   }
 
@@ -408,7 +409,8 @@ class FrequencySketchSpec extends AnyWordSpec with Matchers {
     }
 
     "reject capacity that would cause width to overflow Int with custom widthMultiplier" in {
-      an[IllegalArgumentException] should be thrownBy FastFrequencySketch[String](capacity = 100, widthMultiplier = Int.MaxValue)
+      an[IllegalArgumentException] should be thrownBy
+      FastFrequencySketch[String](capacity = 100, widthMultiplier = Int.MaxValue)
     }
   }
 }

--- a/actor-tests/src/test/scala/org/apache/pekko/util/FrequencySketchSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/FrequencySketchSpec.scala
@@ -264,6 +264,27 @@ class FrequencySketchSpec extends AnyWordSpec with Matchers {
       sketch.frequency("foo") shouldBe 2
       sketch.frequency("bar") shouldBe 2
     }
+
+    "reject capacity that would cause width to overflow Int" in {
+      // capacity > 536,870,912 with default widthMultiplier=4: ceilingPowerOfTwo gives 2^30=1073741824, times 4 overflows
+      an[IllegalArgumentException] should be thrownBy FrequencySketch[String](capacity = 536_870_913)
+    }
+
+    "detect width overflow that would have been missed by Int arithmetic" in {
+      // before the fix, widthMultiplier * ceilingPowerOfTwo(capacity) was computed in Int and could silently overflow
+      val capacity = 536_870_913
+      val widthMultiplier = 4
+      // the old Int multiplication silently overflows to a non-power-of-two or zero/negative value
+      val widthInt = widthMultiplier * FrequencySketch.Bits.ceilingPowerOfTwo(capacity)
+      widthInt should be <= 0 // negative or zero due to Int overflow (old broken behavior)
+      // the new Long multiplication correctly identifies the overflow
+      val widthLong = widthMultiplier.toLong * FrequencySketch.Bits.ceilingPowerOfTwo(capacity).toLong
+      widthLong should be > Int.MaxValue.toLong
+    }
+
+    "reject capacity that would cause width to overflow Int with custom widthMultiplier" in {
+      an[IllegalArgumentException] should be thrownBy FrequencySketch[String](capacity = 100, widthMultiplier = Int.MaxValue)
+    }
   }
 
   "FastFrequencySketch" must {
@@ -369,6 +390,25 @@ class FrequencySketchSpec extends AnyWordSpec with Matchers {
       }
       val accuracy = correct.toDouble / comparisons
       accuracy should be > 0.95 // note: depends on the hash collisions, and random distribution
+    }
+
+    "reject capacity that would cause width to overflow Int" in {
+      // capacity > 536,870,912 with default widthMultiplier=4: ceilingPowerOfTwo gives 2^30=1073741824, times 4 overflows
+      an[IllegalArgumentException] should be thrownBy FastFrequencySketch[String](capacity = 536_870_913)
+    }
+
+    "detect width overflow that would have been missed by Int arithmetic" in {
+      // before the fix, widthMultiplier * ceilingPowerOfTwo(capacity) was computed in Int and could silently overflow
+      val capacity = 536_870_913
+      val widthMultiplier = 4
+      val widthInt = widthMultiplier * FrequencySketch.Bits.ceilingPowerOfTwo(capacity)
+      widthInt should be <= 0 // negative or zero due to Int overflow (old broken behavior)
+      val widthLong = widthMultiplier.toLong * FrequencySketch.Bits.ceilingPowerOfTwo(capacity).toLong
+      widthLong should be > Int.MaxValue.toLong
+    }
+
+    "reject capacity that would cause width to overflow Int with custom widthMultiplier" in {
+      an[IllegalArgumentException] should be thrownBy FastFrequencySketch[String](capacity = 100, widthMultiplier = Int.MaxValue)
     }
   }
 }

--- a/actor/src/main/scala/org/apache/pekko/actor/FaultHandling.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/FaultHandling.scala
@@ -544,7 +544,8 @@ case class AllForOneStrategy(
    *  across actors and thus this field does not take up much space
    */
   private val retriesWindow =
-    (maxNrOfRetriesOption(maxNrOfRetries), withinTimeRangeOption(withinTimeRange).map(_.toMillis.toInt))
+    (maxNrOfRetriesOption(maxNrOfRetries),
+      withinTimeRangeOption(withinTimeRange).map(d => math.min(Int.MaxValue.toLong, d.toMillis).toInt))
 
   def handleChildTerminated(context: ActorContext, child: ActorRef, children: Iterable[ActorRef]): Unit = ()
 
@@ -656,7 +657,8 @@ case class OneForOneStrategy(
    */
   private val retriesWindow = (
     SupervisorStrategy.maxNrOfRetriesOption(maxNrOfRetries),
-    SupervisorStrategy.withinTimeRangeOption(withinTimeRange).map(_.toMillis.toInt))
+    SupervisorStrategy.withinTimeRangeOption(withinTimeRange).map(d =>
+      math.min(Int.MaxValue.toLong, d.toMillis).toInt))
 
   def handleChildTerminated(context: ActorContext, child: ActorRef, children: Iterable[ActorRef]): Unit = ()
 

--- a/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
@@ -61,7 +61,8 @@ private[pekko] object FrequencySketch {
       depth: Int = 4,
       counterBits: Int = 4)(implicit hasher: Hasher[A]): FrequencySketch[A] = {
     val widthLong = widthMultiplier.toLong * Bits.ceilingPowerOfTwo(capacity).toLong
-    require(widthLong <= Int.MaxValue, s"computed width ($widthLong) exceeds Int.MaxValue; reduce capacity or widthMultiplier")
+    require(widthLong <= Int.MaxValue,
+      s"computed width ($widthLong) exceeds Int.MaxValue; reduce capacity or widthMultiplier")
     val width = widthLong.toInt
     val resetSize = math.min(Int.MaxValue.toLong, (resetMultiplier * capacity).toLong).toInt
     new FrequencySketch(depth, width, counterBits, resetSize, hasher)
@@ -259,7 +260,8 @@ private[pekko] object FastFrequencySketch {
    */
   def apply[A](capacity: Int, widthMultiplier: Int = 4, resetMultiplier: Double = 10): FastFrequencySketch[A] = {
     val widthLong = widthMultiplier.toLong * FrequencySketch.Bits.ceilingPowerOfTwo(capacity).toLong
-    require(widthLong <= Int.MaxValue, s"computed width ($widthLong) exceeds Int.MaxValue; reduce capacity or widthMultiplier")
+    require(widthLong <= Int.MaxValue,
+      s"computed width ($widthLong) exceeds Int.MaxValue; reduce capacity or widthMultiplier")
     val width = widthLong.toInt
     val resetSize = math.min(Int.MaxValue.toLong, (resetMultiplier * capacity).toLong).toInt
     new FastFrequencySketch(width, resetSize)

--- a/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
@@ -61,7 +61,7 @@ private[pekko] object FrequencySketch {
       depth: Int = 4,
       counterBits: Int = 4)(implicit hasher: Hasher[A]): FrequencySketch[A] = {
     val width = widthMultiplier * Bits.ceilingPowerOfTwo(capacity)
-    val resetSize = (resetMultiplier * capacity).toInt
+    val resetSize = math.min(Int.MaxValue.toLong, (resetMultiplier * capacity).toLong).toInt
     new FrequencySketch(depth, width, counterBits, resetSize, hasher)
   }
 
@@ -257,7 +257,7 @@ private[pekko] object FastFrequencySketch {
    */
   def apply[A](capacity: Int, widthMultiplier: Int = 4, resetMultiplier: Double = 10): FastFrequencySketch[A] = {
     val width = widthMultiplier * FrequencySketch.Bits.ceilingPowerOfTwo(capacity)
-    val resetSize = (resetMultiplier * capacity).toInt
+    val resetSize = math.min(Int.MaxValue.toLong, (resetMultiplier * capacity).toLong).toInt
     new FastFrequencySketch(width, resetSize)
   }
 }

--- a/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
@@ -60,7 +60,9 @@ private[pekko] object FrequencySketch {
       resetMultiplier: Double = 10,
       depth: Int = 4,
       counterBits: Int = 4)(implicit hasher: Hasher[A]): FrequencySketch[A] = {
-    val width = widthMultiplier * Bits.ceilingPowerOfTwo(capacity)
+    val widthLong = widthMultiplier.toLong * Bits.ceilingPowerOfTwo(capacity).toLong
+    require(widthLong <= Int.MaxValue, s"computed width ($widthLong) exceeds Int.MaxValue; reduce capacity or widthMultiplier")
+    val width = widthLong.toInt
     val resetSize = math.min(Int.MaxValue.toLong, (resetMultiplier * capacity).toLong).toInt
     new FrequencySketch(depth, width, counterBits, resetSize, hasher)
   }
@@ -256,7 +258,9 @@ private[pekko] object FastFrequencySketch {
    * @return a configured FastFrequencySketch
    */
   def apply[A](capacity: Int, widthMultiplier: Int = 4, resetMultiplier: Double = 10): FastFrequencySketch[A] = {
-    val width = widthMultiplier * FrequencySketch.Bits.ceilingPowerOfTwo(capacity)
+    val widthLong = widthMultiplier.toLong * FrequencySketch.Bits.ceilingPowerOfTwo(capacity).toLong
+    require(widthLong <= Int.MaxValue, s"computed width ($widthLong) exceeds Int.MaxValue; reduce capacity or widthMultiplier")
+    val width = widthLong.toInt
     val resetSize = math.min(Int.MaxValue.toLong, (resetMultiplier * capacity).toLong).toInt
     new FastFrequencySketch(width, resetSize)
   }


### PR DESCRIPTION
Not every likely int overflow scenarios but Copilot suggested these are low impact improvements.

FaultHandling.scala (both AllForOneStrategy and OneForOneStrategy) — clamps withinTimeRange.toMillis to Int.MaxValue before converting. Without this, any retry window longer than ~24.8 days silently overflowed to negative, making the window check always false and granting unlimited restarts.

FrequencySketch.scala (both FrequencySketch and FastFrequencySketch factories) — uses a Long intermediate before clamping resetSize, preventing overflow for capacities above ~214M.