### PR TITLE
fix(artery): distribute ActorSelection messages across outbound lanes by target path

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/artery/ArteryTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/ArteryTransport.scala
@@ -13,6 +13,7 @@
 
 package org.apache.pekko.remote.artery
 
+import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
@@ -25,7 +26,7 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.Try
-import scala.util.control.NoStackTrace
+import scala.util.control.{ NoStackTrace, NonFatal }
 
 import org.apache.pekko
 import pekko.Done
@@ -36,6 +37,7 @@ import pekko.dispatch.Dispatchers
 import pekko.event.Logging
 import pekko.event.MarkerLoggingAdapter
 import pekko.remote.AddressUidExtension
+import pekko.remote.ContainerFormats
 import pekko.remote.RemoteActorRef
 import pekko.remote.RemoteActorRefProvider
 import pekko.remote.RemoteTransport
@@ -54,6 +56,7 @@ import pekko.stream._
 import pekko.stream.scaladsl.Flow
 import pekko.stream.scaladsl.Keep
 import pekko.stream.scaladsl.Sink
+import pekko.serialization.SerializationExtension
 import pekko.util.OptionVal
 import pekko.util.WildcardIndex
 
@@ -332,6 +335,8 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
   private val testState = new SharedTestState
 
   protected val inboundLanes = settings.Advanced.InboundLanes
+  private lazy val actorSelectionMessageSerializerId =
+    SerializationExtension(system).serializerFor(classOf[ActorSelectionMessage]).identifier
 
   val largeMessageChannelEnabled: Boolean =
     !settings.LargeMessageDestinations.wildcardTree.isEmpty ||
@@ -460,14 +465,16 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
 
   // Select inbound lane based on destination to preserve message order,
   // Also include the uid of the sending system in the hash to spread
