### PR TITLE
Replace Scala string interpolation in log calls with lazy {} placeholder format

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestKitUtils.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestKitUtils.scala
@@ -64,7 +64,7 @@ private[pekko] object ActorTestKitGuardian {
       reply: ActorRef[ActorRef[T]],
       props: Props): Catcher[Behavior[TestKitCommand]] = {
     case NonFatal(e) =>
-      context.log.error(s"Spawn failed, props [$props]", e)
+      context.log.error("Spawn failed, props [{}]", props, e)
       reply ! context.spawnAnonymous(Behaviors.stopped)
       Behaviors.same
   }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ExtensionsImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ExtensionsImpl.scala
@@ -60,7 +60,7 @@ private[pekko] trait ExtensionsImpl extends Extensions { self: ActorSystem[_] wi
           else throw new RuntimeException(s"[$extensionIdFQCN] is not an 'ExtensionId'")
         case Failure(problem) =>
           if (!throwOnLoadFail)
-            log.error(s"While trying to load extension $extensionIdFQCN, skipping...", problem)
+            log.error("While trying to load extension {}, skipping...", extensionIdFQCN, problem)
           else throw new RuntimeException(s"While trying to load extension [$extensionIdFQCN]", problem)
       }
     }

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorRefProvider.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorRefProvider.scala
@@ -470,18 +470,18 @@ private[pekko] class LocalActorRefProvider private[pekko] (
       if (isWalking)
         message match {
           case null => throw InvalidMessageException("Message is null")
-          case _    => log.error(s"$this received unexpected message [$message]")
+          case _    => log.error("{} received unexpected message [{}]", this, message)
         }
 
     override def sendSystemMessage(message: SystemMessage): Unit = if (isWalking) {
       message match {
         case Failed(child: InternalActorRef, ex, _) =>
-          log.error(ex, s"guardian $child failed, shutting down!")
+          log.error(ex, "guardian {} failed, shutting down!", child)
           causeOfTermination.tryFailure(ex)
           child.stop()
         case Supervise(_, _)           => // TODO register child in some map to keep track of it and enable shutdown after all dead
         case _: DeathWatchNotification => stop()
-        case _                         => log.error(s"$this received unexpected system message [$message]")
+        case _                         => log.error("{} received unexpected system message [{}]", this, message)
       }
     }
   }

