### PR TITLE
Fix a few broken Scaladoc links reported by unidoc

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/io/Tcp.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/Tcp.scala
@@ -316,7 +316,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
   }
 
   /**
-   * Common supertype of [[Write]] and [[WriteFile]].
+   * Common supertype of [[Write]] and [[WritePath]].
    */
   sealed abstract class SimpleWriteCommand extends WriteCommand {
     require(ack != null, "ack must be non-null. Use NoAck if you don't want acks.")
@@ -383,7 +383,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
 
   /**
    * A write command which aggregates two other write commands. Using this construct
-   * you can chain a number of [[Write]] and/or [[WriteFile]] commands together in a way
+   * you can chain a number of [[Write]] and/or [[WritePath]] commands together in a way
    * that allows them to be handled as a single write which gets written out to the
    * network as quickly as possible.
    * If the sub commands contain `ack` requests they will be honored as soon as the

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ShardingMessageExtractor.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ShardingMessageExtractor.scala
@@ -120,7 +120,7 @@ abstract class HashCodeNoEnvelopeMessageExtractor[M](val numberOfShards: Int) ex
  *
  * @param entityId The business domain identifier of the entity.
  * @param message The message to be send to the entity.
- * @throws [[pekko.actor.InvalidMessageException]] if message is null.
+ * @throws pekko.actor.InvalidMessageException if message is null.
  */
 final case class ShardingEnvelope[M](entityId: String, message: M)
     extends WrappedMessage


### PR DESCRIPTION
### Motivation
`sbt unidoc` emits a number of "Could not find any member to link for" Scaladoc warnings (#353). A few of these are plain broken links rather than the trickier private or ambiguous-target cases:

- `Tcp`'s `SimpleWriteCommand` and `CompoundWrite` Scaladoc link `[[WriteFile]]`, but that write command was renamed to `WritePath`.
- `ShardingEnvelope`'s `@throws` tag wraps the exception type in `[[ ]]`. Scaladoc does not parse `[[ ]]` inside `@throws`, so the link is reported as missing.

### Modification
- `Tcp.scala`: update two Scaladoc comments from `[[WriteFile]]` to `[[WritePath]]`.
- `ShardingMessageExtractor.scala`: remove the `[[ ]]` around the `@throws` type so it matches the `@throws <fully.qualified.type> <description>` form used elsewhere in the codebase.

### Result
Three unidoc link warnings are resolved. No API or behaviour change.

### Tests
Not run - docs only. Confirmed locally with `sbt unidoc` that the three warnings no longer appear and no new warnings were introduced; `sbt scalafmtCheck` passes for both touched modules.

### References
Refs #353
