### PR TITLE
refactor: use ByteBuffer fluent API chains with JDK 9 covariant returns

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
@@ -267,10 +267,8 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
       @tailrec def innerRead(buffer: ByteBuffer, remainingLimit: Int): ReadResult =
         if (remainingLimit > 0) {
           // never read more than the configured limit
-          buffer.clear()
           val maxBufferSpace = math.min(DirectBufferSize, remainingLimit)
-          buffer.limit(maxBufferSpace)
-          val readBytes = channel.read(buffer)
+          val readBytes = channel.read(buffer.clear().limit(maxBufferSpace))
           buffer.flip()
 
           if (TraceLogging) log.debug("Read [{}] bytes.", readBytes)

--- a/actor/src/main/scala/org/apache/pekko/io/UdpConnection.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/UdpConnection.scala
@@ -130,10 +130,7 @@ private[io] class UdpConnection(
 
   def doRead(registration: ChannelRegistration, handler: ActorRef): Unit = {
     @tailrec def innerRead(readsLeft: Int, buffer: ByteBuffer): Unit = {
-      buffer.clear()
-      buffer.limit(DirectBufferSize)
-
-      if (channel.read(buffer) > 0) {
+      if (channel.read(buffer.clear().limit(DirectBufferSize)) > 0) {
         buffer.flip()
         handler ! Received(ByteString(buffer))
         innerRead(readsLeft - 1, buffer)

--- a/actor/src/main/scala/org/apache/pekko/io/UdpListener.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/UdpListener.scala
@@ -101,10 +101,7 @@ private[io] class UdpListener(val udp: UdpExt, channelRegistry: ChannelRegistry,
 
   def doReceive(registration: ChannelRegistration, handler: ActorRef): Unit = {
     @tailrec def innerReceive(readsLeft: Int, buffer: ByteBuffer): Unit = {
-      buffer.clear()
-      buffer.limit(DirectBufferSize)
-
-      channel.receive(buffer) match {
+      channel.receive(buffer.clear().limit(DirectBufferSize)) match {
         case sender: InetSocketAddress =>
           buffer.flip()
           handler ! Received(ByteString(buffer), sender)

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/TlsEngineHelpers.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/TlsEngineHelpers.scala
@@ -29,8 +29,7 @@ import org.apache.pekko.annotation.InternalApi
 
   @inline
   def emptyReadBuffer(buffer: ByteBuffer): Unit = {
-    buffer.clear()
-    buffer.flip()
+    buffer.clear().flip()
   }
 
   @inline


### PR DESCRIPTION
### Motivation

JDK 9 changed `ByteBuffer.clear()`, `limit(int)`, `flip()`, `rewind()` to return `ByteBuffer` instead of `Buffer`, enabling fluent method chaining. Previously these returned `Buffer`, requiring either explicit casts or separate statements.

### Modification

Consolidate separate `buffer.clear()` + `buffer.limit(n)` statements into single expressions passed directly to `channel.read()`/`channel.receive()`. Chain `buffer.clear().flip()` in `TlsEngineHelpers.emptyReadBuffer`.

| File | Before | After |
|------|--------|-------|
| `TcpConnection.innerRead` | 4 statements | 3 statements |
| `UdpConnection.innerRead` | 3 statements | 1 statement |
| `UdpListener.innerReceive` | 3 statements | 1 statement |
| `TlsEngineHelpers.emptyReadBuffer` | 2 statements | 1 statement |

### Result

More concise I/O code leveraging JDK 9+ ByteBuffer covariant returns. Semantically identical — clear/limit/flip execution order unchanged.

### Tests

- `sbt "actor-tests / Test / testOnly org.apache.pekko.io.TcpConnectionSpec"` — 34/34 passed
- `sbt "actor-tests / Test / testOnly org.apache.pekko.io.UdpIntegrationSpec"` — 7/7 passed

### References

Refs #3136