### PR TITLE
fix(actor-typed): discard stale ReceiveTimeout after cancelReceiveTimeout to avoid NPE

### DIFF
--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/CancelReceiveTimeoutSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/CancelReceiveTimeoutSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package org.apache.pekko.actor.typed
+
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.LogCapturing
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import pekko.actor.testkit.typed.scaladsl.TestProbe
+import pekko.actor.typed.scaladsl.Behaviors
+import pekko.actor.typed.scaladsl.adapter._
+
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class CancelReceiveTimeoutSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+
+  sealed trait Command
+  case object SetAndCancelTimeout extends Command
+  case object Timeout extends Command
+  case object Ping extends Command
+  case object Pong extends Event
+
+  sealed trait Event
+  case object Done extends Event
+
+  // A no-op interceptor that deepens the behavior stack so the message
+  // passes through InterceptorImpl.receive — the exact code path where
+  // msg.getClass throws NPE on a null message.
+  private def noopInterceptor[T: ClassTag] = new BehaviorInterceptor[T, T] {
+    override def aroundReceive(
+        ctx: TypedActorContext[T],
+        msg: T,
+        target: BehaviorInterceptor.ReceiveTarget[T]): Behavior[T] =
+      target(ctx, msg)
+  }
+
+  "A typed actor with receive timeout" must {
+
+    // Regression test for #3084: cancelReceiveTimeout() sets receiveTimeoutMsg to
+    // null, but a classic ReceiveTimeout already enqueued in the mailbox cannot be
+    // retracted. Before the fix the stale ReceiveTimeout was forwarded to the typed
+    // behavior stack as a null message, causing NPE in InterceptorImpl.receive.
+    "silently discard a stale ReceiveTimeout after cancelReceiveTimeout" in {
+      val probe = TestProbe[Event]()
+
+      def behavior: Behavior[Command] =
+        Behaviors.setup { context =>
+          // Wrap in an interceptor so the message traverses InterceptorImpl.receive,
+          // the exact location where msg.getClass throws NPE on a null message.
+          Behaviors.intercept[Command, Command](() => noopInterceptor[Command]) {
+            Behaviors.receiveMessage {
+              case SetAndCancelTimeout =>
+                // Set a very long timeout (won't actually fire), then immediately
+                // cancel it. This leaves receiveTimeoutMsg as null.
+                context.setReceiveTimeout(1.hour, Timeout)
+                context.cancelReceiveTimeout()
+                probe.ref ! Done
+                Behaviors.same
+
+              case Timeout =>
+                // Should never reach here: the timeout was cancelled and we send
+                // the classic ReceiveTimeout ourselves to simulate the stale case.
+                Behaviors.unhandled
+
+              case Ping =>
+                probe.ref ! Pong
+                Behaviors.same
+            }
+          }
+        }
+
+      val ref = spawn(behavior)
+
+      // Step 1: actor sets and cancels the receive timeout → receiveTimeoutMsg is now null
+      ref ! SetAndCancelTimeout
+      probe.expectMessage(Done)
+
+      // Step 2: simulate a stale classic ReceiveTimeout arriving in the mailbox.
+      // This is what happens when the scheduler fires ReceiveTimeout before
+      // cancelReceiveTimeout() is processed but the actor dequeues them in the
+      // opposite order.
+      ref.toClassic ! pekko.actor.ReceiveTimeout
+
+      // Step 3: verify the actor is still alive and responsive (no NPE crash).
+      ref ! Ping
+      probe.expectMessage(Pong)
+    }
+  }
+}

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/CancelReceiveTimeoutSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/CancelReceiveTimeoutSpec.scala
@@ -1,10 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.pekko.actor.typed

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/adapter/ActorAdapter.scala
@@ -100,7 +100,11 @@ import pekko.util.OptionVal
             } else Terminated(ActorRefAdapter(ref))
           handleSignal(msg)
         case classic.ReceiveTimeout =>
-          handleMessage(ctx.receiveTimeoutMsg)
+          // cancelReceiveTimeout() sets receiveTimeoutMsg to null, but a classic ReceiveTimeout
+          // that was already enqueued in the mailbox before the cancel cannot be retracted.
+          // Discard the stale timeout to avoid passing null into the typed behavior stack (#3084).
+          val timeoutMsg = ctx.receiveTimeoutMsg
+          if (timeoutMsg != null) handleMessage(timeoutMsg)
         case wrapped: AdaptMessage[Any, T] @unchecked =>
           withSafelyAdapted(() => wrapped.adapt()) {
             case AdaptWithRegisteredMessageAdapter(msg) =>


### PR DESCRIPTION
### Motivation

When `context.cancelReceiveTimeout()` is called while a classic `ReceiveTimeout` message has already been enqueued in the mailbox by the scheduler, the typed actor crashes with a `NullPointerException` inside `InterceptorImpl.receive`.

**Root cause trace:**

1. `setReceiveTimeout(d, msg)` → sets `receiveTimeoutMsg = msg`, schedules `classic.ReceiveTimeout` via `scheduleOnce`
2. Before the actor processes the enqueued `ReceiveTimeout`, another message triggers `cancelReceiveTimeout()`
3. `cancelReceiveTimeout()` sets `receiveTimeoutMsg = null` and calls `classicActorContext.setReceiveTimeout(Duration.Undefined)`
4. The already-enqueued `classic.ReceiveTimeout` **cannot be retracted** from the mailbox (the `Cancellable.cancel()` only prevents future scheduling, not already-delivered messages)
5. `ActorAdapter.aroundReceive` matches `classic.ReceiveTimeout` and calls `handleMessage(ctx.receiveTimeoutMsg)` — **with null**
6. The null message propagates through `Behavior.interpretMessage` → `InterceptorImpl.receive` → **`msg.getClass` throws NPE**

This bug was observed in both 2.8.3 and 2.6.21 of the upstream project. A reproduction is available at https://github.com/lolboxen/akka-receive-timeout-bug.

### Modification

- `ActorAdapter.aroundReceive`: null-check `ctx.receiveTimeoutMsg` before forwarding to `handleMessage`. If null (timeout was cancelled), the stale `classic.ReceiveTimeout` is silently discarded.
- Added `CancelReceiveTimeoutSpec`: a deterministic regression test that directly sends `classic.ReceiveTimeout` to a typed actor after `cancelReceiveTimeout()` has been called, verifying the actor survives without NPE. The test uses an interceptor in the behavior stack to exercise the exact `InterceptorImpl.receive` code path where the NPE manifests.

### Result

Typed actors no longer crash when `cancelReceiveTimeout()` races with an already-enqueued stale `ReceiveTimeout`. The fix is a single null-guard at the adapter layer — the typed behavior stack never sees a null message.

### Tests

```
sbt "actor-typed-tests / Test / testOnly org.apache.pekko.actor.typed.CancelReceiveTimeoutSpec"
→ All tests passed

sbt "actor-typed-tests / Test / testOnly org.apache.pekko.actor.typed.ActorContextSpec org.apache.pekko.actor.typed.TimerSpec org.apache.pekko.actor.typed.CancelReceiveTimeoutSpec"
→ 14 tests passed, 0 failed
```

The regression test was verified to **fail without the fix** (NPE at `InterceptorImpl.scala:94`) and **pass with the fix**.

### References

- Reproduction: https://github.com/lolboxen/akka-receive-timeout-bug