### PR TITLE
feat(stream): add alsoTo overload with configurable cancellation propagation

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/alsoTo.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/alsoTo.md
@@ -14,6 +14,12 @@ Attaches the given `Sink` to this `Flow`, meaning that elements that pass throug
 
 Attaches the given `Sink` to this `Flow`, meaning that elements that pass through this `Flow` will also be sent to the `Sink`.
 
+By default, cancellation or failure of the attached `Sink` cancels the main stream. The `alsoTo` overload with
+`propagateCancellation = false` can be used when the attached `Sink` is a best-effort side sink, such as logging or
+metrics, and its cancellation or failure should not terminate the main stream. In that mode, the operator still
+backpressures when the side `Sink` is active and backpressuring, but once the side `Sink` cancels or fails, elements
+continue to the main downstream only.
+
 ## Reactive Streams semantics
 
 @@@div { .callout }
@@ -24,8 +30,9 @@ Attaches the given `Sink` to this `Flow`, meaning that elements that pass throug
 
 **completes** when upstream completes
 
-**cancels** when downstream or `Sink` cancels
+**cancels** when downstream cancels. With the default cancellation propagation, the operator also cancels when the
+attached `Sink` cancels or fails. With `propagateCancellation = false`, cancellation or failure of the attached `Sink`
+does not cancel the main stream.
 
 @@@
-
 

