### PR TITLE
test: isolate SendConsistency specs into separate JVM forks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -434,6 +434,24 @@ lazy val remote =
     .settings(OSGi.remote)
     .settings(Protobuf.settings)
     .settings(Test / parallelExecution := false)
+    .settings(
+      // Isolate SendConsistency specs that create multiple ActorSystems
+      // with TLS-TCP and 1000 round-trip message exchanges into their own
+      // JVM fork. These specs are sensitive to thread contention from
+      // lingering ActorSystem threads of other test classes in the same JVM.
+      Test / testGrouping := {
+        val allTests = (Test / definedTests).value
+        val (sendConsistencyTests, otherTests) =
+          allTests.partition(_.name.contains("SendConsistency"))
+        val defaultForkOptions = ForkOptions()
+          .withRunJVMOptions((Test / javaOptions).value.toVector)
+        val otherGroup =
+          Tests.Group("other", otherTests, Tests.SubProcess(defaultForkOptions))
+        val sendConsistencyGroups = sendConsistencyTests.map { t =>
+          Tests.Group(t.name, Seq(t), Tests.SubProcess(defaultForkOptions))
+        }
+        otherGroup +: sendConsistencyGroups
+      })
     .enablePlugins(DependWalkerPlugin, SbtOsgi)
 
 lazy val remoteTests = pekkoModule("remote-tests")

--- a/build.sbt
+++ b/build.sbt
@@ -443,12 +443,13 @@ lazy val remote =
         val allTests = (Test / definedTests).value
         val (sendConsistencyTests, otherTests) =
           allTests.partition(_.name.contains("SendConsistency"))
-        val defaultForkOptions = ForkOptions()
+        val forkOptions = ForkOptions()
           .withRunJVMOptions((Test / javaOptions).value.toVector)
+          .withWorkingDirectory(Some(new File(System.getProperty("user.dir"))))
         val otherGroup =
-          Tests.Group("other", otherTests, Tests.SubProcess(defaultForkOptions))
+          Tests.Group("other", otherTests, Tests.SubProcess(forkOptions))
         val sendConsistencyGroups = sendConsistencyTests.map { t =>
-          Tests.Group(t.name, Seq(t), Tests.SubProcess(defaultForkOptions))
+          Tests.Group(t.name, Seq(t), Tests.SubProcess(forkOptions))
         }
         otherGroup +: sendConsistencyGroups
       })


### PR DESCRIPTION
### Motivation

`ArteryTlsTcpSendConsistencyWithOneLaneSpec` flakes on CI because it creates 2 ActorSystems with TLS-TCP transport and runs 1000 round-trip message exchanges via `ActorSelection`. When other test classes run in the same forked JVM (the remote module uses a single fork), lingering ActorSystem threads from previous tests consume CPU and compete with the TLS operations, causing the test to exceed its 60-second timeout (30s × timefactor=2).

Even with `Test / parallelExecution := false`, test classes share the same JVM and their ActorSystem cleanup threads (TLS connections, scheduler threads, dispatcher pools) overlap.

### Modification

Add `Tests.Group` configuration to the remote module that partitions `*SendConsistency*` test classes into their own `SubProcess` (forked JVM), while keeping all other remote tests in a shared "other" group:

```scala
Test / testGrouping := {
  val allTests = (Test / definedTests).value
  val (sendConsistencyTests, otherTests) =
    allTests.partition(_.name.contains("SendConsistency"))
  val defaultForkOptions = ForkOptions()
    .withRunJVMOptions((Test / javaOptions).value.toVector)
  val otherGroup = Tests.Group("other", otherTests, Tests.SubProcess(defaultForkOptions))
  val sendConsistencyGroups = sendConsistencyTests.map { t =>
    Tests.Group(t.name, Seq(t), Tests.SubProcess(defaultForkOptions))
  }
  otherGroup +: sendConsistencyGroups
}
```

Each of the 6 SendConsistency specs gets a clean JVM with no thread contention from previously-run test classes.

### Result

SendConsistency specs run in isolated JVM forks, eliminating cross-test thread contention that caused the 1-lane TLS-TCP variant to flake. Other remote tests continue to share a single fork (no additional overhead).

### Tests

```
sbt -Dpekko.test.timefactor=2 "remote / Test / testOnly
  *ArteryTlsTcpSendConsistencyWithOneLaneSpec" — 4/4 passed

sbt "show remote / Test / testGrouping" — verified 6 SendConsistency
  groups + 1 "other" group
```

### References

Refs #3089