### PR TITLE
fix: Scala 3.9 context bound and trait field compatibility

### DIFF
--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Behaviors.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/Behaviors.scala
@@ -234,8 +234,10 @@ object Behaviors {
    * @param monitor The messages will also be sent to this `ActorRef`
    * @param behavior The inner behavior that is decorated
    */
-  def monitor[T](interceptMessageClass: Class[T], monitor: ActorRef[T], behavior: Behavior[T]): Behavior[T] =
-    scaladsl.Behaviors.monitor(monitor, behavior)(ClassTag(interceptMessageClass))
+  def monitor[T](interceptMessageClass: Class[T], monitor: ActorRef[T], behavior: Behavior[T]): Behavior[T] = {
+    implicit val ct: ClassTag[T] = ClassTag(interceptMessageClass)
+    scaladsl.Behaviors.monitor(monitor, behavior)
+  }
 
   /**
    * Behavior decorator that logs all messages to the [[pekko.actor.typed.Behavior]] using the provided
@@ -332,8 +334,10 @@ object Behaviors {
   def transformMessages[Outer, Inner](
       interceptMessageClass: Class[Outer],
       behavior: Behavior[Inner],
-      selector: JFunction[PFBuilder[Outer, Inner], PFBuilder[Outer, Inner]]): Behavior[Outer] =
-    BehaviorImpl.transformMessages(behavior, selector.apply(new PFBuilder).build())(ClassTag(interceptMessageClass))
+      selector: JFunction[PFBuilder[Outer, Inner], PFBuilder[Outer, Inner]]): Behavior[Outer] = {
+    implicit val ct: ClassTag[Outer] = ClassTag(interceptMessageClass)
+    BehaviorImpl.transformMessages(behavior, selector.apply(new PFBuilder).build())
+  }
 
   /**
    * Support for scheduled `self` messages in an actor.
@@ -413,7 +417,8 @@ object Behaviors {
         asScalaMap(mdcForMessage.apply(message))
       }
 
-    WithMdcBehaviorInterceptor[T](asScalaMap(staticMdc), mdcForMessageFun, behavior)(ClassTag(interceptMessageClass))
+    implicit val ct: ClassTag[T] = ClassTag(interceptMessageClass)
+    WithMdcBehaviorInterceptor[T](asScalaMap(staticMdc), mdcForMessageFun, behavior)
   }
 
 }

--- a/actor/src/main/scala/org/apache/pekko/actor/FSM.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/FSM.scala
@@ -763,7 +763,7 @@ trait FSM[S, D] extends Actor with Listeners with ActorLogging {
   /*
    * unhandled event handler
    */
-  private val handleEventDefault: StateFunction = {
+  private def handleEventDefault: StateFunction = {
     case Event(value, _) =>
       log.warning("unhandled event " + value + " in state " + stateName)
       stay()

--- a/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSMBase.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSMBase.scala
@@ -466,7 +466,7 @@ trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging 
   /*
    * unhandled event handler
    */
-  private val handleEventDefault: StateFunction = {
+  private def handleEventDefault: StateFunction = {
     case Event(value, _) =>
       log.warning("unhandled event " + value + " in state " + stateName)
       stay()

--- a/project/PekkoBuild.scala
+++ b/project/PekkoBuild.scala
@@ -98,7 +98,7 @@ object PekkoBuild {
         "-unchecked",
         // 'blessed' since 2.13.1
         "-language:higherKinds") ++
-        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals") else Seq.empty)
+      (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals") else Seq.empty)
     } else {
       Seq(
         "-encoding",

--- a/project/PekkoBuild.scala
+++ b/project/PekkoBuild.scala
@@ -97,8 +97,8 @@ object PekkoBuild {
         "-feature",
         "-unchecked",
         // 'blessed' since 2.13.1
-        "-language:higherKinds",
-        "-Yfuture-lazy-vals")
+        "-language:higherKinds") ++
+        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals") else Seq.empty)
     } else {
       Seq(
         "-encoding",

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -1527,7 +1527,8 @@ private[stream] object Collect {
         log = logAdapter match {
           case Some(l) => l
           case _       =>
-            Logging(materializer.system, materializer)(fromMaterializer)
+            implicit val ls: LogSource[Materializer] = fromMaterializer
+            Logging(materializer.system, materializer)
         }
       }
 
@@ -1647,7 +1648,8 @@ private[stream] object Collect {
         log = logAdapter match {
           case Some(l) => l
           case _       =>
-            Logging.withMarker(materializer.system, materializer)(fromMaterializer)
+            implicit val ls: LogSource[Materializer] = fromMaterializer
+            Logging.withMarker(materializer.system, materializer)
         }
       }
 


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC1 introduces breaking changes:
1. **Context bound desugaring**: `[T: ClassTag]` now desugars differently, making `method(args)(ClassTag(clazz))` fail with "No ClassTag available for T"
2. **Trait field bytecode**: `private val` in traits generates abstract setter methods with generic type signatures that mismatch between trait and implementing class, causing Java subclass compilation failures

### Modification
- **actor-typed/Behaviors.scala**: Use `implicit val ct: ClassTag[T] = ClassTag(clazz)` + implicit resolution instead of explicit `ClassTag(clazz)` passing for `monitor`, `transformMessages`, and `withMdc` methods
- **stream/Ops.scala**: Use `implicit val ls: LogSource[Materializer] = fromMaterializer` + implicit resolution instead of explicit passing for `Log` and `LogWithMarker` preStart methods
- **actor/FSM.scala**, **persistence/PersistentFSMBase.scala**: Change `private val handleEventDefault` to `private def handleEventDefault` to avoid abstract setter generation for this specific field

### Result
- ClassTag and LogSource context bound errors in actor-typed and stream modules are fully resolved
- `handleEventDefault` setter issue is partially mitigated; remaining trait setter issues are tracked in scala/scala3#26372 as a Scala 3.9 compiler regression

### Tests
- `sbt "++3.9.0-RC1!; compile"` — ClassTag/LogSource errors resolved

### References
- scala/scala3#26372 — Trait `private val` setter generates generic signature that Java subclasses cannot implement (Scala 3.9 regression)
- Related to #3073 which fixed similar ClassTag context bound issues for Scala 3.8