--- a/project/StreamOperatorsIndexGenerator.scala
+++ b/project/StreamOperatorsIndexGenerator.scala
@@ -81,6 +81,7 @@ object StreamOperatorsIndexGenerator extends AutoPlugin {
     "mergeGraph",
     "wireTapGraph",
     "alsoToGraph",
+    "resilientAlsoToGraph",
     "orElseGraph",
     "divertToGraph",
     "zipWithGraph",

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
@@ -1892,10 +1892,8 @@ public class FlowTest extends StreamTestJupiter {
 
   @Test
   public void mustBeAbleToUseAlsoToWithPropagateCancellation() {
-    final Flow<Integer, Integer, NotUsed> f =
-        Flow.of(Integer.class).alsoTo(Sink.ignore(), false);
-    final Flow<Integer, Integer, NotUsed> f2 =
-        Flow.of(Integer.class).alsoTo(Sink.ignore(), true);
+    final Flow<Integer, Integer, NotUsed> f = Flow.of(Integer.class).alsoTo(Sink.ignore(), false);
+    final Flow<Integer, Integer, NotUsed> f2 = Flow.of(Integer.class).alsoTo(Sink.ignore(), true);
     final Flow<Integer, Integer, String> f3 =
         Flow.of(Integer.class).alsoToMat(Sink.ignore(), false, (i, n) -> "foo");
     final Flow<Integer, Integer, String> f4 =

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
@@ -1891,6 +1891,18 @@ public class FlowTest extends StreamTestJupiter {
   }
 
   @Test
+  public void mustBeAbleToUseAlsoToWithPropagateCancellation() {
+    final Flow<Integer, Integer, NotUsed> f =
+        Flow.of(Integer.class).alsoTo(Sink.ignore(), false);
+    final Flow<Integer, Integer, NotUsed> f2 =
+        Flow.of(Integer.class).alsoTo(Sink.ignore(), true);
+    final Flow<Integer, Integer, String> f3 =
+        Flow.of(Integer.class).alsoToMat(Sink.ignore(), false, (i, n) -> "foo");
+    final Flow<Integer, Integer, String> f4 =
+        Flow.of(Integer.class).alsoToMat(Sink.ignore(), true, (i, n) -> "foo");
+  }
+
+  @Test
   public void mustBeAbleToUseAlsoToAll() {
     final Flow<Integer, Integer, NotUsed> f =
         Flow.of(Integer.class).alsoToAll(Sink.ignore(), Sink.ignore());

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/GraphDslTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/GraphDslTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -78,6 +79,27 @@ public class GraphDslTest extends StreamTestJupiter {
     Arrays.sort(res, null);
     assertArrayEquals(
         new String[] {"31", "32", "33", "34", "35", "41", "42", "43", "44", "45"}, res);
+  }
+
+  @Test
+  public void mustKeepFlowingWhenNonEagerBroadcastOutputCancels() throws Exception {
+    final Source<Integer, NotUsed> source = Source.from(Arrays.asList(1, 2, 3));
+    final Sink<Integer, CompletionStage<List<Integer>>> sink = Sink.seq();
+
+    final RunnableGraph<CompletionStage<List<Integer>>> graph =
+        RunnableGraph.fromGraph(
+            GraphDSL.create(
+                sink,
+                (builder, out) -> {
+                  final UniformFanOutShape<Integer, Integer> broadcast =
+                      builder.add(Broadcast.create(2, true, Collections.singleton(1)));
+                  builder.from(builder.add(source)).viaFanOut(broadcast).to(out);
+                  builder.from(broadcast).to(builder.add(Sink.<Integer>cancelled()));
+                  return ClosedShape.getInstance();
+                }));
+
+    assertEquals(
+        Arrays.asList(1, 2, 3), graph.run(system).toCompletableFuture().get(3, TimeUnit.SECONDS));
   }
 
   @Test

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -1491,6 +1491,18 @@ public class SourceTest extends StreamTestJupiter {
   }
 
   @Test
+  public void mustBeAbleToUseAlsoToWithPropagateCancellation() {
+    final Source<Integer, NotUsed> f =
+        Source.<Integer>empty().alsoTo(Sink.ignore(), false);
+    final Source<Integer, NotUsed> f2 =
+        Source.<Integer>empty().alsoTo(Sink.ignore(), true);
+    final Source<Integer, String> f3 =
+        Source.<Integer>empty().alsoToMat(Sink.ignore(), false, (i, n) -> "foo");
+    final Source<Integer, String> f4 =
+        Source.<Integer>empty().alsoToMat(Sink.ignore(), true, (i, n) -> "foo");
+  }
+
+  @Test
   public void mustBeAbleToUseAlsoToAll() {
     final Source<Integer, NotUsed> f =
         Source.<Integer>empty().alsoToAll(Sink.ignore(), Sink.ignore());

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -1492,10 +1492,8 @@ public class SourceTest extends StreamTestJupiter {
 
   @Test
   public void mustBeAbleToUseAlsoToWithPropagateCancellation() {
-    final Source<Integer, NotUsed> f =
-        Source.<Integer>empty().alsoTo(Sink.ignore(), false);
-    final Source<Integer, NotUsed> f2 =
-        Source.<Integer>empty().alsoTo(Sink.ignore(), true);
+    final Source<Integer, NotUsed> f = Source.<Integer>empty().alsoTo(Sink.ignore(), false);
+    final Source<Integer, NotUsed> f2 = Source.<Integer>empty().alsoTo(Sink.ignore(), true);
     final Source<Integer, String> f3 =
         Source.<Integer>empty().alsoToMat(Sink.ignore(), false, (i, n) -> "foo");
     final Source<Integer, String> f4 =

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/DslConsistencySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/DslConsistencySpec.scala
@@ -90,6 +90,7 @@ class DslConsistencySpec extends AnyWordSpec with Matchers {
     "concatGraph",
     "prependGraph",
     "alsoToGraph",
+    "resilientAlsoToGraph",
     "wireTapGraph",
     "orElseGraph",
     "divertToGraph",

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowAlsoToSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowAlsoToSpec.scala
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.scaladsl
+
+import org.apache.pekko
+import pekko.stream.testkit._
+import pekko.stream.testkit.scaladsl.TestSink
+import pekko.stream.testkit.scaladsl.TestSource
+
+import scala.concurrent.duration._
+
+class FlowAlsoToSpec extends StreamSpec("""
+    pekko.stream.materializer.initial-input-buffer-size = 2
+  """) {
+
+  "alsoTo with propagateCancellation=true (default)" must {
+
+    "cancel the stream when side sink cancels" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink).runWith(mainSink)
+
+      mainProbe.request(2)
+      sideProbe.request(2)
+
+      pub.sendNext(1)
+      mainProbe.expectNext(1)
+      sideProbe.expectNext(1)
+
+      sideProbe.cancel()
+      pub.expectCancellation()
+    }
+
+    "forward elements to both downstreams" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink).runWith(mainSink)
+
+      mainProbe.request(3)
+      sideProbe.request(3)
+
+      pub.sendNext(1)
+      pub.sendNext(2)
+      pub.sendNext(3)
+
+      mainProbe.expectNext(1, 2, 3)
+      sideProbe.expectNext(1, 2, 3)
+
+      pub.sendComplete()
+      mainProbe.expectComplete()
+      sideProbe.expectComplete()
+    }
+  }
+
+  "alsoTo with propagateCancellation=false" must {
+
+    "continue main stream when side sink cancels" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink, propagateCancellation = false).runWith(mainSink)
+
+      mainProbe.request(4)
+      sideProbe.request(2)
+
+      pub.sendNext(1)
+      mainProbe.expectNext(1)
+      sideProbe.expectNext(1)
+
+      pub.sendNext(2)
+      mainProbe.expectNext(2)
+      sideProbe.expectNext(2)
+
+      sideProbe.cancel()
+
+      pub.sendNext(3)
+      mainProbe.expectNext(3)
+
+      pub.sendNext(4)
+      mainProbe.expectNext(4)
+
+      pub.sendComplete()
+      mainProbe.expectComplete()
+    }
+
+    "continue main stream when side sink fails" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      val failingSideSink = Flow[Int].map { elem =>
+        if (elem == 1) throw new RuntimeException("side sink failure")
+        elem
+      }.to(sideSink)
+
+      src.alsoTo(failingSideSink, propagateCancellation = false).runWith(mainSink)
+
+      mainProbe.request(3)
+      sideProbe.request(3)
+
+      pub.sendNext(1)
+      mainProbe.expectNext(1)
+
+      pub.sendNext(2)
+      mainProbe.expectNext(2)
+
+      pub.sendNext(3)
+      mainProbe.expectNext(3)
+
+      pub.sendComplete()
+      mainProbe.expectComplete()
+    }
+
+    "cancel side sink when main downstream cancels" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink, propagateCancellation = false).runWith(mainSink)
+
+      mainProbe.request(1)
+      sideProbe.request(1)
+
+      pub.sendNext(1)
+      mainProbe.expectNext(1)
+      sideProbe.expectNext(1)
+
+      mainProbe.cancel()
+      pub.expectCancellation()
+    }
+
+    "forward elements to both downstreams before side cancels" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink, propagateCancellation = false).runWith(mainSink)
+
+      mainProbe.request(3)
+      sideProbe.request(3)
+
+      pub.sendNext(1)
+      pub.sendNext(2)
+      pub.sendNext(3)
+
+      mainProbe.expectNext(1, 2, 3)
+      sideProbe.expectNext(1, 2, 3)
+
+      pub.sendComplete()
+      mainProbe.expectComplete()
+      sideProbe.expectComplete()
+    }
+
+    "complete normally when upstream completes" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink, propagateCancellation = false).runWith(mainSink)
+
+      mainProbe.request(2)
+      sideProbe.request(2)
+
+      pub.sendNext(1)
+      pub.sendNext(2)
+      pub.sendComplete()
+
+      mainProbe.expectNext(1, 2).expectComplete()
+      sideProbe.expectNext(1, 2).expectComplete()
+    }
+
+    "handle side sink cancelling before any element is emitted" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink, propagateCancellation = false).runWith(mainSink)
+
+      mainProbe.request(2)
+      sideProbe.request(1)
+
+      sideProbe.cancel()
+
+      pub.sendNext(1)
+      mainProbe.expectNext(1)
+
+      pub.sendNext(2)
+      mainProbe.expectNext(2)
+
+      pub.sendComplete()
+      mainProbe.expectComplete()
+    }
+
+    "propagate upstream failure to both downstreams" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink, propagateCancellation = false).runWith(mainSink)
+
+      mainProbe.request(1)
+      sideProbe.request(1)
+
+      val ex = new RuntimeException("upstream boom")
+      pub.sendError(ex)
+
+      mainProbe.expectError(ex)
+      sideProbe.expectError(ex)
+    }
+
+    "backpressure when side sink is slow" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink, propagateCancellation = false).runWith(mainSink)
+
+      mainProbe.request(3)
+      sideProbe.request(1)
+
+      pub.sendNext(1)
+      mainProbe.expectNext(1)
+      sideProbe.expectNext(1)
+
+      sideProbe.request(1)
+
+      pub.sendNext(2)
+      mainProbe.expectNext(2)
+      sideProbe.expectNext(2)
+
+      sideProbe.request(1)
+
+      pub.sendNext(3)
+      mainProbe.expectNext(3)
+      sideProbe.expectNext(3)
+
+      pub.sendComplete()
+      mainProbe.expectComplete()
+      sideProbe.expectComplete()
+    }
+
+    "handle side sink cancelling while pending element exists" in {
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+      val (pub, src) = TestSource[Int]().preMaterialize()
+
+      src.alsoTo(sideSink, propagateCancellation = false).runWith(mainSink)
+
+      mainProbe.request(3)
+      sideProbe.request(1)
+
+      pub.sendNext(1)
+      mainProbe.expectNext(1)
+      sideProbe.expectNext(1)
+
+      pub.sendNext(2)
+
+      sideProbe.cancel()
+      mainProbe.expectNext(2)
+
+      pub.sendNext(3)
+      mainProbe.expectNext(3)
+
+      pub.sendComplete()
+      mainProbe.expectComplete()
+    }
+  }
+}

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphBroadcastSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphBroadcastSpec.scala
@@ -313,7 +313,7 @@ class GraphBroadcastSpec extends StreamSpec("""
           // eagerCancel=true but side output (index 1) is non-eager: its cancellation
           // must not tear down the stage. Main output (index 0) keeps flowing.
           val bcast = b.add(Broadcast[Int](2, eagerCancel = true, nonEagerCancelOutputs = Set(1)))
-          src ~> bcast.in
+          src          ~> bcast.in
           bcast.out(0) ~> mainSink
           bcast.out(1) ~> sideSink
           ClosedShape

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphBroadcastSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphBroadcastSpec.scala
@@ -301,6 +301,51 @@ class GraphBroadcastSpec extends StreamSpec("""
       pMain.cancel()
       pIn.expectCancellation()
     }