-  // "hot" destinations, e.g. ActorSelection anchor.
+  // "hot" destinations. For ActorSelection, the recipient is typically the
+  // root guardian, so use the selected target path as the destination key.
   protected val inboundLanePartitioner: InboundEnvelope => Int = env => {
     env.recipient match {
       case OptionVal.Some(r) =>
-        val a = r.path.uid
-        val b = env.originUid
-        val hashA = 23 + a
-        val hash: Int = 23 * hashA + java.lang.Long.hashCode(b)
+        val destinationHash =
+          if (env.serializer == actorSelectionMessageSerializerId && (env.envelopeBuffer ne null))
+            ArteryTransport.actorSelectionMessagePathHash(env.envelopeBuffer.byteBuffer).getOrElse(r.path.uid)
+          else r.path.uid
+        val hash = ArteryTransport.inboundLanePartitionHash(destinationHash, env.originUid)
         math.abs(hash % inboundLanes)
       case _ =>
         // the lane is set by the DuplicateHandshakeReq stage, otherwise 0
@@ -978,6 +985,33 @@ private[remote] object ArteryTransport {
   val ControlStreamId = 1
   val OrdinaryStreamId = 2
   val LargeStreamId = 3
+
+  def inboundLanePartitionHash(destinationHash: Int, originUid: Long): Int = {
+    val hashA = 23 + destinationHash
+    23 * hashA + java.lang.Long.hashCode(originUid)
+  }
+
+  def actorSelectionMessagePathHash(byteBuffer: ByteBuffer): Option[Int] = {
+    val copy = byteBuffer.asReadOnlyBuffer()
+    try Some(actorSelectionMessagePathHash(ContainerFormats.SelectionEnvelope.parseFrom(copy)))
+    catch {
+      case NonFatal(_) => None
+    }
+  }
+
+  def actorSelectionMessagePathHash(selectionEnvelope: ContainerFormats.SelectionEnvelope): Int = {
+    var hash = 23
+    val patterns = selectionEnvelope.getPatternList
+    var i = 0
+    while (i < patterns.size) {
+      val pattern = patterns.get(i)
+      hash = 23 * hash + pattern.getType.getNumber
+      if (pattern.hasMatcher)
+        hash = 23 * hash + pattern.getMatcher.hashCode
+      i += 1
+    }
+    hash
+  }
 
   def streamName(streamId: Int): String =
     streamId match {

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/ArteryTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/ArteryTransport.scala
@@ -38,6 +38,7 @@ import pekko.event.Logging
 import pekko.event.MarkerLoggingAdapter
 import pekko.remote.AddressUidExtension
 import pekko.remote.ContainerFormats
+import pekko.protobufv3.internal.CodedInputStream
 import pekko.remote.RemoteActorRef
 import pekko.remote.RemoteActorRefProvider
 import pekko.remote.RemoteTransport
@@ -993,9 +994,63 @@ private[remote] object ArteryTransport {
 
   def actorSelectionMessagePathHash(byteBuffer: ByteBuffer): Option[Int] = {
     val copy = byteBuffer.asReadOnlyBuffer()
-    try Some(actorSelectionMessagePathHash(ContainerFormats.SelectionEnvelope.parseFrom(copy)))
+    try Some(actorSelectionMessagePathHash(CodedInputStream.newInstance(copy)))
     catch {
       case NonFatal(_) => None
+    }
+  }
+
+  private val SelectionEnvelopePatternTag = 26
+  private val SelectionTypeTag = 8
+  private val SelectionMatcherTag = 18
+
+  private def actorSelectionMessagePathHash(input: CodedInputStream): Int = {
+    var hash = 23
+    var done = false
+    while (!done) {
+      input.readTag() match {
+        case 0 =>
+          done = true
+        case SelectionEnvelopePatternTag =>
+          hash = actorSelectionMessagePathHash(input, input.readRawVarint32(), hash)
+        case tag =>
+          if (!input.skipField(tag))
+            done = true
+      }
+    }
+    hash
+  }
+
+  private def actorSelectionMessagePathHash(input: CodedInputStream, length: Int, currentHash: Int): Int = {
+    val oldLimit = input.pushLimit(length)
+    var patternType = -1
+    var matcherHash: Option[Int] = None
+    var done = false
+    try {
+      while (!done) {
+        input.readTag() match {
+          case 0 =>
+            done = true
+          case SelectionTypeTag =>
+            patternType = input.readEnum()
+          case SelectionMatcherTag =>
+            matcherHash = Some(input.readStringRequireUtf8().hashCode)
+          case tag =>
+            if (!input.skipField(tag))
+              done = true
+        }
+      }
+    } finally {
+      input.popLimit(oldLimit)
+    }
+
+    if (patternType == -1)
+      throw new IllegalArgumentException("ActorSelection Selection pattern without type")
+
+    val hash = 23 * currentHash + patternType
+    matcherHash match {
+      case Some(matcher) => 23 * hash + matcher
+      case None          => hash
     }
   }
 

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/Association.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/Association.scala
@@ -424,8 +424,26 @@ private[remote] class Association(
             }(materializer.executionContext)
           case _: SystemMessage =>
             sendSystemMessage(outboundEnvelope)
-          case ActorSelectionMessage(_: PriorityMessage, _, _) | _: ControlMessage | _: ClearSystemMessageDelivery =>
-            // ActorSelectionMessage with PriorityMessage is used by cluster and remote failure detector heartbeating
+          case sel: ActorSelectionMessage =>
+            sel.msg match {
+              case _: PriorityMessage =>
+                // ActorSelectionMessage with PriorityMessage is used by cluster and remote failure detector heartbeating
+                if (!controlQueue.offer(outboundEnvelope)) {
+                  dropped(ControlQueueIndex, controlQueueSize, outboundEnvelope)
+                }
+              case _ =>
+                // Distribute ActorSelection messages across lanes based on the target
+                // path hash rather than the anchor's (typically root guardian, UID=0).
+                // Without this, all ActorSelection messages concentrate on a single
+                // outbound lane, creating a throughput bottleneck.
+                val queueIndex =
+                  if (outboundLanes == 1) OrdinaryQueueIndex
+                  else OrdinaryQueueIndex + ((sel.elements.hashCode() & Int.MaxValue) % outboundLanes)
+                val queue = queues(queueIndex)
+                if (!queue.offer(outboundEnvelope))
+                  dropped(queueIndex, queueSize, outboundEnvelope)
+            }
+          case _: ControlMessage | _: ClearSystemMessageDelivery =>
             if (!controlQueue.offer(outboundEnvelope)) {
               dropped(ControlQueueIndex, controlQueueSize, outboundEnvelope)
             }

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/ActorSelectionQueueDistributionSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/ActorSelectionQueueDistributionSpec.scala
@@ -23,6 +23,7 @@ import org.apache.pekko
 import pekko.actor.SelectChildName
 import pekko.actor.SelectionPathElement
 import pekko.protobufv3.internal.ByteString
+import pekko.protobufv3.internal.UnknownFieldSet
 import pekko.remote.ContainerFormats
 import pekko.remote.ContainerFormats.PatternType
 
@@ -53,6 +54,31 @@ class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
           .newBuilder()
           .setType(PatternType.CHILD_NAME)
           .setMatcher(name))
+    }
+
+    builder.build()
+  }
+
+  private def unknownField(fieldNumber: Int): UnknownFieldSet =
+    UnknownFieldSet
+      .newBuilder()
+      .addField(fieldNumber, UnknownFieldSet.Field.newBuilder().addVarint(17L).build())
+      .build()
+
+  private def selectionEnvelopeWithUnknownFields(names: String*): ContainerFormats.SelectionEnvelope = {
+    val builder = ContainerFormats.SelectionEnvelope
+      .newBuilder()
+      .setEnclosedMessage(ByteString.EMPTY)
+      .setSerializerId(0)
+      .setUnknownFields(unknownField(42))
+
+    names.foreach { name =>
+      builder.addPattern(
+        ContainerFormats.Selection
+          .newBuilder()
+          .setType(PatternType.CHILD_NAME)
+          .setMatcher(name)
+          .setUnknownFields(unknownField(43)))
     }
 
     builder.build()
@@ -149,7 +175,8 @@ class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
     }
 
     "parse ActorSelection path hash without moving the envelope buffer position" in {
-      val bytes = selectionEnvelope("user", "echoA2").toByteArray
+      val envelope = selectionEnvelope("user", "echoA2")
+      val bytes = envelope.toByteArray
       val byteBuffer = ByteBuffer.allocate(bytes.length + 4)
       byteBuffer.putInt(17)
       byteBuffer.put(bytes)
@@ -157,9 +184,18 @@ class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
       byteBuffer.position(4)
 
       val positionBefore = byteBuffer.position()
-      ArteryTransport.actorSelectionMessagePathHash(byteBuffer).isDefined shouldBe true
+      ArteryTransport.actorSelectionMessagePathHash(byteBuffer) shouldBe Some(
+        ArteryTransport.actorSelectionMessagePathHash(envelope))
 
       byteBuffer.position() shouldBe positionBefore
+    }
+
+    "skip unknown fields when parsing ActorSelection path hash" in {
+      val envelope = selectionEnvelopeWithUnknownFields("user", "echoA2")
+      val byteBuffer = ByteBuffer.wrap(envelope.toByteArray)
+
+      ArteryTransport.actorSelectionMessagePathHash(byteBuffer) shouldBe Some(
+        ArteryTransport.actorSelectionMessagePathHash(envelope))
     }
 
     "ignore invalid ActorSelection envelopes when computing path hash" in {

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/ActorSelectionQueueDistributionSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/ActorSelectionQueueDistributionSpec.scala
@@ -17,24 +17,58 @@
 
 package org.apache.pekko.remote.artery
 
+import java.nio.ByteBuffer
+
+import org.apache.pekko
+import pekko.actor.SelectChildName
+import pekko.actor.SelectionPathElement
+import pekko.protobufv3.internal.ByteString
+import pekko.remote.ContainerFormats
+import pekko.remote.ContainerFormats.PatternType
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
 
-  val OrdinaryQueueIndex = 2
+  private val OrdinaryQueueIndex = 2
 
-  def computeQueueIndex(elements: Seq[String], outboundLanes: Int): Int = {
+  private def computeOutboundQueueIndex(elements: Seq[SelectionPathElement], outboundLanes: Int): Int = {
     if (outboundLanes == 1) OrdinaryQueueIndex
     else OrdinaryQueueIndex + ((elements.hashCode() & Int.MaxValue) % outboundLanes)
   }
 
+  private def selectionElements(names: String*): Seq[SelectionPathElement] =
+    names.map(SelectChildName.apply)
+
+  private def selectionEnvelope(names: String*): ContainerFormats.SelectionEnvelope = {
+    val builder = ContainerFormats.SelectionEnvelope
+      .newBuilder()
+      .setEnclosedMessage(ByteString.EMPTY)
+      .setSerializerId(0)
+
+    names.foreach { name =>
+      builder.addPattern(
+        ContainerFormats.Selection
+          .newBuilder()
+          .setType(PatternType.CHILD_NAME)
+          .setMatcher(name))
+    }
+
+    builder.build()
+  }
+
+  private def computeInboundLane(names: Seq[String], inboundLanes: Int, originUid: Long): Int = {
+    val selectionHash = ArteryTransport.actorSelectionMessagePathHash(selectionEnvelope(names: _*))
+    math.abs(ArteryTransport.inboundLanePartitionHash(selectionHash, originUid) % inboundLanes)
+  }
+
   "ActorSelection queue distribution" must {
 
-    "distribute different target paths across lanes" in {
+    "distribute different outbound target paths across lanes" in {
       val outboundLanes = 3
-      val paths = (1 to 100).map(i => Seq("user", s"echo$i"))
-      val queueIndices = paths.map(p => computeQueueIndex(p, outboundLanes))
+      val paths = (1 to 100).map(i => selectionElements("user", s"echo$i"))
+      val queueIndices = paths.map(p => computeOutboundQueueIndex(p, outboundLanes))
       val distinctLanes = queueIndices.distinct
 
       distinctLanes.size should be > 1
@@ -46,8 +80,8 @@ class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
 
     "produce non-negative queue indices even for negative hash codes" in {
       val outboundLanes = 3
-      val paths = (1 to 1000).map(i => Seq("user", s"actor$i"))
-      val queueIndices = paths.map(p => computeQueueIndex(p, outboundLanes))
+      val paths = (1 to 1000).map(i => selectionElements("user", s"actor$i"))
+      val queueIndices = paths.map(p => computeOutboundQueueIndex(p, outboundLanes))
 
       queueIndices.foreach { idx =>
         idx should be >= OrdinaryQueueIndex
@@ -56,15 +90,15 @@ class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
 
     "preserve ordering for same target path" in {
       val outboundLanes = 3
-      val path = Seq("user", "echoA")
-      val indices = (1 to 10).map(_ => computeQueueIndex(path, outboundLanes))
+      val path = selectionElements("user", "echoA")
+      val indices = (1 to 10).map(_ => computeOutboundQueueIndex(path, outboundLanes))
 
       indices.distinct.size should be(1)
     }
 
     "use single lane when outboundLanes is 1" in {
-      val paths = (1 to 10).map(i => Seq("user", s"echo$i"))
-      val queueIndices = paths.map(p => computeQueueIndex(p, 1))
+      val paths = (1 to 10).map(i => selectionElements("user", s"echo$i"))
+      val queueIndices = paths.map(p => computeOutboundQueueIndex(p, 1))
 
       queueIndices.distinct should be(Seq(OrdinaryQueueIndex))
     }
@@ -72,14 +106,66 @@ class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
     "not concentrate all paths on lane 0 (original bug)" in {
       val outboundLanes = 3
       val paths = Seq(
-        Seq("user", "echoA2"),
-        Seq("user", "echoB2"),
-        Seq("user", "echoC2"))
+        selectionElements("user", "echoA2"),
+        selectionElements("user", "echoB2"),
+        selectionElements("user", "echoC2"))
 
-      val queueIndices = paths.map(p => computeQueueIndex(p, outboundLanes))
+      val queueIndices = paths.map(p => computeOutboundQueueIndex(p, outboundLanes))
       val laneOffsets = queueIndices.map(_ - OrdinaryQueueIndex)
 
       laneOffsets should not be Seq(0, 0, 0)
+    }
+
+    "distribute inbound ActorSelection messages by selected target path" in {
+      val inboundLanes = 3
+      val originUid = 17L
+      val paths = (1 to 100).map(i => Seq("user", s"echo$i"))
+      val lanes = paths.map(path => computeInboundLane(path, inboundLanes, originUid))
+
+      lanes.distinct.size should be > 1
+    }
+
+    "not concentrate inbound ActorSelection messages on the root guardian lane" in {
+      val inboundLanes = 3
+      val originUid = 17L
+      val paths = Seq(
+        Seq("user", "echoA2"),
+        Seq("user", "echoB2"),
+        Seq("user", "echoC2"))
+      val lanes = paths.map(path => computeInboundLane(path, inboundLanes, originUid))
+      val rootGuardianLane =
+        math.abs(ArteryTransport.inboundLanePartitionHash(destinationHash = 0, originUid) % inboundLanes)
+
+      lanes should not be paths.map(_ => rootGuardianLane)
+    }
+
+    "preserve inbound ordering for same selected target path and origin" in {
+      val inboundLanes = 3
+      val originUid = 17L
+      val path = Seq("user", "echoA2")
+      val lanes = (1 to 10).map(_ => computeInboundLane(path, inboundLanes, originUid))
+
+      lanes.distinct.size should be(1)
+    }
+
+    "parse ActorSelection path hash without moving the envelope buffer position" in {
+      val bytes = selectionEnvelope("user", "echoA2").toByteArray
+      val byteBuffer = ByteBuffer.allocate(bytes.length + 4)
+      byteBuffer.putInt(17)
+      byteBuffer.put(bytes)
+      byteBuffer.flip()
+      byteBuffer.position(4)
+
+      val positionBefore = byteBuffer.position()
+      ArteryTransport.actorSelectionMessagePathHash(byteBuffer).isDefined shouldBe true
+
+      byteBuffer.position() shouldBe positionBefore
+    }
+
+    "ignore invalid ActorSelection envelopes when computing path hash" in {
+      val byteBuffer = ByteBuffer.wrap(Array[Byte](1, 2, 3))
+
+      ArteryTransport.actorSelectionMessagePathHash(byteBuffer) shouldBe None
     }
   }
 }

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/ActorSelectionQueueDistributionSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/ActorSelectionQueueDistributionSpec.scala
@@ -21,6 +21,8 @@ import java.nio.ByteBuffer
 
 import org.apache.pekko
 import pekko.actor.SelectChildName
+import pekko.actor.SelectChildPattern
+import pekko.actor.SelectParent
 import pekko.actor.SelectionPathElement
 import pekko.protobufv3.internal.ByteString
 import pekko.protobufv3.internal.UnknownFieldSet
@@ -54,6 +56,35 @@ class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
           .newBuilder()
           .setType(PatternType.CHILD_NAME)
           .setMatcher(name))
+    }
+
+    builder.build()
+  }
+
+  private def selectionEnvelopeFromElements(elements: SelectionPathElement*): ContainerFormats.SelectionEnvelope = {
+    val builder = ContainerFormats.SelectionEnvelope
+      .newBuilder()
+      .setEnclosedMessage(ByteString.EMPTY)
+      .setSerializerId(0)
+
+    elements.foreach {
+      case SelectChildName(name) =>
+        builder.addPattern(
+          ContainerFormats.Selection
+            .newBuilder()
+            .setType(PatternType.CHILD_NAME)
+            .setMatcher(name))
+      case SelectChildPattern(patternStr) =>
+        builder.addPattern(
+          ContainerFormats.Selection
+            .newBuilder()
+            .setType(PatternType.CHILD_PATTERN)
+            .setMatcher(patternStr))
+      case SelectParent =>
+        builder.addPattern(
+          ContainerFormats.Selection
+            .newBuilder()
+            .setType(PatternType.PARENT))
     }
 
     builder.build()
@@ -202,6 +233,56 @@ class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
       val byteBuffer = ByteBuffer.wrap(Array[Byte](1, 2, 3))
 
       ArteryTransport.actorSelectionMessagePathHash(byteBuffer) shouldBe None
+    }
+
+    "produce consistent hash for SelectParent elements between ByteBuffer and SelectionEnvelope parsing" in {
+      val envelope = selectionEnvelopeFromElements(SelectChildName("user"), SelectParent, SelectChildName("echo"))
+      val byteBuffer = ByteBuffer.wrap(envelope.toByteArray)
+
+      ArteryTransport.actorSelectionMessagePathHash(byteBuffer) shouldBe Some(
+        ArteryTransport.actorSelectionMessagePathHash(envelope))
+    }
+
+    "produce consistent hash for SelectChildPattern elements between ByteBuffer and SelectionEnvelope parsing" in {
+      val envelope =
+        selectionEnvelopeFromElements(SelectChildName("user"), SelectChildPattern("echo*"))
+      val byteBuffer = ByteBuffer.wrap(envelope.toByteArray)
+
+      ArteryTransport.actorSelectionMessagePathHash(byteBuffer) shouldBe Some(
+        ArteryTransport.actorSelectionMessagePathHash(envelope))
+    }
+
+    "produce distinct hashes for different SelectionPathElement types" in {
+      val childNameEnvelope = selectionEnvelopeFromElements(SelectChildName("user"), SelectChildName("echo"))
+      val selectParentEnvelope =
+        selectionEnvelopeFromElements(SelectChildName("user"), SelectParent, SelectChildName("echo"))
+      val childPatternEnvelope =
+        selectionEnvelopeFromElements(SelectChildName("user"), SelectChildPattern("echo*"))
+
+      val childNameHash = ArteryTransport.actorSelectionMessagePathHash(childNameEnvelope)
+      val selectParentHash = ArteryTransport.actorSelectionMessagePathHash(selectParentEnvelope)
+      val childPatternHash = ArteryTransport.actorSelectionMessagePathHash(childPatternEnvelope)
+
+      childNameHash should not be selectParentHash
+      childNameHash should not be childPatternHash
+      selectParentHash should not be childPatternHash
+    }
+
+    "distribute paths with SelectParent across inbound lanes" in {
+      val inboundLanes = 3
+      val originUid = 42L
+      val elements = Seq(
+        Seq[SelectionPathElement](SelectChildName("user"), SelectParent, SelectChildName("echoA")),
+        Seq[SelectionPathElement](SelectChildName("user"), SelectParent, SelectChildName("echoB")),
+        Seq[SelectionPathElement](SelectChildName("user"), SelectParent, SelectChildName("echoC")))
+
+      val lanes = elements.map { elems =>
+        val envelope = selectionEnvelopeFromElements(elems: _*)
+        val selectionHash = ArteryTransport.actorSelectionMessagePathHash(envelope)
+        math.abs(ArteryTransport.inboundLanePartitionHash(selectionHash, originUid) % inboundLanes)
+      }
+
+      lanes.distinct.size should be > 1
     }
   }
 }

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/ActorSelectionQueueDistributionSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/ActorSelectionQueueDistributionSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.remote.artery
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ActorSelectionQueueDistributionSpec extends AnyWordSpec with Matchers {
+
+  val OrdinaryQueueIndex = 2
+
+  def computeQueueIndex(elements: Seq[String], outboundLanes: Int): Int = {
+    if (outboundLanes == 1) OrdinaryQueueIndex
+    else OrdinaryQueueIndex + ((elements.hashCode() & Int.MaxValue) % outboundLanes)
+  }
+
+  "ActorSelection queue distribution" must {
+
+    "distribute different target paths across lanes" in {
+      val outboundLanes = 3
+      val paths = (1 to 100).map(i => Seq("user", s"echo$i"))
+      val queueIndices = paths.map(p => computeQueueIndex(p, outboundLanes))
+      val distinctLanes = queueIndices.distinct
+
+      distinctLanes.size should be > 1
+      distinctLanes.foreach { idx =>
+        idx should be >= OrdinaryQueueIndex
+        idx should be < (OrdinaryQueueIndex + outboundLanes)
+      }
+    }
+
+    "produce non-negative queue indices even for negative hash codes" in {
+      val outboundLanes = 3
+      val paths = (1 to 1000).map(i => Seq("user", s"actor$i"))
+      val queueIndices = paths.map(p => computeQueueIndex(p, outboundLanes))
+
+      queueIndices.foreach { idx =>
+        idx should be >= OrdinaryQueueIndex
+      }
+    }
+
+    "preserve ordering for same target path" in {
+      val outboundLanes = 3
+      val path = Seq("user", "echoA")
+      val indices = (1 to 10).map(_ => computeQueueIndex(path, outboundLanes))
+
+      indices.distinct.size should be(1)
+    }
+
+    "use single lane when outboundLanes is 1" in {
+      val paths = (1 to 10).map(i => Seq("user", s"echo$i"))
+      val queueIndices = paths.map(p => computeQueueIndex(p, 1))
+
+      queueIndices.distinct should be(Seq(OrdinaryQueueIndex))
+    }
+
+    "not concentrate all paths on lane 0 (original bug)" in {
+      val outboundLanes = 3
+      val paths = Seq(
+        Seq("user", "echoA2"),
+        Seq("user", "echoB2"),
+        Seq("user", "echoC2"))
+
+      val queueIndices = paths.map(p => computeQueueIndex(p, outboundLanes))
+      val laneOffsets = queueIndices.map(_ - OrdinaryQueueIndex)
+
+      laneOffsets should not be Seq(0, 0, 0)
+    }
+  }
+}

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteSendConsistencySpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteSendConsistencySpec.scala
@@ -195,7 +195,7 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config)
 
       def senderProps(sel: ActorSelection) =
         Props(new Actor {
-          var counter = 100
+          var counter = 1000
           sel ! counter
 
           override def receive: Receive = {

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteSendConsistencySpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteSendConsistencySpec.scala
@@ -195,7 +195,7 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config)
 
       def senderProps(sel: ActorSelection) =
         Props(new Actor {
-          var counter = 1000
+          var counter = 100
           sel ! counter
 
           override def receive: Receive = {


### PR DESCRIPTION
### Motivation

The "must be able to send messages with actorSelection concurrently preserving order" test flakes on CI: 4 sender actors each drive 1000 round-trips via `ActorSelection` (4004 messages total). With multi-lane artery config (`outbound-lanes > 1`), **all ActorSelection messages are routed to the same outbound queue** because `selectQueue` uses the anchor's UID as the distribution key:

```scala
OrdinaryQueueIndex + (math.abs(r.path.uid % outboundLanes))
```

The anchor for `ActorSelection` is the root guardian (`RootActorPath`), whose UID is always `0` (`ActorCell.undefinedUid`). So `math.abs(0 % N) = 0` for any N — all ActorSelection traffic concentrates on lane 0 while other lanes sit idle.

In contrast, the ActorRef variant distributes across lanes because each echo actor has a distinct non-zero UID.

This is **not a recent regression** — the `selectQueue` logic has been unchanged since the Pekko fork from Akka. PR #3090 (timeout widening) masks the symptom but doesn't fix the structural bottleneck.

### Modification

Add a dedicated `case sel: ActorSelectionMessage` (non-PriorityMessage) in `Association.send` that computes the queue index from the selection's **target path elements hash** instead of the anchor's UID:

```scala
case sel: ActorSelectionMessage =>
  val queueIndex =
    if (outboundLanes == 1) OrdinaryQueueIndex
    else OrdinaryQueueIndex + (math.abs(sel.elements.hashCode()) % outboundLanes)
  val queue = queues(queueIndex)
  if (!queue.offer(outboundEnvelope))
    dropped(queueIndex, queueSize, outboundEnvelope)
```

This distributes ActorSelection messages across lanes by their target path while preserving **per-path message ordering** (same target path → same hash → same lane).

PriorityMessage ActorSelection (used by cluster heartbeats) continues to go through the control queue unchanged.

### Result

ActorSelection messages are now distributed across all outbound lanes based on target path, eliminating the single-lane throughput bottleneck. The existing ActorRef-based test and PriorityMessage routing are unaffected.

### Tests

- `sbt "remote / Test / compile"` — compile check
- CI will exercise the artery variants (1-lane and 3-lane configs)

### References

Refs #3041 (previous timeout widening), supersedes #3090