### PR TITLE
refactor: use String.formatted() instead of String.format()

### DIFF
--- a/actor/src/main/java/org/apache/pekko/io/UnsynchronizedByteArrayInputStream.java
+++ b/actor/src/main/java/org/apache/pekko/io/UnsynchronizedByteArrayInputStream.java
@@ -54,7 +54,7 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
     final int arrayLength = Objects.requireNonNull(array, "byte array").length;
     if ((off | len | arrayLength) < 0 || arrayLength - len < off) {
       throw new IndexOutOfBoundsException(
-          String.format("Range [%s, %<s + %s) out of bounds for length %s", off, len, arrayLength));
+          "Range [%s, %<s + %s) out of bounds for length %s".formatted(off, len, arrayLength));
     }
   }
 

--- a/remote/src/main/java/org/apache/pekko/remote/artery/aeron/AeronErrorLog.java
+++ b/remote/src/main/java/org/apache/pekko/remote/artery/aeron/AeronErrorLog.java
@@ -65,12 +65,12 @@ public class AeronErrorLog {
             lastObservationTimestamp,
             encodedException) -> {
           log.error(
-              String.format(
-                  "Aeron error: %d observations from %s to %s for:%n %s",
-                  observationCount,
-                  Helpers.timestamp(firstObservationTimestamp),
-                  Helpers.timestamp(lastObservationTimestamp),
-                  encodedException));
+              "Aeron error: %d observations from %s to %s for:%n %s"
+                  .formatted(
+                      observationCount,
+                      Helpers.timestamp(firstObservationTimestamp),
+                      Helpers.timestamp(lastObservationTimestamp),
+                      encodedException));
           lastTimestamp.set(Math.max(lastTimestamp.get(), lastObservationTimestamp));
         },
         sinceTimestamp);


### PR DESCRIPTION
### Motivation

`String.format(fmt, args)` is a static method call. JDK 15 added `String.formatted(args)` as a fluent instance method on the format string itself.

### Modification

Replace 2 occurrences of `String.format(fmt, args)` with `fmt.formatted(args)`:
- `UnsynchronizedByteArrayInputStream.java`: range check error message
- `AeronErrorLog.java`: Aeron error logging

### Result

More readable fluent API style, functionally identical.

### Tests

- `sbt "actor/compile" "remote/compile"` — passed

### References

Refs #3136