### PR TITLE
refactor: rename Jdk9 sbt plugin to Jdk21

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -164,7 +164,7 @@ jobs:
           clean ${{ matrix.command }}
           
   jdk-21-extra-tests:
-    name: Java 21 Extra Tests (including all tests that need Java 9+)
+    name: Java 21 Extra Tests
     runs-on: ubuntu-22.04
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
@@ -192,7 +192,7 @@ jobs:
       - name: Enable jvm-opts
         run: cp .jvmopts-ci .jvmopts
 
-      - name: sbt TestJdk9/test
+      - name: sbt TestJdk21/test
         run: |-
           sbt \
           -Dpekko.mima.enabled=false \
@@ -206,4 +206,4 @@ jobs:
           -Dsbt.log.noformat=false \
           -Dpekko.log.timestamps=true \
           -Dio.netty.leakDetection.level=PARANOID \
-          TestJdk9/test        
+          TestJdk21/test

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -40,5 +40,5 @@ jobs:
         uses: sbt/setup-sbt@af116cce31c00823d3903ce687f9cda3a4f19f1b # v1.2.1
       - uses: scalacenter/sbt-dependency-submission@d84eef4c09e633bcf5f113bcad7fd5e9af1baee9 # v3.1.1
         with:
-          configs-ignore: provided optional test TestJdk9 compile-internal runtime-internal pr-validation multi-jvm scala-tool scala-doc-tool
+          configs-ignore: provided optional test TestJdk21 compile-internal runtime-internal pr-validation multi-jvm scala-tool scala-doc-tool
           modules-ignore: pekko-bench-jmh_2.13 pekko-docs_2.13 pekko-bench-jmh_3 pekko-docs_3

--- a/.github/workflows/generate-doc-check.yml
+++ b/.github/workflows/generate-doc-check.yml
@@ -55,4 +55,4 @@ jobs:
       - name: Compile testClass&docs for all Scala versions
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-        run: sbt ";+TestJdk9 / compile ; +compile:doc"
+        run: sbt ";+TestJdk21 / compile ; +compile:doc"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ sbt "module-name / Test / testOnly fully.qualified.SpecName"
 - Use JDK-specific configs when relevant.
 
 ```shell
-sbt "module-name / TestJdk9 / testOnly fully.qualified.SpecName"
+sbt "module-name / TestJdk21 / testOnly fully.qualified.SpecName"
 ```
 
 - Run PR impact validation for non-trivial code changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ Strange behavior has been reported by users that have tried it.
 
 Pekko, like most Scala projects, compiles faster with the Graal JIT enabled. The easiest way to use it for compiling Pekko is to:
 
-* Use a JDK > 10
+* Use a JDK >= 17
 * Use the following JVM options for SBT e.g. by adding them to the `SBT_OPTS` environment variable: `-XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+UseJVMCICompiler`
 
 ### JDK 21+ Nightly Virtual Threads

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/jfr/Events.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/jfr/Events.scala
@@ -21,8 +21,7 @@ import jdk.jfr.StackTrace
 
 import org.apache.pekko.annotation.InternalApi
 
-// requires jdk9+ to compile
-// for editing these in IntelliJ, open module settings, change JDK dependency to 11 for only this module
+// requires jdk.jfr (available since JDK 9, project baseline is Java 17)
 
 /** INTERNAL API */
 @InternalApi

--- a/build.sbt
+++ b/build.sbt
@@ -137,10 +137,10 @@ lazy val actor = pekkoModule("actor")
   .enablePlugins(BoilerplatePlugin, SbtOsgi)
 
 lazy val actorTests = pekkoModule("actor-tests")
-  .configs(Jdk9.TestJdk9)
+  .configs(Jdk21.TestJdk21)
   .dependsOn(testkit % "compile->compile;test->test", actor)
   .settings(Dependencies.actorTests)
-  .enablePlugins(NoPublish, Jdk9)
+  .enablePlugins(NoPublish, Jdk21)
   .disablePlugins(MimaPlugin)
 
 lazy val pekkoScalaNightly = pekkoModule("scala-nightly")

