### PR TITLE
docs: update Scaladoc examples from Arrays.asList to List.of

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -1621,7 +1621,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Examples:
    *
    * {{{
-   * Source<Integer, ?> nums = Source.from(Arrays.asList(0, 1, 2, 3));
+   * Source<Integer, ?> nums = Source.from(List.of(0, 1, 2, 3));
    * nums.intersperse(",");            //   1 , 2 , 3
    * nums.intersperse("[", ",", "]");  // [ 1 , 2 , 3 ]
    * }}}
@@ -1655,7 +1655,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Examples:
    *
    * {{{
-   * Source<Integer, ?> nums = Source.from(Arrays.asList(0, 1, 2, 3));
+   * Source<Integer, ?> nums = Source.from(List.of(0, 1, 2, 3));
    * nums.intersperse(",");            //   1 , 2 , 3
    * nums.intersperse("[", ",", "]");  // [ 1 , 2 , 3 ]
    * }}}
@@ -3390,8 +3390,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * Example:
    * {{{
-   * Source<Integer, ?> src = Source.from(Arrays.asList(1, 2, 3))
-   * Flow<Integer, Integer, ?> flow = flow.interleave(Source.from(Arrays.asList(4, 5, 6, 7)), 2)
+   * Source<Integer, ?> src = Source.from(List.of(1, 2, 3))
+   * Flow<Integer, Integer, ?> flow = flow.interleave(Source.from(List.of(4, 5, 6, 7)), 2)
    * src.via(flow) // 1, 2, 4, 5, 3, 6, 7
    * }}}
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Graph.scala
@@ -726,7 +726,7 @@ object GraphDSL extends GraphCreate {
       : Graph[S, java.util.List[M]] = {
     require(!graphs.isEmpty, "The input list must have one or more Graph elements")
     val gbuilder = builder[java.util.List[M]]()
-    val toList = (m1: M) => new util.ArrayList(util.Arrays.asList(m1))
+    val toList = (m1: M) => new util.ArrayList(util.List.of(m1))
     val combine = (s: java.util.List[M], m2: M) => {
       val newList = new util.ArrayList(s)
       newList.add(m2)

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Graph.scala
@@ -726,7 +726,7 @@ object GraphDSL extends GraphCreate {
       : Graph[S, java.util.List[M]] = {
     require(!graphs.isEmpty, "The input list must have one or more Graph elements")
     val gbuilder = builder[java.util.List[M]]()
-    val toList = (m1: M) => new util.ArrayList(util.List.of(m1))
+    val toList = (m1: M) => util.List.of(m1)
     val combine = (s: java.util.List[M], m2: M) => {
       val newList = new util.ArrayList(s)
       newList.add(m2)

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -1514,7 +1514,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * Example:
    * {{{
-   * Source.from(List.of(1, 2, 3)).interleave(Source.from(List.of(4, 5, 6, 7), 2)
+   * Source.from(List.of(1, 2, 3)).interleave(Source.from(List.of(4, 5, 6, 7)), 2)
    * // 1, 2, 4, 5, 3, 6, 7
    * }}}
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -128,7 +128,7 @@ object Source {
    * Example usage:
    *
    * {{{
-   * Source.cycle(() -> Arrays.asList(1, 2, 3).iterator());
+   * Source.cycle(() -> List.of(1, 2, 3).iterator());
    * }}}
    *
    * Start a new 'cycled' `Source` from the given elements. The producer stream of elements
@@ -1514,7 +1514,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * Example:
    * {{{
-   * Source.from(Arrays.asList(1, 2, 3)).interleave(Source.from(Arrays.asList(4, 5, 6, 7), 2)
+   * Source.from(List.of(1, 2, 3)).interleave(Source.from(List.of(4, 5, 6, 7), 2)
    * // 1, 2, 4, 5, 3, 6, 7
    * }}}
    *
@@ -3504,7 +3504,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Examples:
    *
    * {{{
-   * Source<Integer, ?> nums = Source.from(Arrays.asList(0, 1, 2, 3));
+   * Source<Integer, ?> nums = Source.from(List.of(0, 1, 2, 3));
    * nums.intersperse(",");            //   1 , 2 , 3
    * nums.intersperse("[", ",", "]");  // [ 1 , 2 , 3 ]
    * }}}
@@ -3537,7 +3537,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Examples:
    *
    * {{{
-   * Source<Integer, ?> nums = Source.from(Arrays.asList(0, 1, 2, 3));
+   * Source<Integer, ?> nums = Source.from(List.of(0, 1, 2, 3));
    * nums.intersperse(",");            //   1 , 2 , 3
    * nums.intersperse("[", ",", "]");  // [ 1 , 2 , 3 ]
    * }}}

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -1013,7 +1013,7 @@ final class SubFlow[In, Out, Mat](
    * Examples:
    *
    * {{{
-   * Source<Integer, ?> nums = Source.from(Arrays.asList(0, 1, 2, 3));
+   * Source<Integer, ?> nums = Source.from(List.of(0, 1, 2, 3));
    * nums.intersperse(",");            //   1 , 2 , 3
    * nums.intersperse("[", ",", "]");  // [ 1 , 2 , 3 ]
    * }}}
@@ -1047,7 +1047,7 @@ final class SubFlow[In, Out, Mat](
    * Examples:
    *
    * {{{
-   * Source<Integer, ?> nums = Source.from(Arrays.asList(0, 1, 2, 3));
+   * Source<Integer, ?> nums = Source.from(List.of(0, 1, 2, 3));
    * nums.intersperse(",");            //   1 , 2 , 3
    * nums.intersperse("[", ",", "]");  // [ 1 , 2 , 3 ]
    * }}}

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -999,7 +999,7 @@ final class SubSource[Out, Mat](
    * Examples:
    *
    * {{{
-   * Source<Integer, ?> nums = Source.from(Arrays.asList(0, 1, 2, 3));
+   * Source<Integer, ?> nums = Source.from(List.of(0, 1, 2, 3));
    * nums.intersperse(",");            //   1 , 2 , 3
    * nums.intersperse("[", ",", "]");  // [ 1 , 2 , 3 ]
    * }}}
@@ -1033,7 +1033,7 @@ final class SubSource[Out, Mat](
    * Examples:
    *
    * {{{
-   * Source<Integer, ?> nums = Source.from(Arrays.asList(0, 1, 2, 3));
+   * Source<Integer, ?> nums = Source.from(List.of(0, 1, 2, 3));
    * nums.intersperse(",");            //   1 , 2 , 3
    * nums.intersperse("[", ",", "]");  // [ 1 , 2 , 3 ]
    * }}}
@@ -2354,7 +2354,7 @@ final class SubSource[Out, Mat](
    *
    * Example:
    * {{{
-   * Source.from(Arrays.asList(1, 2, 3)).interleave(Source.from(Arrays.asList(4, 5, 6, 7), 2)
+   * Source.from(List.of(1, 2, 3)).interleave(Source.from(List.of(4, 5, 6, 7), 2)
    * // 1, 2, 4, 5, 3, 6, 7
    * }}}
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -2354,7 +2354,7 @@ final class SubSource[Out, Mat](
    *
    * Example:
    * {{{
-   * Source.from(List.of(1, 2, 3)).interleave(Source.from(List.of(4, 5, 6, 7), 2)
+   * Source.from(List.of(1, 2, 3)).interleave(Source.from(List.of(4, 5, 6, 7)), 2)
    * // 1, 2, 4, 5, 3, 6, 7
    * }}}
    *


### PR DESCRIPTION
### Motivation

Scaladoc examples in the Stream Java DSL use `Arrays.asList(...)` which creates a mutable fixed-size list backed by an array.

Also updates production code in `org.apache.pekko.stream.javadsl.Graph` to use `List.of` to create an immutable List.

### Modification

Replace with `List.of(...)` (JDK 9 factory) which returns a truly immutable list, consistent with modern Java best practices. Also updates the executable `Graph.scala` code where `util.Arrays.asList` was used.

### Result

Documentation examples use idiomatic JDK 9+ API.

### Tests

CI

### References

Refs #3136