### PR TITLE
refactor: use StackWalker for stack trace inspection in TestKitUtils

### DIFF
--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
@@ -13,7 +13,9 @@
 
 package org.apache.pekko.testkit
 
+import java.lang.StackWalker.StackFrame
 import java.lang.reflect.Modifier
+import java.util.stream.{ Stream => JStream }
 
 import scala.util.matching.Regex
 
@@ -24,6 +26,10 @@ import org.apache.pekko.annotation.InternalApi
  */
 @InternalApi
 private[pekko] object TestKitUtils {
+
+  private val stackWalker: java.util.function.Function[JStream[StackFrame], Array[String]] =
+    (frames: JStream[StackFrame]) =>
+      frames.map(_.getClassName).toArray[String]((size: Int) => new Array[String](size))
 
   def testNameFromCallStack(classToStartFrom: Class[?], testKitRegex: Regex): String = {
 
@@ -36,8 +42,8 @@ private[pekko] object TestKitUtils {
     }
 
     val startFrom = classToStartFrom.getName
-    val filteredStack = Thread.currentThread.getStackTrace.iterator
-      .map(_.getClassName)
+    val classNames = StackWalker.getInstance().walk(stackWalker)
+    val filteredStack = classNames.iterator
       // drop until we find the first occurrence of classToStartFrom
       .dropWhile(!_.startsWith(startFrom))
       // then continue to the next entry after classToStartFrom that makes sense


### PR DESCRIPTION
### Motivation

`TestKitUtils.testNameFromCallStack` uses `Thread.currentThread.getStackTrace` which eagerly constructs the full `StackTraceElement[]` array including method names, file names, and line numbers — but only class names are needed.

### Modification

Replace with `StackWalker` (JDK 9) which avoids creating full `StackTraceElement` objects, only extracting class names via the lighter `StackFrame.getClassName()`. The existing filtering logic (`dropWhile` + `startsWith` matching) is preserved unchanged.

This follows the pattern already established by `LoggerClass.scala` in the same codebase.

### Result

More efficient stack inspection for test infrastructure.

### Tests

- `sbt "actor-tests / Test / testOnly org.apache.pekko.actor.ActorSystemSpec"` — 20/20 passed

### References

Refs #3136