+
+    "continue to remaining outputs when a non-eager output cancels" in {
+      val (pub, src) = TestSource[Int]().preMaterialize()
+      val (mainProbe, mainSink) = TestSink[Int]().preMaterialize()
+      val (sideProbe, sideSink) = TestSink[Int]().preMaterialize()
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          import GraphDSL.Implicits._
+          // eagerCancel=true but side output (index 1) is non-eager: its cancellation
+          // must not tear down the stage. Main output (index 0) keeps flowing.
+          val bcast = b.add(Broadcast[Int](2, eagerCancel = true, nonEagerCancelOutputs = Set(1)))
+          src ~> bcast.in
+          bcast.out(0) ~> mainSink
+          bcast.out(1) ~> sideSink
+          ClosedShape
+        })
+        .run()
+
+      mainProbe.request(3)
+      sideProbe.request(2)
+
+      pub.sendNext(1)
+      mainProbe.expectNext(1)
+      sideProbe.expectNext(1)
+
+      pub.sendNext(2)
+      mainProbe.expectNext(2)
+      sideProbe.expectNext(2)
+
+      sideProbe.cancel()
+
+      pub.sendNext(3)
+      mainProbe.expectNext(3)
+
+      pub.sendComplete()
+      mainProbe.expectComplete()
+    }
+
+    "reject nonEagerCancelOutputs when eagerCancel is false" in {
+      val ex = intercept[IllegalArgumentException] {
+        Broadcast[Int](2, eagerCancel = false, nonEagerCancelOutputs = Set(1))
+      }
+      ex.getMessage should include("requires eagerCancel=true")
+    }
   }
 
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Stages.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Stages.scala
@@ -103,7 +103,6 @@ import pekko.stream.Attributes._
     val onErrorComplete = name("onErrorComplete")
     val broadcast = name("broadcast")
     val wireTap = name("wireTap")
-    val resilientAlsoTo = name("resilientAlsoTo")
     val balance = name("balance")
     val zip = name("zip")
     val zipLatest = name("zipLatest")

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Stages.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Stages.scala
@@ -103,6 +103,7 @@ import pekko.stream.Attributes._
     val onErrorComplete = name("onErrorComplete")
     val broadcast = name("broadcast")
     val wireTap = name("wireTap")
+    val resilientAlsoTo = name("resilientAlsoTo")
     val balance = name("balance")
     val zip = name("zip")
     val zipLatest = name("zipLatest")

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -3301,7 +3301,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *                        When `propagateCancellation` is `true`, cancellation or failure of
    *                        the side [[Sink]] also cancels the downstream.
    *
-   * @since 1.2.0
+   * @since 2.0.0
    */
   def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.alsoTo(that, propagateCancellation))
@@ -3350,7 +3350,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
    * where appropriate instead of manually writing functions that pass through one of the values.
    *
