### PR TITLE
docs: add MiMa fix requirement to CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ sbt +mimaReportBinaryIssues
 ```
 
 - Do not mark a PR ready while the local MiMa run or the GitHub `Check / Binary Compatibility` job is failing.
+- ALL reported MiMa issues must be fixed before creating or updating a PR. Do not ignore or suppress MiMa warnings without explicit maintainer approval.
 - Run Paradox for documentation changes that touch project docs.
 
 ```shell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Before opening or updating a PR, verify:
 - `sbt headerCreateAll` was run to add headers for new files. Never hand-write or invent license headers; let sbt manage them, and preserve existing copyright notices intact.
 - For copied code, the source file or external project is noted in the PR (see Licensing Rules in `AGENTS.md`).
 - Binary compatibility is preserved, and the GitHub `Check / Binary Compatibility` job passes before merge.
-- `sbt +mimaReportBinaryIssues` was run for public API, binary shape, serialization, or MiMa-sensitive internal changes.
+- `sbt +mimaReportBinaryIssues` was run for public API, binary shape, serialization, or MiMa-sensitive internal changes, and ALL reported issues were fixed before creating or updating the PR.
 - Commit messages follow the `AGENTS.md` format.
 - PR bodies follow the `AGENTS.md` format.
 - `Tests` and `References` are present.


### PR DESCRIPTION
### Motivation

Make it explicit that ALL MiMa issues must be resolved before creating or updating a PR.

### Modification

- CLAUDE.md: clarify that `mimaReportBinaryIssues` must pass with all issues fixed
- AGENTS.md: add explicit rule that all MiMa issues must be fixed before PR

### Result

Clear documentation of MiMa requirement for PR readiness.

### Tests

Not run - docs only

### References

None - documentation improvement