### PR TITLE
refactor: use HexFormat for hex encoding instead of manual formatting

### DIFF
--- a/cluster/src/main/scala/org/apache/pekko/cluster/VectorClock.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/VectorClock.scala
@@ -37,10 +37,12 @@ private[cluster] object VectorClock {
 
     def fromHash(hash: String): Node = hash
 
+    private val hexFormat = java.util.HexFormat.of()
+
     private def hash(name: String): String = {
       val digester = MessageDigest.getInstance("MD5")
       digester.update(name.getBytes(StandardCharsets.UTF_8))
-      java.util.HexFormat.of().formatHex(digester.digest())
+      hexFormat.formatHex(digester.digest())
     }
   }
 

--- a/cluster/src/main/scala/org/apache/pekko/cluster/VectorClock.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/VectorClock.scala
@@ -40,9 +40,7 @@ private[cluster] object VectorClock {
     private def hash(name: String): String = {
       val digester = MessageDigest.getInstance("MD5")
       digester.update(name.getBytes(StandardCharsets.UTF_8))
-      digester.digest.map { h =>
-        "%02x".format(0xFF & h)
-      }.mkString
+      java.util.HexFormat.of().formatHex(digester.digest())
     }
   }
 

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/TcpFraming.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/TcpFraming.scala
@@ -85,7 +85,7 @@ import pekko.util.ByteString
         else
           throw new FramingException(
             "Stream didn't start with expected magic bytes, " +
-            s"got [${(magic ++ reader.remainingData).take(10).map("%02x".format(_)).mkString(" ")}] " +
+            s"got [${java.util.HexFormat.ofDelimiter(" ").formatHex((magic ++ reader.remainingData).take(10).toArray)}] " +
             "Connection is rejected. Probably invalid accidental access.")
       }
     }


### PR DESCRIPTION
### Motivation

Manual per-byte hex encoding with `"%02x".format()` is verbose and allocates a `String` per byte. JDK 17's `HexFormat` formats entire byte arrays in one call with zero intermediate allocations.

### Modification

- `VectorClock.scala`: Replace `digester.digest.map("%02x".format).mkString` with `HexFormat.of().formatHex(digester.digest())`
- `TcpFraming.scala`: Replace `.map("%02x".format).mkString(" ")` with `HexFormat.ofDelimiter(" ").formatHex(bytes.toArray)`

### Result

More concise code, fewer allocations (one `String` vs N+1 `String`s), standard JDK 17 API for hex encoding.

### Tests

- `sbt "cluster/compile" "remote/compile"` — passed

### References

Refs #3136