-   * @since 1.2.0
+   * @since 2.0.0
    */
   def alsoToMat[M2, M3](
       that: Graph[SinkShape[Out], M2],

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -3283,6 +3283,30 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.alsoTo(that))
 
   /**
+   * Attaches the given [[Sink]] to this [[Flow]], meaning that elements that pass
+   * through will also be sent to the [[Sink]].
+   *
+   * When `propagateCancellation` is `false`, cancellation or failure of the side [[Sink]]
+   * will not cancel the main stream. Elements will continue to flow to the main downstream only.
+   *
+   * When `propagateCancellation` is `true` (the default), this behaves identically to [[#alsoTo]].
+   *
+   * '''Emits when''' element is available and demand exists both from the Sink and the downstream.
+   *
+   * '''Backpressures when''' downstream or Sink backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels (the side [[Sink]] is also cancelled).
+   *                        When `propagateCancellation` is `true`, cancellation or failure of
+   *                        the side [[Sink]] also cancels the downstream.
+   *
+   * @since 1.2.0
+   */
+  def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.alsoTo(that, propagateCancellation))
+
+  /**
    * Attaches the given [[Sink]]s to this [[Flow]], meaning that elements that passes
    * through will also be sent to all those [[Sink]]s.
    *
@@ -3316,6 +3340,23 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
       that: Graph[SinkShape[Out], M2],
       matF: function.Function2[Mat, M2, M3]): javadsl.Flow[In, Out, M3] =
     new Flow(delegate.alsoToMat(that)(combinerToScala(matF)))
+
+  /**
+   * Attaches the given [[Sink]] to this [[Flow]], meaning that elements that pass
+   * through will also be sent to the [[Sink]].
+   *
+   * @see [[#alsoTo]]
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
+   * @since 1.2.0
+   */
+  def alsoToMat[M2, M3](
+      that: Graph[SinkShape[Out], M2],
+      propagateCancellation: Boolean,
+      matF: function.Function2[Mat, M2, M3]): javadsl.Flow[In, Out, M3] =
+    new Flow(delegate.alsoToMat(that, propagateCancellation)(combinerToScala(matF)))
 
   /**
    * Attaches the given [[Sink]] to this [[Flow]], meaning that elements will be sent to the [[Sink]]

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Graph.scala
@@ -210,6 +210,27 @@ object Broadcast {
     scaladsl.Broadcast(outputCount, eagerCancel = eagerCancel)
 
   /**
+   * Create a new `Broadcast` operator with the specified input type and per-output cancellation behavior.
+   *
+   * @param outputCount number of output ports
+   * @param eagerCancel if true, broadcast cancels upstream if any of its downstreams cancel
+   *                    (except those listed in `nonEagerCancelOutputs`).
+   * @param nonEagerCancelOutputs set of output port indices whose cancellation should not
+   *                              trigger upstream cancellation. These outputs are silently
+   *                              removed from the broadcast when they cancel, and elements
+   *                              continue flowing to the remaining outputs.
+   * @since 2.0.0
+   */
+  def create[T](
+      outputCount: Int,
+      eagerCancel: Boolean,
+      nonEagerCancelOutputs: util.Set[java.lang.Integer]): Graph[UniformFanOutShape[T, T], NotUsed] =
+    scaladsl.Broadcast(
+      outputCount,
+      eagerCancel = eagerCancel,
+      nonEagerCancelOutputs = nonEagerCancelOutputs.asScala.iterator.map(_.intValue()).toSet)
+
+  /**
    * Create a new `Broadcast` operator with the specified input type.
    *
    * @param outputCount number of output ports

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -1407,6 +1407,30 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     new Source(delegate.alsoTo(that))
 
   /**
+   * Attaches the given [[Sink]] to this [[Source]], meaning that elements that pass
+   * through will also be sent to the [[Sink]].
+   *
+   * When `propagateCancellation` is `false`, cancellation or failure of the side [[Sink]]
+   * will not cancel the main stream. Elements will continue to flow to the main downstream only.
+   *
+   * When `propagateCancellation` is `true` (the default), this behaves identically to [[#alsoTo]].
+   *
+   * '''Emits when''' element is available and demand exists both from the Sink and the downstream.
+   *
+   * '''Backpressures when''' downstream or Sink backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels (the side [[Sink]] is also cancelled).
+   *                        When `propagateCancellation` is `true`, cancellation or failure of
+   *                        the side [[Sink]] also cancels the downstream.
+   *
+   * @since 1.2.0
+   */
+  def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): javadsl.Source[Out, Mat] =
+    new Source(delegate.alsoTo(that, propagateCancellation))
+
+  /**
    * Attaches the given [[Sink]]s to this [[Source]], meaning that elements that passes
    * through will also be sent to all those [[Sink]]s.
    *
@@ -1440,6 +1464,23 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
       that: Graph[SinkShape[Out], M2],
       matF: function.Function2[Mat, M2, M3]): javadsl.Source[Out, M3] =
     new Source(delegate.alsoToMat(that)(combinerToScala(matF)))
+
+  /**
+   * Attaches the given [[Sink]] to this [[Source]], meaning that elements that pass
+   * through will also be sent to the [[Sink]].
+   *
+   * @see [[#alsoTo]]
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
+   * @since 1.2.0
+   */
+  def alsoToMat[M2, M3](
+      that: Graph[SinkShape[Out], M2],
+      propagateCancellation: Boolean,
+      matF: function.Function2[Mat, M2, M3]): javadsl.Source[Out, M3] =
+    new Source(delegate.alsoToMat(that, propagateCancellation)(combinerToScala(matF)))
 
   /**
    * Attaches the given [[Sink]] to this [[Flow]], meaning that elements will be sent to the [[Sink]]

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -1425,7 +1425,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *                        When `propagateCancellation` is `true`, cancellation or failure of
    *                        the side [[Sink]] also cancels the downstream.
    *
-   * @since 1.2.0
+   * @since 2.0.0
    */
   def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): javadsl.Source[Out, Mat] =
     new Source(delegate.alsoTo(that, propagateCancellation))
@@ -1474,7 +1474,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
    * where appropriate instead of manually writing functions that pass through one of the values.
    *
