### PR TITLE
fix: widen RemoteSendConsistencySpec await window to 30s

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteSendConsistencySpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteSendConsistencySpec.scala
@@ -176,7 +176,7 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config)
       system.actorOf(senderProps(remoteRefC))
       system.actorOf(senderProps(remoteRefA))
 
-      within(10.seconds) {
+      within(30.seconds) {
         expectMsg("success")
         expectMsg("success")
         expectMsg("success")
@@ -216,7 +216,7 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config)
       system.actorOf(senderProps(selC))
       system.actorOf(senderProps(selA))
 
-      within(10.seconds) {
+      within(30.seconds) {
         expectMsg("success2")
         expectMsg("success2")
         expectMsg("success2")


### PR DESCRIPTION
## Motivation

`ArteryTcp/TlsTcp SendConsistencyWithOneLaneSpec` flake on busy CI:
- `must be able to send messages concurrently preserving order` — times out at the `within` window
- `must be able to send messages with actorSelection concurrently preserving order` — same pattern

Observed locally on Darwin 25.3.0 with timefactor=2 (so `within(10.seconds)` → actual 20s budget):

```
- must be able to send messages concurrently preserving order *** FAILED *** (20 seconds, 5 milliseconds)
  java.lang.AssertionError: assertion failed: timeout (19999978648 nanoseconds) during expectMsg while waiting for success
- must be able to send messages with actorSelection concurrently preserving order *** FAILED *** (20 seconds)
  java.lang.AssertionError: assertion failed: timeout (19999978257 nanoseconds) during expectMsg while waiting for success2
```

The test drives ~4004 round-trips through TCP/TLS-TCP across four sender pairs (1000 ping-pong messages per pair × 4 pairs + acks). TLS handshake plus JIT warmup on a loaded CI runner easily exceed the original 10s budget without indicating any real regression.

## Modification

Bump `within(10.seconds)` → `within(30.seconds)` at lines 179 and 219 of `RemoteSendConsistencySpec.scala`. Two-line diff.

## Result

Up to 60s of dilated wall-clock headroom on CI (timefactor=2 × 30s). Still fails fast on genuine deadlocks — does not mask real regressions.

## Tests

- `scalafmt --test` on the changed file: passes
- Did not run `remote/test` locally; CI `Check / Test` will exercise both ArteryTcp and ArteryTlsTcp variants.

## References

- Failing classes: `ArteryTcpSendConsistencyWithOneLaneSpec`, `ArteryTlsTcpSendConsistencyWithOneLaneSpec` (concrete subclasses of `AbstractRemoteSendConsistencySpec`)
- Test file: `remote/src/test/scala/org/apache/pekko/remote/artery/RemoteSendConsistencySpec.scala`