### PR TITLE
refactor: simplify Collections.unmodifiableSet(emptySet()) to Set.of()

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
@@ -13,6 +13,7 @@
 
 package org.apache.pekko.stream.impl.fusing
 
+import java.util.Collections
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.{ nowarn, tailrec }
@@ -398,7 +399,7 @@ import pekko.util.OptionVal
       lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
       private val activeSubstreamsMap = new java.util.HashMap[Any, SubstreamSource]()
       private val closedSubstreams =
-        if (allowClosedSubstreamRecreation) java.util.Set.of[Any]()
+        if (allowClosedSubstreamRecreation) Collections.emptySet[Any]
         else new java.util.HashSet[Any]()
       private val timeout: FiniteDuration =
         inheritedAttributes.mandatoryAttribute[ActorAttributes.StreamSubscriptionTimeout].timeout

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.impl.fusing
 
-import java.util.Collections
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.{ nowarn, tailrec }
@@ -399,7 +398,7 @@ import pekko.util.OptionVal
       lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
       private val activeSubstreamsMap = new java.util.HashMap[Any, SubstreamSource]()
       private val closedSubstreams =
-        if (allowClosedSubstreamRecreation) Collections.unmodifiableSet(Collections.emptySet[Any])
+        if (allowClosedSubstreamRecreation) java.util.Set.of[Any]()
         else new java.util.HashSet[Any]()
       private val timeout: FiniteDuration =
         inheritedAttributes.mandatoryAttribute[ActorAttributes.StreamSubscriptionTimeout].timeout


### PR DESCRIPTION
### Motivation

`StreamOfStreams.scala` uses `Collections.unmodifiableSet(Collections.emptySet[Any])` — two method calls to create an immutable empty set.

### Modification

Replace with `java.util.Set.of[Any]()` — a single JDK 9 factory call that already returns an immutable empty set. Remove the unused `java.util.Collections` import.

### Result

Cleaner code: one call instead of two. Both approaches produce immutable empty sets with identical semantics.

### Tests

- `sbt "stream/compile"` — passed

### References

Refs #3136