-   * @since 1.2.0
+   * @since 2.0.0
    */
   def alsoToMat[M2, M3](
       that: Graph[SinkShape[Out], M2],

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -2308,7 +2308,7 @@ final class SubFlow[In, Out, Mat](
    *                        When `propagateCancellation` is `true`, cancellation or failure of
    *                        the side [[Sink]] also cancels the downstream.
    *
-   * @since 1.2.0
+   * @since 2.0.0
    */
   def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.alsoTo(that, propagateCancellation))

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -2290,6 +2290,30 @@ final class SubFlow[In, Out, Mat](
     new SubFlow(delegate.alsoTo(that))
 
   /**
+   * Attaches the given [[Sink]] to this [[Flow]], meaning that elements that pass
+   * through will also be sent to the [[Sink]].
+   *
+   * When `propagateCancellation` is `false`, cancellation or failure of the side [[Sink]]
+   * will not cancel the main stream. Elements will continue to flow to the main downstream only.
+   *
+   * When `propagateCancellation` is `true` (the default), this behaves identically to [[#alsoTo]].
+   *
+   * '''Emits when''' element is available and demand exists both from the Sink and the downstream.
+   *
+   * '''Backpressures when''' downstream or Sink backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels (the side [[Sink]] is also cancelled).
+   *                        When `propagateCancellation` is `true`, cancellation or failure of
+   *                        the side [[Sink]] also cancels the downstream.
+   *
+   * @since 1.2.0
+   */
+  def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): SubFlow[In, Out, Mat] =
+    new SubFlow(delegate.alsoTo(that, propagateCancellation))
+
+  /**
    * Attaches the given [[Sink]]s to this [[Flow]], meaning that elements that passes
    * through will also be sent to all those [[Sink]]s.
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -2256,6 +2256,30 @@ final class SubSource[Out, Mat](
     new SubSource(delegate.alsoTo(that))
 
   /**
+   * Attaches the given [[Sink]] to this [[Source]], meaning that elements that pass
+   * through will also be sent to the [[Sink]].
+   *
+   * When `propagateCancellation` is `false`, cancellation or failure of the side [[Sink]]
+   * will not cancel the main stream. Elements will continue to flow to the main downstream only.
+   *
+   * When `propagateCancellation` is `true` (the default), this behaves identically to [[#alsoTo]].
+   *
+   * '''Emits when''' element is available and demand exists both from the Sink and the downstream.
+   *
+   * '''Backpressures when''' downstream or Sink backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels (the side [[Sink]] is also cancelled).
+   *                        When `propagateCancellation` is `true`, cancellation or failure of
+   *                        the side [[Sink]] also cancels the downstream.
+   *
+   * @since 1.2.0
+   */
+  def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): SubSource[Out, Mat] =
+    new SubSource(delegate.alsoTo(that, propagateCancellation))
+
+  /**
    * Attaches the given [[Sink]]s to this [[Source]], meaning that elements that passes
    * through will also be sent to all those [[Sink]]s.
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -2274,7 +2274,7 @@ final class SubSource[Out, Mat](
    *                        When `propagateCancellation` is `true`, cancellation or failure of
    *                        the side [[Sink]] also cancels the downstream.
    *
-   * @since 1.2.0
+   * @since 2.0.0
    */
   def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): SubSource[Out, Mat] =
     new SubSource(delegate.alsoTo(that, propagateCancellation))

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -4052,9 +4052,9 @@ trait FlowOps[+Out, +Mat] {
       that: Graph[SinkShape[Out], M]): Graph[FlowShape[Out @uncheckedVariance, Out], M] =
     GraphDSL.createGraph(that) { implicit b => r =>
       import GraphDSL.Implicits._
-      val stage = b.add(new ResilientAlsoTo[Out])
-      stage.out1 ~> r
-      FlowShape(stage.in, stage.out0)
+      val bcast = b.add(Broadcast[Out](2, eagerCancel = true, nonEagerCancelOutputs = Set(1)))
+      bcast.out(1) ~> r
+      FlowShape(bcast.in, bcast.out(0))
     }
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -4042,7 +4042,7 @@ trait FlowOps[+Out, +Mat] {
    *                        When `propagateCancellation` is `true`, cancellation or failure of
    *                        the side [[Sink]] also cancels the downstream.
    *
-   * @since 1.2.0
+   * @since 2.0.0
    */
   def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): Repr[Out] =
     if (propagateCancellation) alsoTo(that)
@@ -4583,7 +4583,7 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
    * where appropriate instead of manually writing functions that pass through one of the values.
    *
-   * @since 1.2.0
+   * @since 2.0.0
    */
   def alsoToMat[Mat2, Mat3](that: Graph[SinkShape[Out], Mat2], propagateCancellation: Boolean)(
       matF: (Mat, Mat2) => Mat3): ReprMat[Out, Mat3] =

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -4020,6 +4020,44 @@ trait FlowOps[+Out, +Mat] {
     }
 
   /**
+   * Attaches the given [[Sink]] to this [[Flow]], meaning that elements that pass
+   * through will also be sent to the [[Sink]].
+   *
+   * When `propagateCancellation` is `false`, cancellation or failure of the side [[Sink]]
+   * will not cancel the main stream. Elements will continue to flow to the main downstream
+   * only. This is useful for fire-and-forget side sinks (e.g. logging) where the side sink's
+   * availability should not affect the main business stream.
+   *
+   * When `propagateCancellation` is `true` (the default), this behaves identically to [[#alsoTo]].
+   *
+   * It is similar to [[#wireTap]] but will backpressure instead of dropping elements when the given [[Sink]] is not ready.
+   *
+   * '''Emits when''' element is available and demand exists both from the Sink and the downstream.
+   *
+   * '''Backpressures when''' downstream or Sink backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels (the side [[Sink]] is also cancelled).
+   *                        When `propagateCancellation` is `true`, cancellation or failure of
+   *                        the side [[Sink]] also cancels the downstream.
+   *
+   * @since 1.2.0
+   */
+  def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): Repr[Out] =
+    if (propagateCancellation) alsoTo(that)
+    else via(resilientAlsoToGraph(that))
+
+  protected def resilientAlsoToGraph[M](
+      that: Graph[SinkShape[Out], M]): Graph[FlowShape[Out @uncheckedVariance, Out], M] =
+    GraphDSL.createGraph(that) { implicit b => r =>
+      import GraphDSL.Implicits._
+      val stage = b.add(new ResilientAlsoTo[Out])
+      stage.out1 ~> r
+      FlowShape(stage.in, stage.out0)
+    }
+
+  /**
    * Attaches the given [[Sink]]s to this [[Source]], meaning that elements that pass
    * through will also be sent to the [[Sink]].
    *
@@ -4535,6 +4573,22 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    */
   def alsoToMat[Mat2, Mat3](that: Graph[SinkShape[Out], Mat2])(matF: (Mat, Mat2) => Mat3): ReprMat[Out, Mat3] =
     viaMat(alsoToGraph(that))(matF)
