### PR TITLE
fix(stream): prevent double materialization of SourceRef and SinkRef

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StreamRefsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StreamRefsSpec.scala
@@ -17,7 +17,10 @@ import scala.collection.immutable
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.Promise
 import scala.concurrent.duration._
+import scala.util.Try
 import scala.util.control.NoStackTrace
+
+import java.util.concurrent.CountDownLatch
 
 import org.apache.pekko
 import pekko.{ Done, NotUsed }
@@ -26,7 +29,6 @@ import pekko.actor.Status.Failure
 import pekko.pattern._
 import pekko.stream._
 import pekko.stream.impl.streamref.{ SinkRefImpl, SourceRefImpl }
-import pekko.stream.testkit.TestPublisher
 import pekko.stream.testkit.Utils.TE
 import pekko.stream.testkit.scaladsl._
 import pekko.testkit.{ PekkoSpec, TestKit, TestProbe }
@@ -480,6 +482,36 @@ class StreamRefsSpec extends PekkoSpec(StreamRefsSpec.config()) {
       expectTerminated(sinkRefStageActorRef)
     }
 
+    "not allow materializing multiple times" in {
+      val remoteProbe = TestProbe()(remoteSystem)
+      remoteActor.tell("give", remoteProbe.ref)
+      val sourceRef = remoteProbe.expectMsgType[SourceRef[String]]
+
+      sourceRef.source.to(Sink.ignore).run()
+
+      val ex = the[IllegalStateException] thrownBy sourceRef.source.to(Sink.ignore).run()
+      ex.getMessage should include("already been materialized")
+    }
+
+    "not allow concurrent materialization" in {
+      val remoteProbe = TestProbe()(remoteSystem)
+      remoteActor.tell("give", remoteProbe.ref)
+      val sourceRef = remoteProbe.expectMsgType[SourceRef[String]]
+
+      implicit val ec: scala.concurrent.ExecutionContext = system.dispatcher
+      val latch = new CountDownLatch(1)
+      val results = (1 to 10).map { _ =>
+        Future {
+          latch.await()
+          Try(sourceRef.source.to(Sink.ignore).run())
+        }
+      }
+      latch.countDown()
+      val outcomes = Await.result(Future.sequence(results), 10.seconds)
+      outcomes.count(_.isSuccess) shouldBe 1
+      outcomes.count(_.isFailure) shouldBe 9
+    }
+
   }
 
   "A SinkRef" must {
@@ -613,15 +645,30 @@ class StreamRefsSpec extends PekkoSpec(StreamRefsSpec.config()) {
       remoteActor.tell(Command("receive", elementProbe.ref), remoteProbe.ref)
       val sinkRef = remoteProbe.expectMsgType[SinkRef[String]]
 
-      val p1: TestPublisher.Probe[String] = TestSource[String]().to(sinkRef).run()
-      val p2: TestPublisher.Probe[String] = TestSource[String]().to(sinkRef).run()
+      TestSource[String]().to(sinkRef).run()
 
-      p1.ensureSubscription()
-      p1.expectRequest()
+      val ex = the[IllegalStateException] thrownBy TestSource[String]().to(sinkRef).run()
+      ex.getMessage should include("already been materialized")
+    }
 
-      // will be cancelled immediately, since it's 2nd:
-      p2.ensureSubscription()
-      p2.expectCancellation()
+    "not allow concurrent materialization" in {
+      val remoteProbe = TestProbe()(remoteSystem)
+      val elementProbe = TestProbe()(remoteSystem)
+      remoteActor.tell(Command("receive", elementProbe.ref), remoteProbe.ref)
+      val sinkRef = remoteProbe.expectMsgType[SinkRef[String]]
+
+      implicit val ec: scala.concurrent.ExecutionContext = system.dispatcher
+      val latch = new CountDownLatch(1)
+      val results = (1 to 10).map { _ =>
+        Future {
+          latch.await()
+          Try(TestSource[String]().to(sinkRef).run())
+        }
+      }
+      latch.countDown()
+      val outcomes = Await.result(Future.sequence(results), 10.seconds)
+      outcomes.count(_.isSuccess) shouldBe 1
+      outcomes.count(_.isFailure) shouldBe 9
     }
 
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SinkRefImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SinkRefImpl.scala
@@ -27,11 +27,19 @@ import pekko.stream.scaladsl.Sink
 import pekko.stream.stage._
 import pekko.util.{ OptionVal, PrettyDuration }
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 /** INTERNAL API: Implementation class, not intended to be touched directly by end-users */
 @InternalApi
 private[stream] final case class SinkRefImpl[In](initialPartnerRef: ActorRef) extends SinkRef[In] {
+  private val materialized = new AtomicBoolean(false)
+
+  private[stream] def tryClaimMaterialization(): Boolean =
+    materialized.compareAndSet(false, true)
+
   override def sink(): Sink[In, NotUsed] =
-    Sink.fromGraph(new SinkRefStageImpl[In](OptionVal.Some(initialPartnerRef))).mapMaterializedValue(_ => NotUsed)
+    Sink.fromGraph(new SinkRefStageImpl[In](OptionVal.Some(initialPartnerRef), this))
+      .mapMaterializedValue(_ => NotUsed)
 }
 
 /**
@@ -48,7 +56,9 @@ private[stream] final case class SinkRefImpl[In](initialPartnerRef: ActorRef) ex
  * the ref.
  */
 @InternalApi
-private[stream] final class SinkRefStageImpl[In] private[pekko] (val initialPartnerRef: OptionVal[ActorRef])
+private[stream] final class SinkRefStageImpl[In] private[pekko] (
+    val initialPartnerRef: OptionVal[ActorRef],
+    private val owner: SinkRefImpl[?] = null)
     extends GraphStageWithMaterializedValue[SinkShape[In], SourceRef[In]] {
   import SinkRefStageImpl.ActorRefStage
 
@@ -67,6 +77,10 @@ private[stream] final class SinkRefStageImpl[In] private[pekko] (val initialPart
   private[pekko] override def createLogicAndMaterializedValue(
       inheritedAttributes: Attributes,
       eagerMaterializer: Materializer): (GraphStageLogic, SourceRef[In]) = {
+    if (owner != null && !owner.tryClaimMaterialization())
+      throw new IllegalStateException(
+        "This SinkRef has already been materialized. " +
+        "SinkRef is single-use: calling .sink() and materializing it more than once is not supported.")
 
     val logic = new TimerGraphStageLogic(shape) with StageLogging with ActorRefStage with InHandler {
       override protected def logSource: Class[?] = classOf[SinkRefStageImpl[?]]

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SourceRefImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/streamref/SourceRefImpl.scala
@@ -26,11 +26,19 @@ import pekko.stream.scaladsl.Source
 import pekko.stream.stage._
 import pekko.util.{ OptionVal, PrettyDuration }
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 /** INTERNAL API: Implementation class, not intended to be touched directly by end-users */
 @InternalApi
 private[stream] final case class SourceRefImpl[T](initialPartnerRef: ActorRef) extends SourceRef[T] {
+  private val materialized = new AtomicBoolean(false)
+
+  private[stream] def tryClaimMaterialization(): Boolean =
+    materialized.compareAndSet(false, true)
+
   def source: Source[T, NotUsed] =
-    Source.fromGraph(new SourceRefStageImpl(OptionVal.Some(initialPartnerRef))).mapMaterializedValue(_ => NotUsed)
+    Source.fromGraph(new SourceRefStageImpl(OptionVal.Some(initialPartnerRef), this))
+      .mapMaterializedValue(_ => NotUsed)
 }
 
 /**
@@ -107,7 +115,9 @@ private[stream] final case class SourceRefImpl[T](initialPartnerRef: ActorRef) e
  * If it is none, then we are the side creating the ref.
  */
 @InternalApi
-private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: OptionVal[ActorRef])
+private[stream] final class SourceRefStageImpl[Out](
+    val initialPartnerRef: OptionVal[ActorRef],
+    private val owner: SourceRefImpl[?] = null)
     extends GraphStageWithMaterializedValue[SourceShape[Out], SinkRef[Out]] { stage =>
   import SourceRefStageImpl._
 
@@ -126,6 +136,10 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
   private[pekko] override def createLogicAndMaterializedValue(
       inheritedAttributes: Attributes,
       eagerMaterializer: Materializer): (GraphStageLogic, SinkRef[Out]) = {
+    if (owner != null && !owner.tryClaimMaterialization())
+      throw new IllegalStateException(
+        "This SourceRef has already been materialized. " +
+        "SourceRef is single-use: calling .source and materializing it more than once is not supported.")
 
     val logic = new TimerGraphStageLogic(shape) with StageLogging with ActorRefStage with OutHandler {
       override protected def logSource: Class[?] = classOf[SourceRefStageImpl[?]]


### PR DESCRIPTION
### Motivation

`SourceRefImpl.source` and `SinkRefImpl.sink()` create a new `SourceRefStageImpl` / `SinkRefStageImpl` instance on every access. If a user accidentally materializes the returned `Source`/`Sink` more than once, multiple stage instances compete for the same partner handshake, causing the second materialization to fail with a confusing error message (typically a handshake timeout or `IllegalStateException in state AwaitingSubscription`).

Fixes #3106

### Modification

Add an `AtomicBoolean` guard per `SourceRefImpl` / `SinkRefImpl` instance. When the backing stage is materialized, the guard is atomically claimed via `compareAndSet(false, true)`. A second materialization attempt throws a clear `IllegalStateException`:

```
This SourceRef has already been materialized. SourceRef is single-use: calling .source and materializing it more than once is not supported.
```

The guard is passed as an optional `owner` parameter to `SourceRefStageImpl` / `SinkRefStageImpl` (defaulting to `null` for the initial stage created by `StreamRefs.sourceRef()` / `StreamRefs.sinkRef()`, which are always single-materialization by design).

**Key design decisions:**
- `AtomicBoolean` per instance (not `AtomicBooleanFieldUpdater`, which does not exist in the JDK; `AtomicIntegerFieldUpdater` from a Scala companion object fails due to JVM-level `private` access restrictions on case class body fields)
- The `owner` constructor parameter defaults to `null`, so `StreamRefs.scala` call sites remain unchanged
- `SourceRefImpl` / `SinkRefImpl` are `private[stream]` and `@InternalApi`, so the new field does not affect public binary compatibility

### Result

Double materialization of `SourceRef` or `SinkRef` now fails fast with a descriptive error, instead of the previous opaque handshake failure.

### Tests

```
sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.StreamRefsSpec"
# 25/25 passed
```

Two new tests added:
- `A SourceRef must "not allow materializing multiple times"` — verifies `IllegalStateException` on second `.source.run()`
- `A SinkRef must "not allow materializing multiple times"` — updated from previous silent-cancellation behavior to expect the new `IllegalStateException`

### References

Fixes #3106