### PR TITLE
fix(stream): log supervision Resume/Restart in MapAsync operators

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
@@ -27,10 +27,12 @@ import scala.concurrent.duration._
 import org.apache.pekko
 import pekko.Done
 import pekko.stream.ActorAttributes
+import pekko.stream.Attributes
 import pekko.stream.Supervision
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl.TestSink
 import pekko.stream.testkit.scaladsl.TestSource
+import pekko.testkit.EventFilter
 import pekko.testkit.TestDuration
 import pekko.testkit.TestLatch
 import pekko.testkit.TestProbe
@@ -576,6 +578,59 @@ class FlowMapAsyncPartitionedSpec extends StreamSpec with WithLogCapturing {
       deciderTest { (elem, _) =>
         if (elem) Future.failed(thisWillNotStand)
         else Future.successful(elem)
+      }
+    }
+
+    "log error when future fails with resume supervision (ordered)" in {
+      EventFilter.error(
+        start = "Supervision strategy resumed after exception in MapAsyncPartitioned",
+        occurrences = 1).intercept {
+        val result = Source(1 to 5)
+          .mapAsyncPartitioned(4)(_ % 2) { (n, _) =>
+            if (n == 3) Future.failed(TE("err3"))
+            else Future.successful(n)
+          }
+          .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+          .runWith(Sink.seq)
+
+        result.futureValue should ===(Seq(1, 2, 4, 5))
+      }
+    }
+
+    "log error when future fails with resume supervision (unordered)" in {
+      EventFilter.error(
+        start = "Supervision strategy resumed after exception in MapAsyncPartitioned",
+        occurrences = 1).intercept {
+        val result = Source(1 to 5)
+          .mapAsyncPartitionedUnordered(4)(_ % 2) { (n, _) =>
+            if (n == 3) Future.failed(TE("err3"))
+            else Future.successful(n)
+          }
+          .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+          .runWith(Sink.seq)
+
+        result.futureValue.toSet should ===(Set(1, 2, 4, 5))
+      }
+    }
+
+    "not log when log level is Off and resume supervision is used" in {
+      EventFilter.error(
+        start = "Supervision strategy resumed after exception in MapAsyncPartitioned",
+        occurrences = 0).intercept {
+        val result = Source(1 to 5)
+          .mapAsyncPartitioned(4)(_ % 2) { (n, _) =>
+            if (n == 3) Future.failed(TE("err3"))
+            else Future.successful(n)
+          }
+          .withAttributes(
+            ActorAttributes.supervisionStrategy(Supervision.resumingDecider) and
+            Attributes.logLevels(
+              onElement = Attributes.LogLevels.Off,
+              onFinish = Attributes.LogLevels.Off,
+              onFailure = Attributes.LogLevels.Off))
+          .runWith(Sink.seq)
+
+        result.futureValue should ===(Seq(1, 2, 4, 5))
       }
     }
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncSpec.scala
@@ -28,11 +28,13 @@ import scala.util.control.NoStackTrace
 import org.apache.pekko
 import pekko.stream.ActorAttributes
 import pekko.stream.ActorAttributes.supervisionStrategy
+import pekko.stream.Attributes
 import pekko.stream.Supervision
 import pekko.stream.Supervision.resumingDecider
 import pekko.stream.testkit._
 import pekko.stream.testkit.Utils._
 import pekko.stream.testkit.scaladsl.TestSink
+import pekko.testkit.EventFilter
 import pekko.testkit.TestDuration
 import pekko.testkit.TestLatch
 import pekko.testkit.TestProbe