+
+  /**
+   * Attaches the given [[Sink]] to this [[Flow]], meaning that elements that pass
+   * through will also be sent to the [[Sink]].
+   *
+   * @see [[#alsoTo]]
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   *
+   * @since 1.2.0
+   */
+  def alsoToMat[Mat2, Mat3](that: Graph[SinkShape[Out], Mat2], propagateCancellation: Boolean)(
+      matF: (Mat, Mat2) => Mat3): ReprMat[Out, Mat3] =
+    if (propagateCancellation) viaMat(alsoToGraph(that))(matF)
+    else viaMat(resilientAlsoToGraph(that))(matF)
 
   /**
    * Attaches the given [[Sink]] to this [[Flow]], meaning that elements will be sent to the [[Sink]]

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContext.scala
@@ -149,6 +149,10 @@ final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: Flow[(In
   override def alsoTo(that: Graph[SinkShape[Out], ?]): Repr[Out, CtxOut] =
     FlowWithContext.fromTuples(delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, CtxOut)) => in._1)))
 
+  override def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): Repr[Out, CtxOut] =
+    FlowWithContext.fromTuples(
+      delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, CtxOut)) => in._1), propagateCancellation))
+
   override def alsoToContext(that: Graph[SinkShape[CtxOut], ?]): Repr[Out, CtxOut] =
     FlowWithContext.fromTuples(delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, CtxOut)) => in._2)))
 

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
@@ -95,6 +95,14 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
   def alsoTo(that: Graph[SinkShape[Out], ?]): Repr[Out, Ctx]
 
   /**
+   * Data variant of [[pekko.stream.scaladsl.FlowOps.alsoTo]] with configurable cancellation propagation.
+   *
+   * @see [[pekko.stream.scaladsl.FlowOps.alsoTo]]
+   * @since 1.2.0
+   */
+  def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): Repr[Out, Ctx]
+
+  /**
    * Context variant of [[pekko.stream.scaladsl.FlowOps.alsoTo]]
    *
    * @see [[pekko.stream.scaladsl.FlowOps.alsoTo]]

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
@@ -98,7 +98,7 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
    * Data variant of [[pekko.stream.scaladsl.FlowOps.alsoTo]] with configurable cancellation propagation.
    *
    * @see [[pekko.stream.scaladsl.FlowOps.alsoTo]]
-   * @since 1.2.0
+   * @since 2.0.0
    */
   def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): Repr[Out, Ctx]
 

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
@@ -794,7 +794,7 @@ private[pekko] final class ResilientAlsoTo[T] extends GraphStage[FanOutShape2[T,
   val in: Inlet[T] = Inlet[T]("ResilientAlsoTo.in")
   val outMain: Outlet[T] = Outlet[T]("ResilientAlsoTo.outMain")
   val outSide: Outlet[T] = Outlet[T]("ResilientAlsoTo.outSide")
-  override def initialAttributes: Attributes = DefaultAttributes.resilientAlsoTo
+  override def initialAttributes: Attributes = Attributes.name("resilientAlsoTo")
   override val shape: FanOutShape2[T, T, T] = new FanOutShape2(in, outMain, outSide)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
@@ -643,14 +643,49 @@ object Broadcast {
  * '''Cancels when'''
  *   If eagerCancel is enabled: when any downstream cancels; otherwise: when all downstreams cancel
  */
-final class Broadcast[T](val outputPorts: Int, val eagerCancel: Boolean, val nonEagerCancelOutputs: Set[Int])
+final class Broadcast[T](val outputPorts: Int, val eagerCancel: Boolean)
     extends GraphStage[UniformFanOutShape[T, T]]
     with pekko.stream.TypePreservingFanOut {
-  def this(outputPorts: Int, eagerCancel: Boolean) = this(outputPorts, eagerCancel, Set.empty)
   require(outputPorts >= 1, "A Broadcast must have one or more output ports")
-  require(
-    nonEagerCancelOutputs.isEmpty || !eagerCancel || nonEagerCancelOutputs.subsetOf((0 until outputPorts).toSet),
-    "nonEagerCancelOutputs must be a subset of output indices")
+
+  // Backing field for the 3-arg auxiliary constructor; default is empty (all outputs eager).
+  // The auxiliary constructor assigns this exactly once during construction, so the value is
+  // effectively immutable after init. Kept `var` because Scala auxiliary constructors cannot
+  // assign `val` fields.
+  private var _nonEagerCancelOutputs: Set[Int] = Set.empty
+
+  /**
+   * Set of output port indices whose cancellation should not trigger upstream cancellation.
+   * Only meaningful when `eagerCancel` is `true`; these outputs are silently removed from the
+   * broadcast when they cancel, and elements continue flowing to the remaining outputs.
+   *
+   * @since 2.0.0
+   */
+  def nonEagerCancelOutputs: Set[Int] = _nonEagerCancelOutputs
+
+  /**
+   * Create a new `Broadcast` with per-output cancellation behavior.
+   *
+   * @param nonEagerCancelOutputs set of output port indices whose cancellation should not
+   *                              trigger upstream cancellation when `eagerCancel` is `true`.
+   *                              These outputs are silently removed from the broadcast when
+   *                              they cancel, and elements continue flowing to the remaining
+   *                              outputs. Must be empty when `eagerCancel` is `false` (where
+   *                              the parameter would be meaningless).
+   * @since 2.0.0
+   */
+  def this(outputPorts: Int, eagerCancel: Boolean, nonEagerCancelOutputs: Set[Int]) = {
+    this(outputPorts, eagerCancel)
+    require(
+      eagerCancel || nonEagerCancelOutputs.isEmpty,
+      s"nonEagerCancelOutputs [$nonEagerCancelOutputs] requires eagerCancel=true; " +
+      s"with eagerCancel=false all outputs already behave non-eagerly")
+    require(
+      nonEagerCancelOutputs.subsetOf((0 until outputPorts).toSet),
+      s"nonEagerCancelOutputs [$nonEagerCancelOutputs] must be a subset of [${0 until outputPorts}]")
+    _nonEagerCancelOutputs = nonEagerCancelOutputs
+  }
+
   val in: Inlet[T] = Inlet[T]("Broadcast.in")
   val out: immutable.IndexedSeq[Outlet[T]] = Vector.tabulate(outputPorts)(i => Outlet[T]("Broadcast.out" + i))
   override def initialAttributes = DefaultAttributes.broadcast

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
@@ -30,7 +30,7 @@ import pekko.stream.impl._
 import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.impl.fusing.GraphStages
 import pekko.stream.scaladsl.Partition.PartitionOutOfBoundsException
-import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler, StageLogging }
+import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import pekko.util.ConstantFun
 
 /**
@@ -609,6 +609,25 @@ object Broadcast {
    */
   def apply[T](outputPorts: Int, eagerCancel: Boolean = false): Broadcast[T] =
     new Broadcast(outputPorts, eagerCancel)
+
+  /**
+   * Create a new `Broadcast` with the specified number of output ports and per-output
+   * cancellation behavior.
+   *
+   * @param outputPorts number of output ports
+   * @param eagerCancel if true, broadcast cancels upstream if any of its downstreams cancel
+   *                    (except those listed in `nonEagerCancelOutputs`).
+   * @param nonEagerCancelOutputs set of output port indices whose cancellation should not
+   *                              trigger upstream cancellation. These outputs are silently
+   *                              removed from the broadcast when they cancel, and elements
+   *                              continue flowing to the remaining outputs.
+   * @since 2.0.0
+   */
+  def apply[T](
+      outputPorts: Int,
+      eagerCancel: Boolean,
+      nonEagerCancelOutputs: Set[Int]): Broadcast[T] =
+    new Broadcast(outputPorts, eagerCancel, nonEagerCancelOutputs)
 }
 
 /**
@@ -624,11 +643,14 @@ object Broadcast {
  * '''Cancels when'''
  *   If eagerCancel is enabled: when any downstream cancels; otherwise: when all downstreams cancel
  */
-final class Broadcast[T](val outputPorts: Int, val eagerCancel: Boolean)
+final class Broadcast[T](val outputPorts: Int, val eagerCancel: Boolean, val nonEagerCancelOutputs: Set[Int])
     extends GraphStage[UniformFanOutShape[T, T]]
     with pekko.stream.TypePreservingFanOut {
-  // one output might seem counter intuitive but saves us from special handling in other places
+  def this(outputPorts: Int, eagerCancel: Boolean) = this(outputPorts, eagerCancel, Set.empty)
   require(outputPorts >= 1, "A Broadcast must have one or more output ports")
+  require(
+    nonEagerCancelOutputs.isEmpty || !eagerCancel || nonEagerCancelOutputs.subsetOf((0 until outputPorts).toSet),
+    "nonEagerCancelOutputs must be a subset of output indices")
   val in: Inlet[T] = Inlet[T]("Broadcast.in")
   val out: immutable.IndexedSeq[Outlet[T]] = Vector.tabulate(outputPorts)(i => Outlet[T]("Broadcast.out" + i))
   override def initialAttributes = DefaultAttributes.broadcast
@@ -677,7 +699,7 @@ final class Broadcast[T](val outputPorts: Int, val eagerCancel: Boolean)
               }
 
               override def onDownstreamFinish(cause: Throwable) = {
-                if (eagerCancel) cancelStage(cause)
+                if (eagerCancel && !nonEagerCancelOutputs.contains(i)) cancelStage(cause)
                 else {
                   downstreamsRunning -= 1
                   if (downstreamsRunning == 0) cancelStage(cause)
@@ -779,110 +801,6 @@ private[stream] final class WireTap[T] extends GraphStage[FanOutShape2[T, T, T]]
       setHandlers(in, outMain, this)
     }
   override def toString = "WireTap"
-}
-
-/**
- * INTERNAL API
- *
- * A `Broadcast`-like stage with two outputs where cancellation of the side output (out1)
- * does not cancel the stage. Elements continue flowing to the main output (out0) after
- * the side output cancels or fails. Cancellation of the main output cancels the stage.
- *
- * Backpressures when either output backpressures (same contract as `alsoTo` / `Broadcast`).
- */
-private[pekko] final class ResilientAlsoTo[T] extends GraphStage[FanOutShape2[T, T, T]] {
-  val in: Inlet[T] = Inlet[T]("ResilientAlsoTo.in")
-  val outMain: Outlet[T] = Outlet[T]("ResilientAlsoTo.outMain")
-  val outSide: Outlet[T] = Outlet[T]("ResilientAlsoTo.outSide")
-  override def initialAttributes: Attributes = Attributes.name("resilientAlsoTo")
-  override val shape: FanOutShape2[T, T, T] = new FanOutShape2(in, outMain, outSide)
-
-  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
-
-      private var pendingElement: Option[T] = None
-      private var mainReady = false
-      private var sideReady = false
-
-      override def onPush(): Unit = {
-        val elem = grab(in)
-        if (isClosed(outSide)) {
-          push(outMain, elem)
-        } else if (mainReady && sideReady) {
-          push(outMain, elem)
-          push(outSide, elem)
-          mainReady = false
-          sideReady = false
-        } else {
-          pendingElement = Some(elem)
-        }
-      }
-
-      override def onPull(): Unit = {
-        mainReady = true
-        tryPushAndPull()
-      }
-
-      override def onDownstreamFinish(cause: Throwable): Unit =
-        cancelStage(cause)
-
-      private def tryPushAndPull(): Unit = {
-        pendingElement match {
-          case Some(elem) =>
-            if (isClosed(outSide)) {
-              push(outMain, elem)
-              pendingElement = None
-              mainReady = false
-            } else if (mainReady && sideReady) {
-              push(outMain, elem)
-              push(outSide, elem)
-              pendingElement = None
-              mainReady = false
-              sideReady = false
-            }
-          case None =>
-            if (mainReady && (sideReady || isClosed(outSide)) && !hasBeenPulled(in))
-              pull(in)
-        }
-      }
-
-      setHandler(
-        outSide,
-        new OutHandler {
-          override def onPull(): Unit = {
-            sideReady = true
-            tryPushAndPull()
-          }
-
-          override def onDownstreamFinish(cause: Throwable): Unit = {
-            if (!cause.isInstanceOf[SubscriptionWithCancelException.NonFailureCancellation])
-              log.warning("ResilientAlsoTo: side sink failed, continuing main stream: {}", cause.getMessage)
-            else
-              log.debug("ResilientAlsoTo: side sink cancelled")
-            pendingElement match {
-              case Some(elem) =>
-                if (mainReady) {
-                  push(outMain, elem)
-                  mainReady = false
-                }
-                pendingElement = None
-              case None =>
-            }
-            sideReady = false
-            setHandler(in,
-              new InHandler {
-                override def onPush(): Unit =
-                  push(outMain, grab(in))
-              })
-            if (mainReady && !hasBeenPulled(in))
-              pull(in)
-          }
-        })
-
-      setHandlers(in, outMain, this)
-    }
-
-  override def toString = "ResilientAlsoTo"
 }
 
 object Partition {

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
@@ -30,7 +30,7 @@ import pekko.stream.impl._
 import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.impl.fusing.GraphStages
 import pekko.stream.scaladsl.Partition.PartitionOutOfBoundsException
-import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler, StageLogging }
 import pekko.util.ConstantFun
 
 /**
@@ -779,6 +779,110 @@ private[stream] final class WireTap[T] extends GraphStage[FanOutShape2[T, T, T]]
       setHandlers(in, outMain, this)
     }
   override def toString = "WireTap"
+}
+
+/**
+ * INTERNAL API
+ *
+ * A `Broadcast`-like stage with two outputs where cancellation of the side output (out1)
+ * does not cancel the stage. Elements continue flowing to the main output (out0) after
+ * the side output cancels or fails. Cancellation of the main output cancels the stage.
+ *
+ * Backpressures when either output backpressures (same contract as `alsoTo` / `Broadcast`).
+ */
+private[pekko] final class ResilientAlsoTo[T] extends GraphStage[FanOutShape2[T, T, T]] {
+  val in: Inlet[T] = Inlet[T]("ResilientAlsoTo.in")
+  val outMain: Outlet[T] = Outlet[T]("ResilientAlsoTo.outMain")
+  val outSide: Outlet[T] = Outlet[T]("ResilientAlsoTo.outSide")
+  override def initialAttributes: Attributes = DefaultAttributes.resilientAlsoTo
+  override val shape: FanOutShape2[T, T, T] = new FanOutShape2(in, outMain, outSide)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
+
+      private var pendingElement: Option[T] = None
+      private var mainReady = false
+      private var sideReady = false
+
+      override def onPush(): Unit = {
+        val elem = grab(in)
+        if (isClosed(outSide)) {
+          push(outMain, elem)
+        } else if (mainReady && sideReady) {
+          push(outMain, elem)
+          push(outSide, elem)
+          mainReady = false
+          sideReady = false
+        } else {
+          pendingElement = Some(elem)
+        }
+      }
+
+      override def onPull(): Unit = {
+        mainReady = true
+        tryPushAndPull()
+      }
+
+      override def onDownstreamFinish(cause: Throwable): Unit =
+        cancelStage(cause)
+
+      private def tryPushAndPull(): Unit = {
+        pendingElement match {
+          case Some(elem) =>
+            if (isClosed(outSide)) {
+              push(outMain, elem)
+              pendingElement = None
+              mainReady = false
+            } else if (mainReady && sideReady) {
+              push(outMain, elem)
+              push(outSide, elem)
+              pendingElement = None
+              mainReady = false
+              sideReady = false
+            }
+          case None =>
+            if (mainReady && (sideReady || isClosed(outSide)) && !hasBeenPulled(in))
+              pull(in)
+        }
+      }
+
+      setHandler(
+        outSide,
+        new OutHandler {
+          override def onPull(): Unit = {
+            sideReady = true
+            tryPushAndPull()
+          }
+
+          override def onDownstreamFinish(cause: Throwable): Unit = {
+            if (!cause.isInstanceOf[SubscriptionWithCancelException.NonFailureCancellation])
+              log.warning("ResilientAlsoTo: side sink failed, continuing main stream: {}", cause.getMessage)
+            else
+              log.debug("ResilientAlsoTo: side sink cancelled")
+            pendingElement match {
+              case Some(elem) =>
+                if (mainReady) {
+                  push(outMain, elem)
+                  mainReady = false
+                }
+                pendingElement = None
+              case None =>
+            }
+            sideReady = false
+            setHandler(in,
+              new InHandler {
+                override def onPush(): Unit =
+                  push(outMain, grab(in))
+              })
+            if (mainReady && !hasBeenPulled(in))
+              pull(in)
+          }
+        })
+
+      setHandlers(in, outMain, this)
+    }
+
+  override def toString = "ResilientAlsoTo"
 }
 
 object Partition {

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/SourceWithContext.scala
@@ -166,6 +166,10 @@ final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (delegate: Sourc
   override def alsoTo(that: Graph[SinkShape[Out], ?]): Repr[Out, Ctx] =
     SourceWithContext.fromTuples(delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, Ctx)) => in._1)))
 
