### PR TITLE
feat(stream): add supervisor strategy support to Throttle costCalculation

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowThrottleSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowThrottleSpec.scala
@@ -347,6 +347,46 @@ class FlowThrottleSpec extends StreamSpec("""
         .expectError(ex)
     }
 
+    "resume on cost calculation exception with supervision strategy" in {
+      Source(1 to 5)
+        .throttle(2, 200.millis, 0, e => if (e == 3) throw new RuntimeException("boom") else 1, Shaping)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2, 4, 5)
+        .expectComplete()
+    }
+
+    "resume on cost calculation exception with supervision in Enforcing mode" in {
+      Source(1 to 5)
+        .throttle(2, 200.millis, 10, e => if (e == 3) throw new RuntimeException("boom") else 1, Enforcing)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2, 4, 5)
+        .expectComplete()
+    }
+
+    "restart on cost calculation exception with restarting decider" in {
+      Source(1 to 5)
+        .throttle(2, 200.millis, 0, e => if (e == 3) throw new RuntimeException("boom") else 1, Shaping)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2, 4, 5)
+        .expectComplete()
+    }
+
+    "fail on cost calculation exception by default" in {
+      val ex = new RuntimeException("cost boom") with NoStackTrace
+      Source(1 to 5)
+        .throttle(2, 200.millis, 0, e => if (e == 3) throw ex else 1, Shaping)
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2)
+        .expectError(ex)
+    }
+
     "work for real scenario with automatic burst size" taggedAs TimingTest in {
       val startTime = System.nanoTime()
       val counter1 = new AtomicInteger

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Throttle.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Throttle.scala
@@ -14,10 +14,12 @@
 package org.apache.pekko.stream.impl
 
 import scala.concurrent.duration.{ FiniteDuration, _ }
+import scala.util.control.NonFatal
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream._
+import pekko.stream.ActorAttributes.SupervisionStrategy
 import pekko.stream.ThrottleMode.Enforcing
 import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import pekko.stream.stage._
@@ -57,9 +59,10 @@ import pekko.util.NanoTimeTokenBucket
   require(!(mode == ThrottleMode.Enforcing && effectiveMaximumBurst < 0), "maximumBurst must be > 0 in Enforcing mode")
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new TimerGraphStageLogic(shape) with InHandler with OutHandler {
+    new TimerGraphStageLogic(shape) with StageLogging with InHandler with OutHandler {
       private val tokenBucket = new NanoTimeTokenBucket(effectiveMaximumBurst, nanosBetweenTokens)
       private var currentElement: T = _
+      private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
 
       override def preStart(): Unit = tokenBucket.init()
 
@@ -70,16 +73,28 @@ import pekko.util.NanoTimeTokenBucket
 
       override def onPush(): Unit = {
         val elem = grab(in)
-        val cost = costCalculation(elem)
-        val delayNanos = tokenBucket.offer(cost)
+        try {
+          val cost = costCalculation(elem)
+          val delayNanos = tokenBucket.offer(cost)
 
-        if (delayNanos == 0L) push(out, elem)
-        else {
-          if (mode eq Enforcing) failStage(new RateExceededException("Maximum throttle throughput exceeded."))
+          if (delayNanos == 0L) push(out, elem)
           else {
-            currentElement = elem
-            scheduleOnce(Throttle.TimerKey, delayNanos.nanos)
+            if (mode eq Enforcing) failStage(new RateExceededException("Maximum throttle throughput exceeded."))
+            else {
+              currentElement = elem
+              scheduleOnce(Throttle.TimerKey, delayNanos.nanos)
+            }
           }
+        } catch {
+          case NonFatal(ex) =>
+            val directive = decider(ex)
+            directive match {
+              case Supervision.Stop => failStage(ex)
+              case _                =>
+                log.debug("Exception in costCalculation for element [{}]: {}. Supervision strategy: {}.",
+                  elem, ex.getMessage, directive)
+                pull(in)
+            }
         }
       }
 


### PR DESCRIPTION
### Motivation

The `Throttle` stage's `costCalculation` function had no exception handling. If the user-provided cost function threw, the exception propagated directly and failed the stage unconditionally. Unlike other stages (`MapAsync`, `Filter`, `Log`), `Throttle` did not consult the `SupervisionStrategy` decider, preventing users from configuring Resume or Restart behavior for bad elements.

Fixes #3101

### Modification

- Add `try-catch` around `costCalculation(elem)` with `NonFatal` handling
- Add `decider` lookup via `SupervisionStrategy` mandatory attribute
- On `Stop`: `failStage` (preserves default behavior)
- On `Resume`/`Restart`: log at debug level and `pull` next element
- Mix in `StageLogging` for observability
- Add 4 new tests covering Resume, Restart, Stop directives and Enforcing mode

### Result

Users can now configure supervision strategy on `Throttle` to skip elements that cause `costCalculation` exceptions, matching the behavior of other stages in Pekko Streams.

### Tests

```
sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.FlowThrottleSpec"
# 27 tests passed (4 new + 23 existing)
```

### References

Fixes #3101
