### PR TITLE
fix: widen ActorSelection SendConsistencySpec timeout to 60s

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteSendConsistencySpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteSendConsistencySpec.scala
@@ -216,7 +216,7 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config)
       system.actorOf(senderProps(selC))
       system.actorOf(senderProps(selA))
 
-      within(30.seconds) {
+      within(60.seconds) {
         expectMsg("success2")
         expectMsg("success2")
         expectMsg("success2")


### PR DESCRIPTION
### Motivation

The "must be able to send messages with actorSelection concurrently preserving order" test flakes on CI: 4 sender actors each drive 1000 round trips via `ActorSelection` (4004 messages total), wrapped in `ActorSelectionMessage` with remote-side path traversal overhead. On CI with `-Dpekko.test.timefactor=2`, `within(30.seconds)` dilates to 60s which is insufficient under load — 3 of 4 senders complete but the 4th times out waiting for the final `success2` message.

Investigation confirmed no recent code change caused this:
- Artery does not use stage actors → `LazyDispatch` (ba4e950edb) has zero impact
- Materializer wiring optimization (03ebaf59bb) affects materialization only, not runtime message flow
- `GraphInterpreter` `pendingFinalization` (a5058437af) is a hot-path optimization, no behavioral change

### Modification

Bump `within(30.seconds)` → `within(60.seconds)` at line 219 for the ActorSelection test only. The ActorRef variant (line 179) is unchanged as it passes within the original budget.

### Result

Up to 120s of dilated wall-clock headroom on CI for the ActorSelection variant; still fails fast on genuine deadlocks.

### Tests

- `sbt "remote / Test / compile"` — passes
- CI Check / Test will exercise the artery variants

### References

Refs #3041 (previous timeout widening from 10s to 30s)