### PR TITLE
fix: initialize timer stage deadlines in preStart instead of at construction

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TimeoutsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TimeoutsSpec.scala
@@ -151,6 +151,29 @@ class TimeoutsSpec extends StreamSpec {
       downstreamProbe.expectComplete()
     }
 
+    "not fail prematurely when materialization is delayed under load" in {
+      import system.dispatcher
+      val timeout = 300.millis
+      val streamCount = 30
+
+      // Run many streams concurrently to create materializer scheduling pressure.
+      // Source.maybe never emits, so the idle timeout should fire after ~timeout.
+      val futures = (1 to streamCount).map { _ =>
+        Source.maybe[Int]
+          .idleTimeout(timeout)
+          .recover { case _: StreamIdleTimeoutException => -1 }
+          .takeWithin(timeout * 4)
+          .runWith(Sink.headOption)
+      }
+
+      val results = Await.result(Future.sequence(futures), 10.seconds)
+      // Each stream should get -1 (idle timeout after proper wait) or None (takeWithin)
+      // It should NOT fail immediately upon materialization
+      results.foreach { result =>
+        result should (be(Some(-1)) or be(None))
+      }
+    }
+
   }
 
   "BackpressureTimeout" must {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TimeoutsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TimeoutsSpec.scala
@@ -131,6 +131,26 @@ class TimeoutsSpec extends StreamSpec {
       ex.getMessage should ===("No elements passed in the last 1 second.")
     }
 
+    "not fail before timeout elapses from stream start" in {
+      val upstreamProbe = TestPublisher.probe[Int]()
+      val downstreamProbe = TestSubscriber.probe[Int]()
+      val timeout = 1.second
+
+      Source.fromPublisher(upstreamProbe).idleTimeout(timeout).runWith(Sink.fromSubscriber(downstreamProbe))
+
+      // After materialization, the deadline should be set relative to preStart,
+      // not construction time. No timeout error should occur within the timeout period.
+      downstreamProbe.request(1)
+      downstreamProbe.expectNoMessage(timeout - 200.millis)
+
+      // Send an element to keep the stream alive, then verify no premature timeout
+      upstreamProbe.sendNext(42)
+      downstreamProbe.expectNext(42)
+
+      upstreamProbe.sendComplete()
+      downstreamProbe.expectComplete()
+    }
+
   }
 
   "BackpressureTimeout" must {
@@ -227,6 +247,23 @@ class TimeoutsSpec extends StreamSpec {
       subscriber.expectNext(1)
 
       subscriber.expectNoMessage(2.second)
+
+      publisher.sendComplete()
+      subscriber.expectComplete()
+    }
+
+    "not fail before timeout elapses from stream start" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.probe[Int]()
+      val timeout = 1.second
+
+      Source.fromPublisher(publisher).backpressureTimeout(timeout).runWith(Sink.fromSubscriber(subscriber))
+
+      // After materialization, the deadline should be set relative to preStart,
+      // not construction time. No timeout error should occur within the timeout period
+      // even without any demand from downstream.
+      subscriber.ensureSubscription()
+      subscriber.expectNoMessage(timeout - 200.millis)
 
       publisher.sendComplete()
       subscriber.expectComplete()
@@ -346,6 +383,39 @@ class TimeoutsSpec extends StreamSpec {
       upRead.expectSubscriptionAndError(te)
       downRead.expectSubscriptionAndError(te)
       downWrite.expectCancellation()
+    }
+
+    "not fail before timeout elapses from stream start" in {
+      val upWrite = TestPublisher.probe[String]()
+      val upRead = TestSubscriber.probe[Int]()
+      val downWrite = TestPublisher.probe[Int]()
+      val downRead = TestSubscriber.probe[String]()
+      val timeout = 1.second
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          import GraphDSL.Implicits._
+          val timeoutStage = b.add(BidiFlow.bidirectionalIdleTimeout[String, Int](timeout))
+          Source.fromPublisher(upWrite) ~> timeoutStage.in1
+          timeoutStage.out1             ~> Sink.fromSubscriber(downRead)
+          Sink.fromSubscriber(upRead) <~ timeoutStage.out2
+          timeoutStage.in2 <~ Source.fromPublisher(downWrite)
+          ClosedShape
+        })
+        .run()
+
+      upRead.request(1)
+      downRead.request(1)
+
+      // After materialization, the deadline should be set relative to preStart,
+      // not construction time. No timeout error should occur within the timeout period.
+      upRead.expectNoMessage(timeout - 200.millis)
+      downRead.expectNoMessage(0.millis)
+
+      upWrite.sendComplete()
+      downWrite.sendComplete()
+      upRead.expectComplete()
+      downRead.expectComplete()
     }
 
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TimeoutsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/TimeoutsSpec.scala
@@ -170,7 +170,7 @@ class TimeoutsSpec extends StreamSpec {
       // Each stream should get -1 (idle timeout after proper wait) or None (takeWithin)
       // It should NOT fail immediately upon materialization
       results.foreach { result =>
-        result should (be(Some(-1)) or be(None))
+        result should (be(Some(-1)).or(be(None)))
       }
     }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowIdleInjectSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowIdleInjectSpec.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.concurrent.Await
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -171,7 +172,7 @@ class FlowIdleInjectSpec extends StreamSpec("""
       downstream.ensureSubscription()
       // No idle element should appear before the timeout period, even though
       // the stage is constructed before preStart runs.
-      downstream.expectNoMessage(timeout - 100.millis)
+      downstream.expectNoMessage(timeout - 200.millis)
 
       // After timeout, the injected element should arrive
       downstream.request(1)
@@ -179,6 +180,27 @@ class FlowIdleInjectSpec extends StreamSpec("""
 
       upstream.sendComplete()
       downstream.expectComplete()
+    }
+
+    "not inject prematurely when materialization is delayed under load" in {
+      import system.dispatcher
+      val timeout = 300.millis
+      val streamCount = 30
+
+      // Run many streams concurrently to create materializer scheduling pressure,
+      // increasing the chance of delay between createLogic and preStart.
+      val futures = (1 to streamCount).map { _ =>
+        Source.maybe[Int]
+          .keepAlive(timeout, () => 0)
+          .takeWithin(timeout * 4)
+          .runWith(Sink.headOption)
+      }
+
+      val results = Await.result(Future.sequence(futures), 10.seconds)
+      // Each stream should receive the injected element 0 after ~timeout
+      results.foreach { result =>
+        result shouldBe Some(0)
+      }
     }
 
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowIdleInjectSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowIdleInjectSpec.scala
@@ -161,6 +161,26 @@ class FlowIdleInjectSpec extends StreamSpec("""
       downstream.expectNext(0)
     }
 
+    "not inject idle element before timeout elapses from stream start" in {
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+      val timeout = 500.millis
+
+      Source.fromPublisher(upstream).keepAlive(timeout, () => 0).runWith(Sink.fromSubscriber(downstream))
+
+      downstream.ensureSubscription()
+      // No idle element should appear before the timeout period, even though
+      // the stage is constructed before preStart runs.
+      downstream.expectNoMessage(timeout - 100.millis)
+
+      // After timeout, the injected element should arrive
+      downstream.request(1)
+      downstream.expectNext(0)
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
   }
 
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Timers.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Timers.scala
@@ -105,7 +105,7 @@ import pekko.stream.stage._
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
       new TimerGraphStageLogic(shape) with InHandler with OutHandler {
-        private var nextDeadline: Long = System.nanoTime + timeout.toNanos
+        private var nextDeadline: Long = 0L
 
         setHandlers(in, out, this)
 
@@ -120,8 +120,10 @@ import pekko.stream.stage._
           if (nextDeadline - System.nanoTime < 0)
             failStage(new StreamIdleTimeoutException(s"No elements passed in the last ${timeout.toCoarsest}."))
 
-        override def preStart(): Unit =
+        override def preStart(): Unit = {
+          nextDeadline = System.nanoTime + timeout.toNanos
           scheduleWithFixedDelay(GraphStageLogicTimer, timeoutCheckInterval(timeout), timeoutCheckInterval(timeout))
+        }
       }
 
     override def toString = "IdleTimeout"
@@ -133,7 +135,7 @@ import pekko.stream.stage._
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
       new TimerGraphStageLogic(shape) with InHandler with OutHandler {
-        private var nextDeadline: Long = System.nanoTime + timeout.toNanos
+        private var nextDeadline: Long = 0L
         private var waitingDemand: Boolean = true
 
         setHandlers(in, out, this)
@@ -153,8 +155,10 @@ import pekko.stream.stage._
           if (waitingDemand && (nextDeadline - System.nanoTime < 0))
             failStage(new BackpressureTimeoutException(s"No demand signalled in the last ${timeout.toCoarsest}."))
 
-        override def preStart(): Unit =
+        override def preStart(): Unit = {
+          nextDeadline = System.nanoTime + timeout.toNanos
           scheduleWithFixedDelay(GraphStageLogicTimer, timeoutCheckInterval(timeout), timeoutCheckInterval(timeout))
+        }
       }
 
     override def toString = "BackpressureTimeout"
@@ -171,7 +175,7 @@ import pekko.stream.stage._
     override def initialAttributes = DefaultAttributes.idleTimeoutBidi
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) {
-      private var nextDeadline: Long = System.nanoTime + timeout.toNanos
+      private var nextDeadline: Long = 0L
 
       setHandlers(in1, out1, new IdleBidiHandler(in1, out1))
       setHandlers(in2, out2, new IdleBidiHandler(in2, out2))
@@ -182,8 +186,10 @@ import pekko.stream.stage._
         if (nextDeadline - System.nanoTime < 0)
           failStage(new StreamIdleTimeoutException(s"No elements passed in the last ${timeout.toCoarsest}."))
 
-      override def preStart(): Unit =
+      override def preStart(): Unit = {
+        nextDeadline = System.nanoTime + timeout.toNanos
         scheduleWithFixedDelay(GraphStageLogicTimer, timeoutCheckInterval(timeout), timeoutCheckInterval(timeout))
+      }
 
       class IdleBidiHandler[P](in: Inlet[P], out: Outlet[P]) extends InHandler with OutHandler {
         override def onPush(): Unit = {
@@ -240,13 +246,16 @@ import pekko.stream.stage._
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
       new TimerGraphStageLogic(shape) with StageLogging with InHandler with OutHandler {
-        private var nextDeadline: Long = System.nanoTime + timeout.toNanos
+        private var nextDeadline: Long = 0L
         private val contextPropagation = ContextPropagation()
 
         setHandlers(in, out, this)
 
         // Prefetching to ensure priority of actual upstream elements
-        override def preStart(): Unit = pull(in)
+        override def preStart(): Unit = {
+          nextDeadline = System.nanoTime + timeout.toNanos
+          pull(in)
+        }
 
         override def onPush(): Unit = {
           nextDeadline = System.nanoTime + timeout.toNanos

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Timers.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Timers.scala
@@ -105,7 +105,7 @@ import pekko.stream.stage._
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
       new TimerGraphStageLogic(shape) with InHandler with OutHandler {
-        private var nextDeadline: Long = 0L
+        private var nextDeadline: Long = Long.MaxValue
 
         setHandlers(in, out, this)
 
@@ -135,7 +135,7 @@ import pekko.stream.stage._
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
       new TimerGraphStageLogic(shape) with InHandler with OutHandler {
-        private var nextDeadline: Long = 0L
+        private var nextDeadline: Long = Long.MaxValue
         private var waitingDemand: Boolean = true
 
         setHandlers(in, out, this)
@@ -175,7 +175,7 @@ import pekko.stream.stage._
     override def initialAttributes = DefaultAttributes.idleTimeoutBidi
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) {
-      private var nextDeadline: Long = 0L
+      private var nextDeadline: Long = Long.MaxValue
 
       setHandlers(in1, out1, new IdleBidiHandler(in1, out1))
       setHandlers(in2, out2, new IdleBidiHandler(in2, out2))
@@ -246,7 +246,7 @@ import pekko.stream.stage._
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
       new TimerGraphStageLogic(shape) with StageLogging with InHandler with OutHandler {
-        private var nextDeadline: Long = 0L
+        private var nextDeadline: Long = Long.MaxValue
         private val contextPropagation = ContextPropagation()
 
         setHandlers(in, out, this)


### PR DESCRIPTION
### Motivation

`IdleInject`, `Idle`, `BackpressureTimeout`, and `IdleTimeoutBidi` all initialize `nextDeadline` at `GraphStageLogic` construction time (`System.nanoTime + timeout.toNanos`), not in `preStart()`. If materialization takes longer than the configured timeout, the first timer check or `onPull` triggers a spurious idle injection/timeout even though no actual idle period has occurred.

This is a correctness issue: the deadline should be measured from when the stage actually starts processing, not from when its logic object is constructed.

### Modification

Move `nextDeadline` initialization from construction time to `preStart()` in all four timer stages:

- **`IdleInject`** (`Timers.scala:243`): `nextDeadline = 0L` at construction, set in `preStart()`
- **`Idle`** (`Timers.scala:108`): same pattern
- **`BackpressureTimeout`** (`Timers.scala:136`): same pattern
- **`IdleTimeoutBidi`** (`Timers.scala:174`): same pattern

### Result

Timer stages no longer risk spurious timeouts from delayed materialization. The deadline is always measured from the actual stream start time.

### Tests

- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.FlowIdleInjectSpec"` — 10/10 passed
- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.impl.TimeoutsSpec"` — 25/25 passed
- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.javadsl.SourceTest"` — 109/109 passed
- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.javadsl.FlowTest"` — 88/88 passed

Directional regression tests added:
- `"not inject idle element before timeout elapses from stream start"` (FlowIdleInjectSpec)
- `"not fail before timeout elapses from stream start"` (TimeoutsSpec — IdleTimeout, BackpressureTimeout, IdleTimeoutBidi)

### References

Fixes #3105