@@ -550,6 +552,51 @@ class FlowMapAsyncSpec extends StreamSpec {
 
       result.futureValue should ===(Seq(false))
       failCount.get() should ===(1)
+    }
+
+    "log error when future fails with resume supervision" in {
+      EventFilter.error(start = "Supervision strategy resumed after exception in MapAsync", occurrences = 1).intercept {
+        val result = Source(1 to 5)
+          .mapAsync(4)(n =>
+            if (n == 3) Future.failed(new TE("err3"))
+            else Future.successful(n))
+          .withAttributes(supervisionStrategy(resumingDecider))
+          .runWith(Sink.seq)
+
+        result.futureValue should ===(Seq(1, 2, 4, 5))
+      }
+    }
+
+    "log error when mapAsync function throws with resume supervision" in {
+      implicit val ec = system.dispatcher
+      EventFilter.error(start = "Supervision strategy resumed after exception in MapAsync", occurrences = 1).intercept {
+        val result = Source(1 to 5)
+          .mapAsync(4)(n =>
+            if (n == 3) throw TE("err-sync")
+            else Future(n))
+          .withAttributes(supervisionStrategy(resumingDecider))
+          .runWith(Sink.seq)
+
+        result.futureValue should ===(Seq(1, 2, 4, 5))
+      }
+    }
+
+    "not log when log level is Off and resume supervision is used" in {
+      EventFilter.error(start = "Supervision strategy resumed after exception in MapAsync", occurrences = 0).intercept {
+        val result = Source(1 to 5)
+          .mapAsync(4)(n =>
+            if (n == 3) Future.failed(new TE("err3"))
+            else Future.successful(n))
+          .withAttributes(
+            supervisionStrategy(resumingDecider) and
+            Attributes.logLevels(
+              onElement = Attributes.LogLevels.Off,
+              onFinish = Attributes.LogLevels.Off,
+              onFailure = Attributes.LogLevels.Off))
+          .runWith(Sink.seq)
+
+        result.futureValue should ===(Seq(1, 2, 4, 5))
+      }
     }
 
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncUnorderedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncUnorderedSpec.scala
@@ -26,9 +26,11 @@ import scala.util.control.NoStackTrace
 
 import org.apache.pekko
 import pekko.stream.ActorAttributes.supervisionStrategy
+import pekko.stream.Attributes
 import pekko.stream.Supervision.resumingDecider
 import pekko.stream.testkit._
 import pekko.stream.testkit.scaladsl._
+import pekko.testkit.EventFilter
 import pekko.testkit.TestDuration
 import pekko.testkit.TestLatch
 import pekko.testkit.TestProbe
@@ -373,6 +375,57 @@ class FlowMapAsyncUnorderedSpec extends StreamSpec {
           .futureValue(Timeout(3.seconds.dilated)) should ===(N)
       } finally {
         timer.interrupt()
+      }
+    }
+
+    "log error when future fails with resume supervision" in {
+      EventFilter.error(
+        start = "Supervision strategy resumed after exception in MapAsyncUnordered",
+        occurrences = 1).intercept {
+        val result = Source(1 to 5)
+          .mapAsyncUnordered(4)(n =>
+            if (n == 3) Future.failed(new Exception("err3") with NoStackTrace)
+            else Future.successful(n))
+          .withAttributes(supervisionStrategy(resumingDecider))
+          .runWith(Sink.seq)
+
+        result.futureValue.toSet should ===(Set(1, 2, 4, 5))
+      }
+    }
+
+    "log error when mapAsyncUnordered function throws with resume supervision" in {
+      implicit val ec = system.dispatcher
+      EventFilter.error(
+        start = "Supervision strategy resumed after exception in MapAsyncUnordered",
+        occurrences = 1).intercept {
+        val result = Source(1 to 5)
+          .mapAsyncUnordered(4)(n =>
+            if (n == 3) throw Utils.TE("err-sync")
+            else Future(n))
+          .withAttributes(supervisionStrategy(resumingDecider))
+          .runWith(Sink.seq)
+
+        result.futureValue.toSet should ===(Set(1, 2, 4, 5))
+      }
+    }
+
+    "not log when log level is Off and resume supervision is used" in {
+      EventFilter.error(
+        start = "Supervision strategy resumed after exception in MapAsyncUnordered",
+        occurrences = 0).intercept {
+        val result = Source(1 to 5)
+          .mapAsyncUnordered(4)(n =>
+            if (n == 3) Future.failed(new Exception("err3") with NoStackTrace)
+            else Future.successful(n))
+          .withAttributes(
+            supervisionStrategy(resumingDecider) and
+            Attributes.logLevels(
+              onElement = Attributes.LogLevels.Off,
+              onFinish = Attributes.LogLevels.Off,
+              onFailure = Attributes.LogLevels.Off))
+          .runWith(Sink.seq)
+
+        result.futureValue.toSet should ===(Set(1, 2, 4, 5))
       }
     }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
