### PR TITLE
Fix sbt load warnings by excluding unused lint keys (#3029)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,14 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 ThisBuild / pekkoCoreProject := true
 
+Global / excludeLintKeys ++= Set(
+  projectInfoVersion,
+  logManager,
+  unidocProjectFilter,
+  fork,
+  javacOptions
+)
+
 enablePlugins(
   UnidocRoot,
   UnidocWithPrValidation,


### PR DESCRIPTION
Motivation:
sbt load was showing 165 warnings about unused keys, which cluttered the output and made it harder to identify real issues.

Modification:
Added Global / excludeLintKeys to build.sbt to exclude the following keys from lintUnused checks:
- projectInfoVersion (used for linking to API docs)
- logManager (used to add timestamps to log output)
- unidocProjectFilter (used to filter projects for unidoc generation)
- fork (used for PR validation)
- javacOptions (used to disable doclint for tests)

Result:
sbt load now completes without any warnings about unused keys.

Tests:
- Verified sbt load completes without warnings

Refs: None - housekeeping
(cherry picked from commit 7c1d0a623da0531d997c56919dc810e58de67385)