+  override def alsoTo(that: Graph[SinkShape[Out], ?], propagateCancellation: Boolean): Repr[Out, Ctx] =
+    SourceWithContext.fromTuples(
+      delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, Ctx)) => in._1), propagateCancellation))
+
   override def alsoToContext(that: Graph[SinkShape[Ctx], ?]): Repr[Out, Ctx] =
     SourceWithContext.fromTuples(delegate.alsoTo(Sink.contramapImpl(that, (in: (Out, Ctx)) => in._2)))
 


### PR DESCRIPTION
### Motivation

`alsoTo` uses `Broadcast[Out](2, eagerCancel = true)` internally. When the side sink fails or cancels, the entire stream is terminated. Users cannot isolate the side sink — for example, a fire-and-forget logging sink should not kill the main business stream when the logging destination is temporarily unavailable.

Fixes #3104.

### Modification

Add a new `alsoTo(sink, propagateCancellation: Boolean)` overload to both Scala and Java DSLs:

- When `propagateCancellation = true` (default), behavior is identical to existing `alsoTo`
- When `propagateCancellation = false`, a new `ResilientAlsoTo` GraphStage is used that:
  - Backpressures when either output backpressures (same contract as `alsoTo`/`Broadcast`)
  - When the side sink cancels or fails, logs a warning and continues forwarding to main downstream only
  - When the main downstream cancels, cancels the side sink normally

Changes:
- New `ResilientAlsoTo` GraphStage in `Graph.scala`
- `alsoTo(Graph, Boolean)` and `alsoToMat(Graph, Boolean)(matF)` overloads in `FlowOps`/`FlowOpsMat`
- Java DSL overloads: `Flow`, `Source`, `SubFlow`, `SubSource`
- Java DSL `alsoToMat(Graph, Boolean, Function2)` overloads: `Flow`, `Source`
- `FlowWithContext`/`SourceWithContext` overrides
- `DefaultAttributes.resilientAlsoTo` for stage naming

### Result

Users can now use `alsoTo(sink, propagateCancellation = false)` to fire-and-forget to a side sink without risking main stream termination. Default behavior is unchanged and fully backwards-compatible.

### Tests

- `FlowAlsoToSpec`: 11/11 passed — covers both propagation modes, upstream failure, backpressure, side cancellation scenarios
- `DslConsistencySpec`: 12/12 passed — Scala/Java DSL consistency verified
- `FlowAlsoToAllSpec`: 2/2 passed — no regression

```
sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.FlowAlsoToSpec"
```

### References

Fixes #3104