--- a/actor/src/main/scala/org/apache/pekko/actor/CoordinatedShutdown.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/CoordinatedShutdown.scala
@@ -722,7 +722,7 @@ final class CoordinatedShutdown private[pekko] (
           case Nil                                                  => Future.successful(Done)
           case phaseName :: remaining if !phases(phaseName).enabled =>
             tasks.get(phaseName).foreach { phaseDef =>
-              log.info(s"Phase [{}] disabled through configuration, skipping [{}] tasks.", phaseName, phaseDef.size)
+              log.info("Phase [{}] disabled through configuration, skipping [{}] tasks.", phaseName, phaseDef.size)
             }
             loop(remaining)
           case phaseName :: remaining =>

--- a/actor/src/main/scala/org/apache/pekko/io/SelectionHandler.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/SelectionHandler.scala
@@ -200,12 +200,12 @@ private[io] object SelectionHandler {
     executionContext.execute(select) // start selection "loop"
 
     def register(channel: SelectableChannel, initialOps: Int)(implicit channelActor: ActorRef): Unit = {
-      if (settings.TraceLogging) log.debug(s"Scheduling Registering channel $channel with initialOps $initialOps")
+      if (settings.TraceLogging) log.debug("Scheduling Registering channel {} with initialOps {}", channel, initialOps)
       execute {
         new Task {
           def tryRun(): Unit =
             try {
-              if (settings.TraceLogging) log.debug(s"Registering channel $channel with initialOps $initialOps")
+              if (settings.TraceLogging) log.debug("Registering channel {} with initialOps {}", channel, initialOps)
               val key = channel.register(selector, initialOps, channelActor)
               channelActor ! new ChannelRegistration {
                 def enableInterest(ops: Int): Unit = enableInterestOps(key, ops)
@@ -244,7 +244,7 @@ private[io] object SelectionHandler {
       execute {
         new Task {
           def tryRun(): Unit = {
-            if (settings.TraceLogging) log.debug(s"Enabling $ops on $key")
+            if (settings.TraceLogging) log.debug("Enabling {} on {}", ops, key)
             val currentOps = key.interestOps
             val newOps = currentOps | ops
             if (newOps != currentOps) key.interestOps(newOps)

--- a/actor/src/main/scala/org/apache/pekko/pattern/internal/BackoffOnRestartSupervisor.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/internal/BackoffOnRestartSupervisor.scala
@@ -105,7 +105,7 @@ import pekko.pattern.{
 
   def onTerminated: Receive = {
     case Terminated(c) =>
-      log.debug(s"Terminating, because child [$c] terminated itself")
+      log.debug("Terminating, because child [{}] terminated itself", c)
       stop(self)
   }
 

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/ClusterMetricsCollector.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/ClusterMetricsCollector.scala
@@ -84,10 +84,10 @@ private[metrics] class ClusterMetricsSupervisor extends Actor with ActorLogging 
       children.foreach(stop)
       collectorInstance += 1
       actorOf(Props(classOf[ClusterMetricsCollector]), collectorName)
-      log.debug(s"Collection started.")
+      log.debug("Collection started.")
     case CollectionStopMessage =>
       children.foreach(stop)
-      log.debug(s"Collection stopped.")
+      log.debug("Collection stopped.")
   }
 
 }

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/ClusterMetricsExtension.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/ClusterMetricsExtension.scala
@@ -63,8 +63,8 @@ class ClusterMetricsExtension(system: ExtendedActorSystem) extends Extension {
       immutable.Seq(classOf[Config] -> SupervisorStrategyConfiguration))
     .getOrElse {
       val log: LoggingAdapter = Logging(system, classOf[ClusterMetricsExtension])
-      log.error(s"Configured strategy provider $SupervisorStrategyProvider failed to load, using default ${classOf[
-          ClusterMetricsStrategy].getName}.")
+      log.error("Configured strategy provider {} failed to load, using default {}.",
+        SupervisorStrategyProvider, classOf[ClusterMetricsStrategy].getName)
       new ClusterMetricsStrategy(SupervisorStrategyConfiguration)
     }
 

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/MetricsCollector.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/MetricsCollector.scala
@@ -71,7 +71,7 @@ private[metrics] object MetricsCollector {
     val useInternal = CollectorFallback && CollectorProvider == ""
 
     def create(provider: String) = TryNative {
-      log.debug(s"Trying $provider.")
+      log.debug("Trying {}.", provider)
       system
         .asInstanceOf[ExtendedActorSystem]
         .dynamicAccess

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/internal/ShardingProducerControllerImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/delivery/internal/ShardingProducerControllerImpl.scala
@@ -408,7 +408,7 @@ private class ShardingProducerControllerImpl[A: ClassTag](
         context.log.error(errorMessage)
         throw new TimeoutException(errorMessage)
       } else {
-        context.log.info(s"StoreMessageSent seqNr [{}] failed, attempt [{}], retrying.", f.messageSent.seqNr, f.attempt)
+        context.log.info("StoreMessageSent seqNr [{}] failed, attempt [{}], retrying.", f.messageSent.seqNr, f.attempt)
         // retry
         storeMessageSent(f.messageSent, attempt = f.attempt + 1)
         Behaviors.same

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
@@ -1096,7 +1096,7 @@ private[pekko] class ShardRegion(
 
     Future.traverse(shards.toSeq) { case (shardId, shard) => askOne(shard, msg, shardId) }.map { ps =>
       val qr = ShardsQueryResult[T](ps, this.shards.size, timeout.duration)
-      if (qr.failed.nonEmpty) log.warning(s"{}: $qr", typeName)
+      if (qr.failed.nonEmpty) log.warning("{}: {}", typeName, qr)
       qr
     }
   }

--- a/cluster-tools/src/main/scala/org/apache/pekko/cluster/client/ClusterClient.scala
+++ b/cluster-tools/src/main/scala/org/apache/pekko/cluster/client/ClusterClient.scala
@@ -516,7 +516,7 @@ final class ClusterClient(settings: ClusterClientSettings) extends Actor with Ac
       else if (contacts.size == 1) initialContactsSel.union(contacts)
       else contacts
     if (log.isDebugEnabled)
-      log.debug(s"""Sending GetContacts to [${sendTo.mkString(",")}]""")
+      log.debug("Sending GetContacts to [{}]", sendTo.mkString(","))
     sendTo.foreach { _ ! GetContacts }
   }
 

--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
@@ -313,7 +313,7 @@ private[pekko] class ClientFSM(name: RoleName, controllerAddr: InetSocketAddress
       } catch {
         case NonFatal(ex) =>
           // silence this one to not make tests look like they failed, it's not really critical
-          log.debug(s"Failed closing channel with ${ex.getClass.getName} ${ex.getMessage}")
+          log.debug("Failed closing channel with {} {}", ex.getClass.getName, ex.getMessage)
       }
   }
 

--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
@@ -313,7 +313,8 @@ private[pekko] class ClientFSM(name: RoleName, controllerAddr: InetSocketAddress
       } catch {
         case NonFatal(ex) =>
           // silence this one to not make tests look like they failed, it's not really critical
-          log.debug("Failed closing channel with {} {}", ex.getClass.getName, ex.getMessage)
+          if (log.isDebugEnabled)
+            log.debug("Failed closing channel with {} {}", ex.getClass.getName, ex.getMessage)
       }
   }
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/Persistence.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Persistence.scala
@@ -270,7 +270,7 @@ class Persistence(val system: ExtendedActorSystem) extends Extension {
     .getStringList("journal.auto-start-journals")
     .forEach(new Consumer[String] {
       override def accept(id: String): Unit = {
-        log.info(s"Auto-starting journal plugin `$id`")
+        log.info("Auto-starting journal plugin `{}`", id)
         journalFor(id)
       }
     })
@@ -278,7 +278,7 @@ class Persistence(val system: ExtendedActorSystem) extends Extension {
     .getStringList("snapshot-store.auto-start-snapshot-stores")
     .forEach(new Consumer[String] {
       override def accept(id: String): Unit = {
-        log.info(s"Auto-starting snapshot store `$id`")
+        log.info("Auto-starting snapshot store `{}`", id)
         snapshotStoreFor(id)
       }
     })
@@ -409,7 +409,7 @@ class Persistence(val system: ExtendedActorSystem) extends Extension {
     val pluginClassName = pluginConfig.getString("class")
     if (isEmpty(pluginClassName))
       throw new IllegalArgumentException(s"Plugin class name must be defined in config property [$configPath.class]")
-    log.debug(s"Create plugin: $pluginActorName $pluginClassName")
+    log.debug("Create plugin: {} {}", pluginActorName, pluginClassName)
     val pluginClass = system.dynamicAccess.getClassFor[Any](pluginClassName).get
     val pluginDispatcherId = pluginConfig.getString("plugin-dispatcher")
     val pluginActorArgs: List[AnyRef] =

--- a/persistence/src/main/scala/org/apache/pekko/persistence/PersistencePlugin.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/PersistencePlugin.scala
@@ -83,7 +83,7 @@ private[pekko] abstract class PersistencePlugin[ScalaDsl, JavaDsl, T: ClassTag](
       s"'reference.conf' is missing persistence plugin config path: '$configPath'")
     val pluginConfig = mergedConfig.getConfig(configPath)
     val pluginClassName = pluginConfig.getString("class")
-    log.debug(s"Create plugin: $configPath $pluginClassName")
+    log.debug("Create plugin: {} {}", configPath, pluginClassName)
     val pluginClass = system.dynamicAccess.getClassFor[AnyRef](pluginClassName).get
 
     def instantiate(args: collection.immutable.Seq[(Class[_], AnyRef)]) =

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapters.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapters.scala
@@ -52,7 +52,7 @@ class EventAdapters(
         }
         map.putIfAbsent(clazz, value) match {
           case null =>
-            log.debug(s"Using EventAdapter: {} for event [{}]", value.getClass.getName, clazz.getName)
+            log.debug("Using EventAdapter: {} for event [{}]", value.getClass.getName, clazz.getName)
             value
           case some => some
         }

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapters.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapters.scala
@@ -52,7 +52,8 @@ class EventAdapters(
         }
         map.putIfAbsent(clazz, value) match {
           case null =>
-            log.debug("Using EventAdapter: {} for event [{}]", value.getClass.getName, clazz.getName)
+            if (log.isDebugEnabled)
+              log.debug("Using EventAdapter: {} for event [{}]", value.getClass.getName, clazz.getName)
             value
           case some => some
         }

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/ArteryTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/ArteryTransport.scala
@@ -599,7 +599,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
       case _: AeronTerminated  => // shutdown already in progress
       case cause if isShutdown =>
         // don't restart after shutdown, but log some details so we notice
-        log.warning(s"{} failed after shutdown. {}: {}", streamName, cause.getClass.getName, cause.getMessage)
+        log.warning("{} failed after shutdown. {}: {}", streamName, cause.getClass.getName, cause.getMessage)
       case _: AbruptTerminationException => // ActorSystem shutdown
       case cause                         =>
         if (restartCounter.restart()) {
@@ -630,7 +630,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
         else {
           val flushingPromise = Promise[Done]()
           if (log.isDebugEnabled)
-            log.debug(s"Flushing associations [{}]", allAssociations.map(_.remoteAddress).mkString(", "))
+            log.debug("Flushing associations [{}]", allAssociations.map(_.remoteAddress).mkString(", "))
           system.systemActorOf(
             FlushOnShutdown
               .props(flushingPromise, settings.Advanced.ShutdownFlushTimeout, allAssociations)

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/aeron/ArteryAeronUdpTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/aeron/ArteryAeronUdpTransport.scala
@@ -190,13 +190,13 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
     ctx.availableImageHandler(new AvailableImageHandler {
       override def onAvailableImage(img: Image): Unit = {
         if (log.isDebugEnabled)
-          log.debug(s"onAvailableImage from ${img.sourceIdentity} session ${img.sessionId}")
+          log.debug("onAvailableImage from {} session {}", img.sourceIdentity, img.sessionId)
       }
     })
     ctx.unavailableImageHandler(new UnavailableImageHandler {
       override def onUnavailableImage(img: Image): Unit = {
         if (log.isDebugEnabled)
-          log.debug(s"onUnavailableImage from ${img.sourceIdentity} session ${img.sessionId}")
+          log.debug("onUnavailableImage from {} session {}", img.sourceIdentity, img.sessionId)
 
         // freeSessionBuffer in AeronSource FragmentAssembler
         streamMatValues.get.valuesIterator.foreach {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/TLSActor.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/TLSActor.scala
@@ -118,9 +118,9 @@ import pekko.util.ByteString
             ByteString.empty
           case _ => throw new RuntimeException() // won't happen, compiler exhaustiveness check pleaser
         }
-        if (tracing) log.debug(s"chopping from new chunk of ${buffer.size} into $name (${b.position()})")
+        if (tracing) log.debug("chopping from new chunk of {} into {} ({})", buffer.size, name, b.position())
       } else {
-        if (tracing) log.debug(s"chopping from old chunk of ${buffer.size} into $name (${b.position()})")
+        if (tracing) log.debug("chopping from old chunk of {} into {} ({})", buffer.size, name, b.position())
       }
       val copied = buffer.copyToBuffer(b)
       buffer = buffer.drop(copied)
@@ -134,7 +134,7 @@ import pekko.util.ByteString
      */
     def putBack(b: ByteBuffer): Unit =
       if (b.hasRemaining) {
-        if (tracing) log.debug(s"putting back ${b.remaining} bytes into $name")
+        if (tracing) log.debug("putting back {} bytes into {}", b.remaining, name)
         val bs = ByteString(b)
         if (bs.nonEmpty) buffer = bs ++ buffer
         prepare(b)
@@ -178,7 +178,7 @@ import pekko.util.ByteString
   var currentSession = engine.getSession
 
   def setNewSessionParameters(params: NegotiateNewSession): Unit = {
-    if (tracing) log.debug(s"applying $params")
+    if (tracing) log.debug("applying {}", params)
     currentSession.invalidate()
     TlsUtils.applySessionParameters(engine, params)
     engine.beginHandshake()
@@ -310,7 +310,7 @@ import pekko.util.ByteString
         true
       } catch {
         case ex: SSLException =>
-          if (tracing) log.debug(s"SSLException during doUnwrap: $ex")
+          if (tracing) log.debug("SSLException during doUnwrap: {}", ex)
           fail(ex, closeTransport = false)
           try engine.closeInbound()
           catch { case _: SSLException => () }
@@ -338,7 +338,7 @@ import pekko.util.ByteString
       try doWrap()
       catch {
         case ex: SSLException =>
-          if (tracing) log.debug(s"SSLException during doWrap: $ex")
+          if (tracing) log.debug("SSLException during doWrap: {}", ex)
           fail(ex, closeTransport = false)
           completeOrFlush()
       }
@@ -360,7 +360,7 @@ import pekko.util.ByteString
     if (transportOutBuffer.hasRemaining) {
       val bs = ByteString(transportOutBuffer)
       outputBunch.enqueue(TransportOut, bs)
-      if (tracing) log.debug(s"sending ${bs.size} bytes")
+      if (tracing) log.debug("sending {} bytes", bs.size)
     }
     transportOutBuffer.clear()
   }
@@ -463,8 +463,8 @@ import pekko.util.ByteString
     val st = lastHandshakeStatus
     val taskCount = TlsEngineHelpers.runDelegatedTasks(engine)
     lastHandshakeStatus = engine.getHandshakeStatus
-    if (tracing && taskCount > 0) log.debug(s"ran $taskCount delegated TLS task(s)")
-    if (tracing && st != lastHandshakeStatus) log.debug(s"handshake status after tasks: $lastHandshakeStatus")
+    if (tracing && taskCount > 0) log.debug("ran {} delegated TLS task(s)", taskCount)
+    if (tracing && st != lastHandshakeStatus) log.debug("handshake status after tasks: {}", lastHandshakeStatus)
   }
 
   private def handshakeFinished(): Unit = {
@@ -519,7 +519,7 @@ import pekko.util.ByteString
   override protected def pumpFinished(): Unit = {
     inputBunch.cancel()
     outputBunch.complete()
-    if (tracing) log.debug(s"STOP Outbound Closed: ${engine.isOutboundDone} Inbound closed: ${engine.isInboundDone}")
+    if (tracing) log.debug("STOP Outbound Closed: {} Inbound closed: {}", engine.isOutboundDone, engine.isInboundDone)
     stopped = true
     context.stop(self)
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SourceRefImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SourceRefImpl.scala
@@ -314,7 +314,7 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
           state match {
             case WaitingForCancelAck(partner, cause) =>
               verifyPartner(sender, partner)
-              log.debug(s"[{}] Got cancellation ack from remote, canceling", stageActorName)
+              log.debug("[{}] Got cancellation ack from remote, canceling", stageActorName)
               cancelStage(cause)
             case other =>
               throw new IllegalStateException(s"[$stageActorName] Got an Ack when in state $other")

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/RestartFlow.scala
@@ -371,7 +371,7 @@ object RestartWithBackoffFlow {
         }
 
         override protected def onTimer(timerKey: Any): Unit = {
-          log.debug(s"Stage was canceled after delay of $delay")
+          log.debug("Stage was canceled after delay of {}", delay)
           cause match {
             case OptionVal.Some(ex) =>
               cancelStage(ex)


### PR DESCRIPTION
also some cases where `s"..."` was used where it had no effect