### PR TITLE
Add TCK tests for replay bounds across a deletion gap

### DIFF
--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/journal/JournalSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/journal/JournalSpec.scala
@@ -247,6 +247,56 @@ abstract class JournalSpec(config: Config)
       journal ! ReplayMessages(0, Long.MaxValue, Long.MaxValue, pid, receiverProbe.ref)
       receiverProbe.expectMsg(RecoverySuccess(highestSequenceNr = 5L))
     }
+
+    "replay all surviving messages when the lower bound equals the last deleted sequence number" in {
+      val deleteProbe = TestProbe()
+      journal ! DeleteMessagesTo(pid, 3L, deleteProbe.ref)
+      deleteProbe.expectMsg(DeleteMessagesSuccess(3L))
+
+      journal ! ReplayMessages(3L, Long.MaxValue, Long.MaxValue, pid, receiverProbe.ref)
+      receiverProbe.expectMsg(replayedMessage(4))
+      receiverProbe.expectMsg(replayedMessage(5))
+      receiverProbe.expectMsg(RecoverySuccess(highestSequenceNr = 5L))
+    }
+
+    "replay surviving messages within bounds when the replay window spans a deleted prefix" in {
+      val deleteProbe = TestProbe()
+      journal ! DeleteMessagesTo(pid, 3L, deleteProbe.ref)
+      deleteProbe.expectMsg(DeleteMessagesSuccess(3L))
+
+      journal ! ReplayMessages(1, 4, Long.MaxValue, pid, receiverProbe.ref)
+      receiverProbe.expectMsg(replayedMessage(4))
+      receiverProbe.expectMsg(RecoverySuccess(highestSequenceNr = 5L))
+    }
+
+    "return only recovery success when the upper bound falls within a deleted prefix" in {
+      val deleteProbe = TestProbe()
+      journal ! DeleteMessagesTo(pid, 3L, deleteProbe.ref)
+      deleteProbe.expectMsg(DeleteMessagesSuccess(3L))
+
+      journal ! ReplayMessages(1, 2, Long.MaxValue, pid, receiverProbe.ref)
+      receiverProbe.expectMsg(RecoverySuccess(highestSequenceNr = 5L))
+    }
+
+    "return only recovery success when the upper bound equals the last deleted sequence number" in {
+      val deleteProbe = TestProbe()
+      journal ! DeleteMessagesTo(pid, 3L, deleteProbe.ref)
+      deleteProbe.expectMsg(DeleteMessagesSuccess(3L))
+
+      journal ! ReplayMessages(1, 3, Long.MaxValue, pid, receiverProbe.ref)
+      receiverProbe.expectMsg(RecoverySuccess(highestSequenceNr = 5L))
+    }
+
+    "replay from the first surviving message when the lower bound equals the first surviving sequence number" in {
+      val deleteProbe = TestProbe()
+      journal ! DeleteMessagesTo(pid, 3L, deleteProbe.ref)
+      deleteProbe.expectMsg(DeleteMessagesSuccess(3L))
+
+      journal ! ReplayMessages(4, Long.MaxValue, Long.MaxValue, pid, receiverProbe.ref)
+      receiverProbe.expectMsg(replayedMessage(4))
+      receiverProbe.expectMsg(replayedMessage(5))
+      receiverProbe.expectMsg(RecoverySuccess(highestSequenceNr = 5L))
+    }
   }
 
   "A Journal optionally".may {


### PR DESCRIPTION
### Motivation
[PR #517 on `pekko-persistence-jdbc`](https://github.com/apache/pekko-persistence-jdbc/pull/517) added regression tests for replaying messages whose range overlaps a deleted prefix (the gap left by `DeleteMessagesTo`). @pjfanning asked for the same coverage in the shared TCK so all journal implementations meet one contract.

### Test cases
Add five `JournalSpec` cases. Each deletes messages 1..3 (4..5 survive) and then replays a different window:
1. lower bound = 3 (last deleted): replays 4, 5
2. window 1..4 (spans the gap): replays 4
3. window 1..2 (ends inside the gap): no replay, `RecoverySuccess` only
4. window 1..3 (ends at last deleted): no replay, `RecoverySuccess` only
5. lower bound = 4 (first survivor): replays 4, 5