--- a/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/FlightRecording.scala
+++ b/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/FlightRecording.scala
@@ -21,7 +21,7 @@ import org.apache.pekko.actor.{ ActorSystem, ExtendedActorSystem }
  * This will work on JDK11 and JDK8 built with the enable-jfr flag (8u262+).
  *
  * For Pekko JRF recordings you may need to run a publish for multi jvm tests
- * to get the ComileJDK9 things compiled.
+ * to get the JFR classes compiled.
  */
 class FlightRecording(system: ActorSystem) {
 

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/internal/jfr/Events.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/internal/jfr/Events.scala
@@ -17,8 +17,7 @@ import jdk.jfr.{ Category, Event, Label, StackTrace, Timespan }
 
 import org.apache.pekko.annotation.InternalApi
 
-// requires jdk9+ to compile
-// for editing these in IntelliJ, open module settings, change JDK dependency to 11 for only this module
+// requires jdk.jfr (available since JDK 9, project baseline is Java 17)
 
 /** INTERNAL API */
 

--- a/docs/src/test/java/jdocs/stream/operators/source/AsSubscriber.java
+++ b/docs/src/test/java/jdocs/stream/operators/source/AsSubscriber.java
@@ -24,7 +24,7 @@ import org.apache.pekko.stream.javadsl.Source;
 public interface AsSubscriber {
   // We are 'faking' the JavaFlowSupport API here so we can include the signature as a snippet in
   // the API,
-  // because we're not publishing those (jdk9+) classes in our API docs yet.
+  // because we're not publishing those (java.util.concurrent.Flow) classes in our API docs yet.
   static class JavaFlowSupport {
     public static final class Source {
       public

--- a/docs/src/test/java/jdocs/stream/operators/source/FromPublisher.java
+++ b/docs/src/test/java/jdocs/stream/operators/source/FromPublisher.java
@@ -24,7 +24,7 @@ import org.apache.pekko.stream.javadsl.Source;
 public interface FromPublisher {
   // We are 'faking' the JavaFlowSupport API here so we can include the signature as a snippet in
   // the API,
-  // because we're not publishing those (jdk9+) classes in our API docs yet.
+  // because we're not publishing those (java.util.concurrent.Flow) classes in our API docs yet.
   static class JavaFlowSupport {
     public static final class Source {
       public

--- a/project/CopyrightHeaderForJdk21.scala
+++ b/project/CopyrightHeaderForJdk21.scala
@@ -14,13 +14,13 @@
 import sbtheader.HeaderPlugin.autoImport.headerSources
 import sbt.{ Compile, Def, Test, _ }
 
-object CopyrightHeaderForJdk9 extends AutoPlugin {
+object CopyrightHeaderForJdk21 extends AutoPlugin {
 
-  override lazy val requires = CopyrightHeader && Jdk9
+  override lazy val requires = CopyrightHeader && Jdk21
   override lazy val trigger = allRequirements
 
   private lazy val additionalFiles = Def.setting {
-    import Jdk9._
+    import Jdk21._
     for {
       dir <- additionalSourceDirectories.value ++ additionalTestSourceDirectories.value
       language <- List("java", "scala")

--- a/project/Jdk21.scala
+++ b/project/Jdk21.scala
@@ -14,15 +14,14 @@
 import sbt.Keys._
 import sbt._
 
-object Jdk9 extends AutoPlugin {
+object Jdk21 extends AutoPlugin {
   import JdkOptions.JavaVersion._
 
-  // The version 21 is special for any Java versions >= 21
   private val supportedJavaLTSVersions = List("21")
 
-  lazy val CompileJdk9 = config("CompileJdk9").extend(Compile)
+  lazy val CompileJdk21 = config("CompileJdk21").extend(Compile)
 
-  lazy val TestJdk9 = config("TestJdk9").extend(Test).extend(CompileJdk9)
+  lazy val TestJdk21 = config("TestJdk21").extend(Test).extend(CompileJdk21)
 
   lazy val ScalaSourceDirectories: Seq[String] = getAdditionalSourceDirectoryNames("scala")
   lazy val ScalaTestSourceDirectories: Seq[String] = getAdditionalSourceDirectoryNames("scala", isTest = true)
@@ -53,43 +52,34 @@ object Jdk9 extends AutoPlugin {
       yield (task / sourceDirectory).value / sourceDirectoryName
   }
 
-  lazy val compileJdk9Settings = Seq(
-    // following the scala-2.12, scala-sbt-1.0, ... convention
+  lazy val compileJdk21Settings = Seq(
     unmanagedSourceDirectories := additionalSourceDirectories.value,
     scalacOptions := PekkoBuild.DefaultScalacOptions.value ++ Seq("-release", majorVersion.toString),
     javacOptions := PekkoBuild.DefaultJavacOptions ++ Seq("--release", majorVersion.toString))
 
-  lazy val testJdk9Settings = Seq(
-    // following the scala-2.12, scala-sbt-1.0, ... convention
+  lazy val testJdk21Settings = Seq(
     unmanagedSourceDirectories := additionalTestSourceDirectories.value,
     scalacOptions := PekkoBuild.DefaultScalacOptions.value ++ Seq("-release", majorVersion.toString),
     javacOptions := PekkoBuild.DefaultJavacOptions ++ Seq("--release", majorVersion.toString),
-    compile := compile.dependsOn(CompileJdk9 / compile).value,
-    classpathConfiguration := TestJdk9,
+    compile := compile.dependsOn(CompileJdk21 / compile).value,
+    classpathConfiguration := TestJdk21,
     externalDependencyClasspath := (Test / externalDependencyClasspath).value)
 
   lazy val compileSettings = Seq(
-    // It might have been more 'neat' to add the jdk9 products to the jar via packageBin/mappings, but that doesn't work with the OSGi plugin,
-    // so we add them to the fullClasspath instead.
-    //    Compile / packageBin / mappings
-    //      ++= (CompileJdk9 / products).value.flatMap(Path.allSubpaths),
-    // Since sbt-osgi upgrade to 0.9.5, the fullClasspath is no longer used on packaging when use sbt-osgi, so we have to
-    // add jdk9 products to dependencyClasspathAsJars instead.
-    //    Compile / fullClasspath ++= (CompileJdk9 / exportedProducts).value)
-    Compile / dependencyClasspathAsJars ++= (CompileJdk9 / exportedProducts).value)
+    Compile / dependencyClasspathAsJars ++= (CompileJdk21 / exportedProducts).value)
 
   lazy val testSettings = Seq((Test / test) := {
     (Test / test).value
-    (TestJdk9 / test).value
+    (TestJdk21 / test).value
   })
 
   override lazy val trigger = noTrigger
-  override lazy val projectConfigurations = Seq(CompileJdk9)
+  override lazy val projectConfigurations = Seq(CompileJdk21)
   override lazy val projectSettings =
-    inConfig(CompileJdk9)(Defaults.compileSettings) ++
-    inConfig(CompileJdk9)(compileJdk9Settings) ++
+    inConfig(CompileJdk21)(Defaults.compileSettings) ++
+    inConfig(CompileJdk21)(compileJdk21Settings) ++
     compileSettings ++
-    inConfig(TestJdk9)(Defaults.testSettings) ++
-    inConfig(TestJdk9)(testJdk9Settings) ++
+    inConfig(TestJdk21)(Defaults.testSettings) ++
+    inConfig(TestJdk21)(testJdk21Settings) ++
     testSettings
 }

--- a/project/PekkoBuild.scala
+++ b/project/PekkoBuild.scala
@@ -276,7 +276,7 @@ object PekkoBuild {
         UsefulTask("testQuick",
           "Runs all the tests. When run multiple times will only run previously failing tests (shell mode only)"),
         UsefulTask("testOnly *.AnySpec", "Only run a selected test"),
-        UsefulTask("TestJdk9 / testOnly *.AnySpec", "Only run a Jdk9+ selected test"),
+        UsefulTask("TestJdk21 / testOnly *.AnySpec", "Only run a Jdk21+ selected test"),
         UsefulTask("testQuick *.AnySpec",
           "Only run a selected test. When run multiple times will only run previously failing tests (shell mode only)"),
         UsefulTask("testQuickUntilPassed", "Runs all tests in a continuous loop until all tests pass"),

--- a/project/PekkoDevelocityPlugin.scala
+++ b/project/PekkoDevelocityPlugin.scala
@@ -70,12 +70,12 @@ object PekkoDevelocityPlugin extends AutoPlugin {
 }
 
 /**
- * An AutoPlugin to add Develocity test configuration to the TestJdk9 configuration.
+ * An AutoPlugin to add Develocity test configuration to the TestJdk21 configuration.
  */
-object PekkoDevelocityJdk9TestSettingsPlugin extends AutoPlugin {
+object PekkoDevelocityJdk21TestSettingsPlugin extends AutoPlugin {
   override lazy val trigger: PluginTrigger = allRequirements
-  override lazy val requires: Plugins = DevelocityPlugin && Jdk9
+  override lazy val requires: Plugins = DevelocityPlugin && Jdk21
 
   // See https://docs.gradle.com/develocity/sbt-plugin/#enabling_build_cache_in_a_custom_sbt_configuration
-  override lazy val projectSettings = DevelocityPlugin.develocitySettings(Jdk9.TestJdk9)
+  override lazy val projectSettings = DevelocityPlugin.develocitySettings(Jdk21.TestJdk21)
 }

--- a/project/ProjectFileIgnoreSupport.scala
+++ b/project/ProjectFileIgnoreSupport.scala
@@ -19,9 +19,9 @@ import sbt.ConsoleLogger
 class ProjectFileIgnoreSupport(ignoreConfigFile: File, descriptor: String) {
   private lazy val stdoutLogger = ConsoleLogger(System.out)
 
-  private val javaSourceDirectories = Set("java") ++ Jdk9.JavaSourceDirectories ++ Jdk9.JavaTestSourceDirectories
+  private val javaSourceDirectories = Set("java") ++ Jdk21.JavaSourceDirectories ++ Jdk21.JavaTestSourceDirectories
 
-  private val scalaSourceDirectories = Set("scala") ++ Jdk9.ScalaSourceDirectories ++ Jdk9.ScalaTestSourceDirectories
+  private val scalaSourceDirectories = Set("scala") ++ Jdk21.ScalaSourceDirectories ++ Jdk21.ScalaTestSourceDirectories
 
   private lazy val ignoreConfig = {
     require(

--- a/project/ScalaFixForJdk21Plugin.scala
+++ b/project/ScalaFixForJdk21Plugin.scala
@@ -14,18 +14,18 @@
 import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 import scalafix.sbt.ScalafixPlugin
 
-object ScalaFixForJdk9Plugin extends AutoPlugin with ScalafixSupport {
+object ScalaFixForJdk21Plugin extends AutoPlugin with ScalafixSupport {
   override lazy val trigger: PluginTrigger = allRequirements
-  import Jdk9._
-  override lazy val requires: Plugins = Jdk9 && ScalafixPlugin
+  import Jdk21._
+  override lazy val requires: Plugins = Jdk21 && ScalafixPlugin
 
   import ScalafixPlugin.autoImport.scalafixConfigSettings
   import sbt._
 
-  lazy val scalafixIgnoredSetting: Seq[Setting[?]] = Seq(ignore(TestJdk9))
+  lazy val scalafixIgnoredSetting: Seq[Setting[?]] = Seq(ignore(TestJdk21))
 
   override lazy val projectSettings: Seq[Def.Setting[?]] =
-    Seq(CompileJdk9, TestJdk9).flatMap(c => inConfig(c)(scalafixConfigSettings(c))) ++
+    Seq(CompileJdk21, TestJdk21).flatMap(c => inConfig(c)(scalafixConfigSettings(c))) ++
     scalafixIgnoredSetting ++ Seq(
       updateProjectCommands(
         alias = "fixall",

--- a/project/TestExtras.scala
+++ b/project/TestExtras.scala
@@ -63,15 +63,13 @@ object TestExtras {
           val baseList =
             List(
               "The java JavaExtension.java" ->
-              "actor-tests/target/test-reports/TEST-org.apache.pekko.actor.JavaExtension.xml")
-          val jdk9Only = List(
-            "The jdk9-only FlowPublisherSinkSpec.scala" ->
-            "stream-tests/target/test-reports/TEST-org.apache.pekko.stream.scaladsl.FlowPublisherSinkSpec.xml",
-            "The jdk9-only JavaFlowSupportCompileTest.java" ->
-            "stream-tests/target/test-reports/TEST-org.apache.pekko.stream.javadsl.JavaFlowSupportCompileTest.xml")
+              "actor-tests/target/test-reports/TEST-org.apache.pekko.actor.JavaExtension.xml",
+              "FlowPublisherSinkSpec.scala" ->
+              "stream-tests/target/test-reports/TEST-org.apache.pekko.stream.scaladsl.FlowPublisherSinkSpec.xml",
+              "JavaFlowSupportCompileTest.java" ->
+              "stream-tests/target/test-reports/TEST-org.apache.pekko.stream.javadsl.JavaFlowSupportCompileTest.xml")
 
-          val testsToCheck =
-            baseList ::: jdk9Only
+          val testsToCheck = baseList
 
           testsToCheck.foreach((shouldExist _).tupled)
         })


### PR DESCRIPTION
### Motivation

The `Jdk9` sbt plugin was historically named for JDK 9 features (e.g., `java.util.concurrent.Flow`), but since Java 17 became the minimum baseline, JDK 9 features are part of the standard build. The plugin's `supportedJavaLTSVersions` only contains `"21"` — it exclusively manages JDK 21+ source directories (virtual thread tests). The misleading name caused confusion for developers.

### Modification

- **Renamed** `Jdk9` → `Jdk21`, `CompileJdk9` → `CompileJdk21`, `TestJdk9` → `TestJdk21`
- **Renamed files**: `Jdk9.scala` → `Jdk21.scala`, `CopyrightHeaderForJdk9.scala` → `CopyrightHeaderForJdk21.scala`, `ScalaFixForJdk9Plugin.scala` → `ScalaFixForJdk21Plugin.scala`
- **Renamed** `PekkoDevelocityJdk9TestSettingsPlugin` → `PekkoDevelocityJdk21TestSettingsPlugin`
- **Updated** all references in `build.sbt`, `project/*.scala`, `AGENTS.md`
- **Updated** CI workflows: `build-test-prValidation.yml`, `dependency-graph.yml`, `generate-doc-check.yml`
- **Cleaned up** stale `jdk9Only` labels in `TestExtras.scala` (Flow tests are in regular source dirs since Java 17 is baseline)
- **Updated** outdated comments: `"requires jdk9+"` → `"project baseline is Java 17"`
- **Updated** `CONTRIBUTING.md`: `"JDK > 10"` → `"JDK >= 17"`
- **Cleaned up** stale `"jdk9+"` references in docs test files and `FlightRecording.scala`

### Result

Build plugin names now accurately reflect their function (JDK 21 virtual thread tests). Developers and CI workflows use the clearer `TestJdk21` configuration name. Stale JDK 9 references that no longer apply with Java 17 baseline are removed.

### Tests

- `sbt "actor-tests / compile"` — success
- `sbt "actor-tests / TestJdk21 / compile"` — success (3 Scala + 2 Java JDK 21 sources compiled to `TestJdk21-classes`)
- `sbt "headerCreateAll"` — success
- `git diff --check` — clean

### References

None - build infrastructure cleanup