### PR TITLE
Clean up stopped FSM transition listeners

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/FSMTransitionSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/FSMTransitionSpec.scala
@@ -20,6 +20,8 @@ import pekko.testkit._
 
 object FSMTransitionSpec {
 
+  case object ListenerCount
+
   class Supervisor extends Actor {
     def receive = { case _ => }
   }
@@ -44,7 +46,8 @@ object FSMTransitionSpec {
       case Event("tick", _) => goto(0)
     }
     whenUnhandled {
-      case Event("reply", _) => stay().replying("reply")
+      case Event("reply", _)       => stay().replying("reply")
+      case Event(ListenerCount, _) => stay().replying(listeners.size)
     }
     initialize()
     override def preRestart(reason: Throwable, msg: Option[Any]): Unit = { target ! "restarted" }
@@ -107,9 +110,30 @@ class FSMTransitionSpec extends PekkoSpec with ImplicitSender {
       within(1.second) {
         fsm ! FSM.SubscribeTransitionCallBack(forward)
         expectMsg(FSM.CurrentState(fsm, 0))
-        pekko.pattern.gracefulStop(forward, 5.seconds)
+        watch(forward)
+        system.stop(forward)
+        expectTerminated(forward)
         fsm ! "tick"
         expectNoMessage()
+      }
+    }
+
+    "remove stopped listeners" in {
+      val forward = system.actorOf(Props(new Forwarder(testActor)))
+      val fsm = system.actorOf(Props(new MyFSM(testActor)))
+
+      within(3.seconds) {
+        fsm ! FSM.SubscribeTransitionCallBack(forward)
+        expectMsg(FSM.CurrentState(fsm, 0))
+
+        watch(forward)
+        system.stop(forward)
+        expectTerminated(forward)
+
+        awaitAssert {
+          fsm ! ListenerCount
+          expectMsg(0)
+        }
       }
     }
   }

--- a/actor/src/main/mima-filters/2.0.x.backwards.excludes/fsm-transition-listeners.excludes
+++ b/actor/src/main/mima-filters/2.0.x.backwards.excludes/fsm-transition-listeners.excludes
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Clean up stopped FSM transition listeners
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.actor.FSM.org$apache$pekko$actor$FSM$$watchedListeners*")

