### PR TITLE
refactor: use Files.readString() in PemManagersProvider

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.remote.artery.tcp.ssl
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.security.{ KeyStore, PrivateKey }
 import java.security.cert.{ Certificate, CertificateFactory, X509Certificate }
@@ -73,7 +74,7 @@ private[ssl] object PemManagersProvider {
    */
   @InternalApi
   private[ssl] def loadPrivateKey(filename: String): PrivateKey = blocking {
-    val pemData = Files.readString(new File(filename).toPath)
+    val pemData = Files.readString(new File(filename).toPath, StandardCharsets.UTF_8)
     DERPrivateKeyLoader.load(PEMDecoder.decode(pemData))
   }
 

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.remote.artery.tcp.ssl
 
 import java.io.File
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.security.{ KeyStore, PrivateKey }
 import java.security.cert.{ Certificate, CertificateFactory, X509Certificate }
@@ -74,8 +73,7 @@ private[ssl] object PemManagersProvider {
    */
   @InternalApi
   private[ssl] def loadPrivateKey(filename: String): PrivateKey = blocking {
-    val bytes = Files.readAllBytes(new File(filename).toPath)
-    val pemData = new String(bytes, StandardCharsets.UTF_8)
+    val pemData = Files.readString(new File(filename).toPath)
     DERPrivateKeyLoader.load(PEMDecoder.decode(pemData))
   }
 


### PR DESCRIPTION
### Motivation

`PemManagersProvider.loadPrivateKey` reads a PEM file with `Files.readAllBytes()` and immediately converts to `String` via `new String(bytes, StandardCharsets.UTF_8)`.

### Modification

Replace with `Files.readString()` (JDK 11) which reads a file directly into a `String` using UTF-8 by default. Remove the unused `StandardCharsets` import.

### Result

Eliminates intermediate `byte[]` allocation and explicit charset conversion. One line instead of two.

### Tests

- `sbt "remote/compile"` — passed

### References

Refs #3136