@@ -25,7 +25,10 @@ import scala.util.control.{ NoStackTrace, NonFatal }
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
+import pekko.event.Logging
+import pekko.event.Logging.LogLevel
 import pekko.stream.ActorAttributes.SupervisionStrategy
+import pekko.stream.Attributes.LogLevels
 import pekko.stream.stage._
 import pekko.util.OptionVal
 
@@ -82,8 +85,10 @@ private[stream] final class MapAsyncPartitioned[In, Out, Partition](
   override val shape: FlowShape[In, Out] = FlowShape(in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new GraphStageLogic(shape) with InHandler with OutHandler {
+    new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
       private val contextPropagation = pekko.stream.impl.ContextPropagation()
+
+      override protected def logSource: Class[?] = classOf[MapAsyncPartitioned[?, ?, ?]]
 
       private final class Contextual[T](context: AnyRef, val element: T) {
         private var suspended = false
@@ -106,6 +111,30 @@ private[stream] final class MapAsyncPartitioned[In, Out, Partition](
 
       private var partitionsInProgress: mutable.Set[Partition] = _
       private var buffer: mutable.Queue[(Partition, Contextual[Holder[In, Out]])] = _
+
+      private def logSupervisionFailure(ex: Throwable): Unit = {
+        val logAt: LogLevel = inheritedAttributes.get[LogLevels] match {
+          case Some(levels) => levels.onFailure
+          case None         => LogLevels.defaultErrorLevel(materializer.system)
+        }
+        logAt match {
+          case Logging.ErrorLevel =>
+            log.error(ex, "Supervision strategy resumed after exception in MapAsyncPartitioned: {}", ex.getMessage)
+          case Logging.WarningLevel =>
+            log.warning(ex, "Supervision strategy resumed after exception in MapAsyncPartitioned: {}", ex.getMessage)
+          case Logging.InfoLevel =>
+            log.info(
+              "Supervision strategy resumed after exception in MapAsyncPartitioned: {}: {}",
+              Logging.simpleName(ex.getClass),
+              ex.getMessage)
+          case Logging.DebugLevel =>
+            log.debug(
+              "Supervision strategy resumed after exception in MapAsyncPartitioned: {}: {}",
+              Logging.simpleName(ex.getClass),
+              ex.getMessage)
+          case _ => // Off, nop
+        }
+      }
 
       private val futureCB = getAsyncCallback[Holder[In, Out]](holder =>
         holder.out match {
@@ -142,7 +171,9 @@ private[stream] final class MapAsyncPartitioned[In, Out, Partition](
             wrappedInput.suspend()
           }
         } catch {
-          case NonFatal(ex) => if (decider(ex) == Supervision.Stop) failStage(ex)
+          case NonFatal(ex) =>
+            if (decider(ex) == Supervision.Stop) failStage(ex)
+            else logSupervisionFailure(ex)
         }
 
         pullIfNeeded()
@@ -201,7 +232,8 @@ private[stream] final class MapAsyncPartitioned[In, Out, Partition](
                   case Supervision.Stop =>
                     failStage(ex)
                   case _ =>
-                  // try next element
+                    // try next element
+                    logSupervisionFailure(ex)
                 }
               case Failure(ex) =>
                 // fatal exception in buffer, not sure that it can actually happen, but for good measure
@@ -242,7 +274,8 @@ private[stream] final class MapAsyncPartitioned[In, Out, Partition](
                     case Supervision.Stop =>
                       failStage(ex)
                     case _ =>
-                    // try next element
+                      // try next element
+                      logSupervisionFailure(ex)
                   }
                 case Failure(ex) =>
                   // fatal exception in buffer, not sure that it can actually happen, but for good measure

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -1296,10 +1296,36 @@ private[stream] object Collect {
   override val shape = FlowShape(in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new GraphStageLogic(shape) with InHandler with OutHandler {
+    new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
+
+      override protected def logSource: Class[?] = classOf[MapAsync[?, ?]]
 
       lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
       var buffer: BufferImpl[Holder[Out]] = _
+
+      private def logSupervisionFailure(ex: Throwable): Unit = {
+        val logAt: LogLevel = inheritedAttributes.get[LogLevels] match {
+          case Some(levels) => levels.onFailure
+          case None         => LogLevels.defaultErrorLevel(materializer.system)
+        }
+        logAt match {
+          case Logging.ErrorLevel =>
+            log.error(ex, "Supervision strategy resumed after exception in MapAsync: {}", ex.getMessage)
+          case Logging.WarningLevel =>
+            log.warning(ex, "Supervision strategy resumed after exception in MapAsync: {}", ex.getMessage)
+          case Logging.InfoLevel =>
+            log.info(
+              "Supervision strategy resumed after exception in MapAsync: {}: {}",
+              Logging.simpleName(ex.getClass),
+              ex.getMessage)
+          case Logging.DebugLevel =>
+            log.debug(
+              "Supervision strategy resumed after exception in MapAsync: {}: {}",
+              Logging.simpleName(ex.getClass),
+              ex.getMessage)
+          case _ => // Off, nop
+        }
+      }
 
       private val futureCB = getAsyncCallback[Holder[Out]](holder =>
         holder.elem match {
@@ -1348,7 +1374,9 @@ private[stream] object Collect {
 
         } catch {
           // this logic must only be executed if f throws, not if the future is failed
-          case NonFatal(ex) => if (decider(ex) == Supervision.Stop) failStage(ex)
+          case NonFatal(ex) =>
+            if (decider(ex) == Supervision.Stop) failStage(ex)
+            else logSupervisionFailure(ex)
         }
 
         pullIfNeeded()
@@ -1380,6 +1408,7 @@ private[stream] object Collect {
                 case Supervision.Stop => failStage(ex)
                 case _                =>
                   // try next element
+                  logSupervisionFailure(ex)
                   pushNextIfPossible()
               }
             case Failure(ex) =>
@@ -1413,8 +1442,10 @@ private[stream] object Collect {
   override val shape = FlowShape(in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new GraphStageLogic(shape) with InHandler with OutHandler {
+    new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
       override def toString = s"MapAsyncUnordered.Logic(inFlight=$inFlight, buffer=$buffer)"
+
+      override protected def logSource: Class[?] = classOf[MapAsyncUnordered[?, ?]]
 
       private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
 
@@ -1423,6 +1454,30 @@ private[stream] object Collect {
       private val invokeFutureCB: Try[Out] => Unit = getAsyncCallback(futureCompleted).invoke
 
       private def todo: Int = inFlight + buffer.used
+
+      private def logSupervisionFailure(ex: Throwable): Unit = {
+        val logAt: LogLevel = inheritedAttributes.get[LogLevels] match {
+          case Some(levels) => levels.onFailure
+          case None         => LogLevels.defaultErrorLevel(materializer.system)
+        }
+        logAt match {
+          case Logging.ErrorLevel =>
+            log.error(ex, "Supervision strategy resumed after exception in MapAsyncUnordered: {}", ex.getMessage)
+          case Logging.WarningLevel =>
+            log.warning(ex, "Supervision strategy resumed after exception in MapAsyncUnordered: {}", ex.getMessage)
+          case Logging.InfoLevel =>
+            log.info(
+              "Supervision strategy resumed after exception in MapAsyncUnordered: {}: {}",
+              Logging.simpleName(ex.getClass),
+              ex.getMessage)
+          case Logging.DebugLevel =>
+            log.debug(
+              "Supervision strategy resumed after exception in MapAsyncUnordered: {}: {}",
+              Logging.simpleName(ex.getClass),
+              ex.getMessage)
+          case _ => // Off, nop
+        }
+      }
 
       override def preStart(): Unit = buffer = BufferImpl(parallelism, inheritedAttributes)
 
@@ -1441,8 +1496,11 @@ private[stream] object Collect {
             else if (!hasBeenPulled(in)) tryPull(in)
           case Failure(ex) =>
             if (decider(ex) == Supervision.Stop) failStage(ex)
-            else if (isCompleted) completeStage()
-            else if (!hasBeenPulled(in)) tryPull(in)
+            else {
+              logSupervisionFailure(ex)
+              if (isCompleted) completeStage()
+              else if (!hasBeenPulled(in)) tryPull(in)
+            }
         }
       }
 
@@ -1455,7 +1513,9 @@ private[stream] object Collect {
             case Some(v) => futureCompleted(v)
           }
         } catch {
-          case NonFatal(ex) => if (decider(ex) == Supervision.Stop) failStage(ex)
+          case NonFatal(ex) =>
+            if (decider(ex) == Supervision.Stop) failStage(ex)
+            else logSupervisionFailure(ex)
         }
         if (todo < parallelism && !hasBeenPulled(in)) tryPull(in)
       }


### PR DESCRIPTION
## Summary
- Adds error logging when supervision strategy returns Resume or Restart for failed elements in `MapAsync`, `MapAsyncUnordered`, and `MapAsyncPartitioned`
- Respects the `stage-errors-default-log-level` configuration and per-stage `LogLevels.onFailure` attribute from #2805
- Logging placed to avoid double-logging (uses `Holder`'s directive cache to ensure exactly one log per failure)

## Changes
- `MapAsync`: Added `StageLogging` mixin, `logSupervisionFailure` helper, logging in `pushNextIfPossible` and sync exception handler
- `MapAsyncUnordered`: Added `StageLogging` mixin, `logSupervisionFailure` helper, logging in `futureCompleted` and sync exception handler
- `MapAsyncPartitioned`: Added `StageLogging` mixin, `logSupervisionFailure` helper, logging in both ordered and unordered `pushNextIfPossible` and sync exception handler

### Motivation
`MapAsync`, `MapAsyncUnordered`, and `MapAsyncPartitioned` silently skip failed elements when the supervision strategy returns Resume or Restart. This makes production debugging difficult — users cannot see which elements were dropped or what exceptions occurred.

### Modification
- Mix in `StageLogging` trait for all three operators
- Add `logSupervisionFailure` helper that checks `LogLevels.onFailure` attribute, falls back to `LogLevels.defaultErrorLevel(system)`, and logs at the configured level
- For `MapAsync` and `MapAsyncPartitioned`, logging is placed in `pushNextIfPossible` (not in `futureCB` or the fast path) to avoid double-logging since the `Holder` caches the supervision directive
- For `MapAsyncUnordered`, logging is placed in `futureCompleted` (no buffer re-processing)
- Sync exception handlers log directly since they bypass the `Holder` caching

### Result
Supervision Resume/Restart decisions now produce log entries with exception details, enabling users to diagnose dropped elements. Log level can be controlled via `pekko.stream.materializer.stage-errors-default-log-level` config or per-stage `ActorAttributes.logLevels`.

### Tests
- `FlowMapAsyncSpec`: 3 new tests (async future failure logs, sync throw logs, log level Off disables logging)
- `FlowMapAsyncUnorderedSpec`: 3 new tests (same pattern)
- `FlowMapAsyncPartitionedSpec`: 3 new tests (ordered, unordered, log level Off)
- All 74 existing + new tests pass

### References
Fixes #3103