### PR TITLE
Fix sbt load warnings by excluding unused lint keys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,14 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 ThisBuild / pekkoCoreProject := true
 
+Global / excludeLintKeys ++= Set(
+  projectInfoVersion,
+  logManager,
+  unidocProjectFilter,
+  fork,
+  javacOptions
+)
+
 enablePlugins(
   UnidocRoot,
   UnidocWithPrValidation,


### PR DESCRIPTION
### Motivation
sbt load was showing 165 warnings about unused keys, which cluttered the output and made it harder to identify real issues.

### Modification
Added  to  to exclude the following keys from  checks:
-  (used for linking to API docs)
-  (used to add timestamps to log output)
-  (used to filter projects for unidoc generation)
-  (used for PR validation)
-  (used to disable doclint for tests)

### Result
sbt load now completes without any warnings about unused keys.

### Tests
- Verified sbt load completes without warnings

### References
None - housekeeping