### PR TITLE
refactor: use CompletableFuture.orTimeout in FutureTimeoutSupport

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/pattern/FutureTimeoutSupport.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/FutureTimeoutSupport.scala
@@ -134,23 +134,18 @@ trait FutureTimeoutSupport {
       catch {
         case NonFatal(t) => CompletableFuture.failedStage(t)
       }
-    if (stage.toCompletableFuture.isDone) {
-      stage
-    } else {
-      val p = new CompletableFuture[T]
-      val timeout = using.scheduleOnce(duration,
-        () => {
-          p.completeExceptionally(new TimeoutException(s"Timeout of $duration expired"))
-          stage.toCompletableFuture.cancel(true)
-          ()
-        })
-      stage.handle[Unit]((v: T, ex: Throwable) => {
-        timeout.cancel()
-        if (v != null) p.complete(v)
-        if (ex ne null) p.completeExceptionally(ex)
+    val millis = if (duration.isZero || duration.isNegative) 0L else duration.toMillis
+    val timeoutMessage = s"Timeout of $duration expired"
+    stage.toCompletableFuture
+      .orTimeout(millis, java.util.concurrent.TimeUnit.MILLISECONDS)
+      .handle((v: T, ex: Throwable) => {
+        if (ex ne null) {
+          ex match {
+            case _: TimeoutException => throw new TimeoutException(timeoutMessage)
+            case _                   => throw ex
+          }
+        } else v
       })
-      p
-    }
   }
 
 }

--- a/actor/src/main/scala/org/apache/pekko/pattern/FutureTimeoutSupport.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/FutureTimeoutSupport.scala
@@ -135,13 +135,14 @@ trait FutureTimeoutSupport {
         case NonFatal(t) => CompletableFuture.failedStage(t)
       }
     val millis = if (duration.isZero || duration.isNegative) 0L else duration.toMillis
-    val timeoutMessage = s"Timeout of $duration expired"
+    // Note: no explicit `isDone` fast-path is needed here because
+    // `CompletableFuture.orTimeout` already short-circuits on an already-completed stage.
     stage.toCompletableFuture
       .orTimeout(millis, java.util.concurrent.TimeUnit.MILLISECONDS)
       .handle((v: T, ex: Throwable) => {
         if (ex ne null) {
           ex match {
-            case _: TimeoutException => throw new TimeoutException(timeoutMessage)
+            case _: TimeoutException => throw new TimeoutException(s"Timeout of $duration expired")
             case _                   => throw ex
           }
         } else v


### PR DESCRIPTION
### Motivation

`FutureTimeoutSupport.timeoutCompletionStage` was `@deprecated("Use CompletableFuture#orTimeout instead.", "2.0.0")` but still used a manual `Scheduler`-based implementation internally with `scheduleOnce` + `completeExceptionally(new TimeoutException(...))`.

### Modification

Rewrite `timeoutCompletionStage` to delegate to `CompletableFuture.orTimeout()`. A `handle()` wrapper provides a consistent timeout message (`"Timeout of $duration expired"`) across JDK versions — JDK 25's `orTimeout` produces a null `TimeoutException` message, unlike JDK 17 which included a descriptive message. The `Scheduler` parameter is retained for API compatibility but no longer used.

### Result

- Simpler implementation (~5 fewer lines)
- No `Scheduler` dependency for timeout scheduling (uses JDK shared `ForkJoinPool`)
- Consistent timeout exception messages across JDK versions
- `orTimeout` still cancels the underlying future on timeout (same behavior as before)

### Tests

- `sbt "actor-tests / Test / testOnly org.apache.pekko.pattern.PatternsTest"` — 33/33 passed

### References

Refs #3136