### PR TITLE
fix: add missing space in StageActor PoisonPill/Kill warning message

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StageActorRefSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StageActorRefSpec.scala
@@ -166,7 +166,7 @@ class StageActorRefSpec extends StreamSpec with ImplicitSender {
       stageRef ! PoisonPill // should log a warning, and NOT stop the stage.
       val actorName = """StageActorRef-[\d+]"""
       val expectedMsg =
-        s"[PoisonPill|Kill] message sent to StageActorRef($actorName) will be ignored,since it is not a real Actor. " +
+        s"[PoisonPill|Kill] message sent to StageActorRef($actorName) will be ignored, since it is not a real Actor. " +
         "Use a custom message type to communicate with it instead."
       expectMsgPF(1.second, expectedMsg) {
         case Logging.Warning(_, _, msg) => expectedMsg.r.pattern.matcher(msg.toString).matches()

--- a/stream/src/main/scala/org/apache/pekko/stream/stage/GraphStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/stage/GraphStage.scala
@@ -223,7 +223,7 @@ object GraphStageLogic {
       val f: (ActorRef, Any) => Unit = {
         case (_, m @ (PoisonPill | Kill)) =>
           materializer.logger.warning(
-            "{} message sent to StageActor({}) will be ignored, since it is not a real Actor." +
+            "{} message sent to StageActor({}) will be ignored, since it is not a real Actor. " +
             "Use a custom message type to communicate with it instead.",
             m,
             functionRef.path)


### PR DESCRIPTION
### Motivation

The warning message logged when `PoisonPill` or `Kill` is sent to a `StageActor` was missing a space between the period and the next sentence, resulting in:

```
"...not a real Actor.Use a custom message type to communicate with it instead."
```

### Modification

Add the missing space after the period in the warning message in `GraphStage.scala`, and after the comma in the corresponding test regex in `StageActorRefSpec.scala`.

### Result

Warning message reads correctly:

```
"...not a real Actor. Use a custom message type to communicate with it instead."
```

### Tests

- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.StageActorRefSpec"` — 8/8

### References

None - minor formatting fix