--- a/actor/src/main/scala/org/apache/pekko/actor/FSM.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/FSM.scala
@@ -99,6 +99,7 @@ object FSM {
    * INTERNAL API
    */
   private final case class TimeoutMarker(generation: Long)
+  private final case class ListenerTerminated(actorRef: ActorRef)
 
   /** INTERNAL API */
   @InternalApi
@@ -406,9 +407,8 @@ object FSM {
  *
  * Another feature is that other actors may subscribe for transition events by
  * sending a <code>SubscribeTransitionCallback</code> message to this actor.
- * Stopping a listener without unregistering will not remove the listener from the
- * subscription list; use <code>UnsubscribeTransitionCallback</code> before stopping
- * the listener.
+ * Stopping a listener will remove it from the subscription list. Subscriptions
+ * may also be removed explicitly with <code>UnsubscribeTransitionCallback</code>.
  *
  * State timeouts set an upper bound to the time which may pass before another
  * message is received in the current state. If no external message is
@@ -779,9 +779,32 @@ trait FSM[S, D] extends Actor with Listeners with ActorLogging {
    * transition handling
    */
   private var transitionEvent: List[TransitionHandler] = Nil
+  private var watchedListeners: Set[ActorRef] = Set.empty
   private def handleTransition(prev: S, next: S): Unit = {
     val tuple = (prev, next)
     for (te <- transitionEvent) { if (te.isDefinedAt(tuple)) te(tuple) }
+  }
+
+  private def addListener(actorRef: ActorRef): Unit = {
+    if (listeners.add(actorRef)) {
+      context.asInstanceOf[ActorCell].isWatching(actorRef) match {
+        case false =>
+          context.watchWith(actorRef, ListenerTerminated(actorRef))
+          watchedListeners += actorRef
+        case true =>
+          log.warning(
+            "Listener [{}] is already watched by this FSM; it will not be automatically removed on termination. " +
+            "Use UnsubscribeTransitionCallBack explicitly.",
+            actorRef)
+      }
+    }
+  }
+
+  private def removeListener(actorRef: ActorRef): Unit = {
+    if (listeners.remove(actorRef) && watchedListeners.contains(actorRef)) {
+      watchedListeners -= actorRef
+      context.unwatch(actorRef)
+    }
   }
 
   /*
@@ -807,19 +830,20 @@ trait FSM[S, D] extends Actor with Listeners with ActorLogging {
         processMsg(msg, t)
       }
     case SubscribeTransitionCallBack(actorRef) =>
-      // TODO Use context.watch(actor) and receive Terminated(actor) to clean up list
-      listeners.add(actorRef)
+      addListener(actorRef)
       // send current state back as reference point
       actorRef ! CurrentState(self, currentState.stateName)
     case Listen(actorRef) =>
-      // TODO Use context.watch(actor) and receive Terminated(actor) to clean up list
-      listeners.add(actorRef)
+      addListener(actorRef)
       // send current state back as reference point
       actorRef ! CurrentState(self, currentState.stateName)
     case UnsubscribeTransitionCallBack(actorRef) =>
-      listeners.remove(actorRef)
+      removeListener(actorRef)
     case Deafen(actorRef) =>
+      removeListener(actorRef)
+    case ListenerTerminated(actorRef) =>
       listeners.remove(actorRef)
+      watchedListeners -= actorRef
     case value =>
       if (timeoutFuture.isDefined) {
         timeoutFuture.get.cancel()

--- a/docs/src/main/paradox/fsm.md
+++ b/docs/src/main/paradox/fsm.md
@@ -417,9 +417,8 @@ transitions use `stay()` instead of `goto(S)`.
 External monitors may be unregistered by sending
 `UnsubscribeTransitionCallBack(actorRef)` to the `FSM` actor.
 
-Stopping a listener without unregistering will not remove the listener from the
-subscription list; use `UnsubscribeTransitionCallback` before stopping
-the listener.
+Stopping a listener will remove it from the subscription list. Subscriptions may
+also be removed explicitly with `UnsubscribeTransitionCallback`.
 
 @@@ div { .group-scala }
 

--- a/persistence/src/main/mima-filters/2.0.x.backwards.excludes/fsm-transition-listeners.excludes
+++ b/persistence/src/main/mima-filters/2.0.x.backwards.excludes/fsm-transition-listeners.excludes
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Clean up stopped FSM transition listeners
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.persistence.fsm.PersistentFSMBase.org$apache$pekko$persistence$fsm$PersistentFSMBase$$watchedListeners*")

--- a/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSM.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSM.scala
@@ -310,6 +310,7 @@ object PersistentFSM {
   /** INTERNAL API */
   @InternalApi
   private[persistence] final case class TimeoutMarker(generation: Long)
+  private[persistence] final case class ListenerTerminated(actorRef: ActorRef)
 
   /** INTERNAL API */
   @InternalApi

--- a/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSMBase.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSMBase.scala
@@ -85,9 +85,8 @@ import pekko.routing.{ Deafen, Listen, Listeners }
  *
  * Another feature is that other actors may subscribe for transition events by
  * sending a <code>SubscribeTransitionCallback</code> message to this actor.
- * Stopping a listener without unregistering will not remove the listener from the
- * subscription list; use <code>UnsubscribeTransitionCallback</code> before stopping
- * the listener.
+ * Stopping a listener will remove it from the subscription list. Subscriptions
+ * may also be removed explicitly with <code>UnsubscribeTransitionCallback</code>.
  *
  * State timeouts set an upper bound to the time which may pass before another
  * message is received in the current state. If no external message is
@@ -482,9 +481,32 @@ trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging 
    * transition handling
    */
   private var transitionEvent: List[TransitionHandler] = Nil
+  private var watchedListeners: Set[ActorRef] = Set.empty
   private def handleTransition(prev: S, next: S): Unit = {
     val tuple = (prev, next)
     for (te <- transitionEvent) { if (te.isDefinedAt(tuple)) te(tuple) }
+  }
+
+  private def addListener(actorRef: ActorRef): Unit = {
+    if (listeners.add(actorRef)) {
+      context.asInstanceOf[ActorCell].isWatching(actorRef) match {
+        case false =>
+          context.watchWith(actorRef, ListenerTerminated(actorRef))
+          watchedListeners += actorRef
+        case true =>
+          log.warning(
+            "Listener [{}] is already watched by this FSM; it will not be automatically removed on termination. " +
+            "Use UnsubscribeTransitionCallBack explicitly.",
+            actorRef)
+      }
+    }
+  }
+
+  private def removeListener(actorRef: ActorRef): Unit = {
+    if (listeners.remove(actorRef) && watchedListeners.contains(actorRef)) {
+      watchedListeners -= actorRef
+      context.unwatch(actorRef)
+    }
   }
 
   /*
@@ -510,19 +532,20 @@ trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging 
         processMsg(msg, t)
       }
     case SubscribeTransitionCallBack(actorRef) =>
-      // TODO Use context.watch(actor) and receive Terminated(actor) to clean up list
-      listeners.add(actorRef)
+      addListener(actorRef)
       // send current state back as reference point
       actorRef ! CurrentState(self, currentState.stateName, currentState.timeout)
     case Listen(actorRef) =>
-      // TODO Use context.watch(actor) and receive Terminated(actor) to clean up list
-      listeners.add(actorRef)
+      addListener(actorRef)
       // send current state back as reference point
       actorRef ! CurrentState(self, currentState.stateName, currentState.timeout)
     case UnsubscribeTransitionCallBack(actorRef) =>
-      listeners.remove(actorRef)
+      removeListener(actorRef)
     case Deafen(actorRef) =>
+      removeListener(actorRef)
+    case ListenerTerminated(actorRef) =>
       listeners.remove(actorRef)
+      watchedListeners -= actorRef
     case value =>
       if (timeoutFuture.isDefined) {
         timeoutFuture.get.cancel()

--- a/persistence/src/test/scala/org/apache/pekko/persistence/fsm/PersistentFSMSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/fsm/PersistentFSMSpec.scala
@@ -73,6 +73,30 @@ abstract class PersistentFSMSpec(config: Config) extends PersistenceSpec(config)
       expectTerminated(fsmRef)
     }
 
+    "remove stopped transition listeners" in {
+      val persistenceId = name
+      val listener = TestProbe()
+      val fsmRef = system.actorOf(SimpleTransitionFSM.props(persistenceId, TestProbe().ref))
+
+      fsmRef ! SubscribeTransitionCallBack(listener.ref)
+      listener.expectMsg(CurrentState(fsmRef, LookingAround, None))
+      fsmRef ! ListenerCount
+      expectMsg(1)
+
+      watch(listener.ref)
+      system.stop(listener.ref)
+      expectTerminated(listener.ref)
+
+      awaitAssert {
+        fsmRef ! ListenerCount
+        expectMsg(0)
+      }
+
+      watch(fsmRef)
+      fsmRef ! PoisonPill
+      expectTerminated(fsmRef)
+    }
+
     "function as a regular FSM on state timeout" taggedAs TimingTest in {
       val persistenceId = name
       val fsmRef = system.actorOf(WebStoreCustomerFSM.props(persistenceId, dummyReportActorRef))
@@ -450,6 +474,7 @@ object PersistentFSMSpec {
   case object Leave extends Command
   case object GetCurrentCart extends Command
   // #customer-commands
+  case object ListenerCount
 
   // #customer-domain-events
   sealed trait DomainEvent
@@ -472,8 +497,9 @@ object PersistentFSMSpec {
     startWith(LookingAround, EmptyShoppingCart)
 
     when(LookingAround) {
-      case Event("stay", _) => stay()
-      case Event(_, _)      => goto(LookingAround)
+      case Event("stay", _)        => stay()
+      case Event(ListenerCount, _) => stay().replying(listeners.size)
+      case Event(_, _)             => goto(LookingAround)
     }
 
     onTransition {


### PR DESCRIPTION
## Summary

Classic FSM and PersistentFSM keep transition listeners in a listener set until they explicitly unsubscribe. This changes the subscription path to DeathWatch listeners with an internal cleanup message, so stopped listener actors are removed automatically.

The explicit unsubscribe/deafen paths still remove listeners, and they now also unwatch only DeathWatch registrations created by the listener subscription path. If an FSM was already watching the same actor for its own logic, this change does not replace that existing watch.

## Tests

- `actor-tests/testOnly org.apache.pekko.actor.FSMTransitionSpec`
- `persistence/testOnly org.apache.pekko.persistence.fsm.InmemPersistentFSMSpec`
- `docs/paradox`
