### PR TITLE
fix: remove redundant Float cast in CountMinSketch pattern match

### DIFF
--- a/remote/src/main/java/org/apache/pekko/remote/artery/compress/CountMinSketch.java
+++ b/remote/src/main/java/org/apache/pekko/remote/artery/compress/CountMinSketch.java
@@ -178,7 +178,7 @@ public class CountMinSketch {
         return hashLong(Double.doubleToRawLongBits(d), 0);
       }
       if (o instanceof Float f) {
-        return hashLong(Float.floatToRawIntBits((Float) o), 0);
+        return hashLong(Float.floatToRawIntBits(f), 0);
       }
       if (o instanceof byte[] array) {
         return bytesHash(array, 0);


### PR DESCRIPTION
### Motivation

`CountMinSketch.java` line 181 uses `(Float) o` cast inside an `instanceof Float f` pattern match. The pattern variable `f` is already bound to the Float value, making the explicit cast redundant.

### Modification

Use the pattern variable `f` directly instead of `(Float) o`.

### Result

Cleaner code, no functional change.

### Tests

- `sbt "remote/compile"` — passed

### References

Refs #3136