### PR TITLE
refactor: use StandardCharsets.UTF_8 with URLEncoder/URLDecoder

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/pattern/AskSupport.scala
+++ b/actor/src/main/scala/org/apache/pekko/pattern/AskSupport.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.pattern
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeoutException
 
 import scala.annotation.{ nowarn, tailrec }
@@ -28,7 +29,7 @@ import org.apache.pekko
 import pekko.actor._
 import pekko.annotation.{ InternalApi, InternalStableApi }
 import pekko.dispatch.sysmsg._
-import pekko.util.{ ByteString, Timeout }
+import pekko.util.Timeout
 
 /**
  * This is what is used to complete a Future that is returned from an ask/? call,
@@ -457,7 +458,7 @@ final class AskableActorSelection(val actorSel: ActorSelection) extends AnyVal {
         if (timeout.duration.length <= 0)
           Future.failed[Any](AskableActorRef.negativeTimeoutException(actorSel, message, sender))
         else {
-          val refPrefix = URLEncoder.encode(actorSel.pathString.replace("/", "_"), ByteString.UTF_8)
+          val refPrefix = URLEncoder.encode(actorSel.pathString.replace("/", "_"), StandardCharsets.UTF_8)
           PromiseActorRef(ref.provider, timeout, targetName = actorSel, message.getClass.getName, refPrefix, sender)
             .ask(actorSel, message, timeout)
         }
@@ -486,7 +487,7 @@ final class ExplicitlyAskableActorSelection(val actorSel: ActorSelection) extend
           val message = messageFactory(ref.provider.deadLetters)
           Future.failed[Any](AskableActorRef.negativeTimeoutException(actorSel, message, sender))
         } else {
-          val refPrefix = URLEncoder.encode(actorSel.pathString.replace("/", "_"), ByteString.UTF_8)
+          val refPrefix = URLEncoder.encode(actorSel.pathString.replace("/", "_"), StandardCharsets.UTF_8)
           val a = PromiseActorRef(ref.provider, timeout, targetName = actorSel, "unknown", refPrefix, sender)
           val message = messageFactory(a)
           a.messageClassName = message.getClass.getName

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.cluster.sharding.typed
 package internal
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.ConcurrentHashMap

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -52,7 +52,7 @@ import pekko.japi.function.{ Function => JFunction }
 import pekko.pattern.AskTimeoutException
 import pekko.pattern.PromiseActorRef
 import pekko.pattern.StatusReply
-import pekko.util.{ ByteString, Timeout }
+import pekko.util.Timeout
 
 /**
  * INTERNAL API
@@ -196,7 +196,7 @@ import pekko.util.{ ByteString, Timeout }
               override def apply(t: String): ActorRef[scaladsl.ClusterSharding.ShardCommand] = {
                 system.systemActorOf(
                   ShardCommandActor.behavior(stopMessage.getOrElse(PoisonPill)),
-                  URLEncoder.encode(typeKey.name, ByteString.UTF_8) + "ShardCommandDelegator")
+                  URLEncoder.encode(typeKey.name, StandardCharsets.UTF_8) + "ShardCommandDelegator")
               }
             })
 
@@ -334,7 +334,7 @@ import pekko.util.{ ByteString, Timeout }
       case _ => false
     }
 
-  override val refPrefix = URLEncoder.encode(s"${typeKey.name}-$entityId", ByteString.UTF_8)
+  override val refPrefix = URLEncoder.encode(s"${typeKey.name}-$entityId", StandardCharsets.UTF_8)
 
   override def tell(msg: M): Unit =
     shardRegion ! ShardingEnvelope(entityId, msg)

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ClusterSharding.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ClusterSharding.scala
@@ -50,7 +50,6 @@ import pekko.cluster.singleton.ClusterSingletonManager
 import pekko.event.Logging
 import pekko.pattern.BackoffOpts
 import pekko.pattern.ask
-import pekko.util.ByteString
 
 /**
  * This extension provides sharding functionality of actors in a cluster.
@@ -754,7 +753,7 @@ private[pekko] class ClusterShardingGuardian extends Actor {
       case Some(ref) => ref
       case None      =>
         val name = role match {
-          case Some(r) => URLEncoder.encode(r, ByteString.UTF_8) + "Replicator"
+          case Some(r) => URLEncoder.encode(r, StandardCharsets.UTF_8) + "Replicator"
           case None    => "replicator"
         }
         val ref = context.actorOf(Replicator.props(replicatorSettings(role, settings)), name)
@@ -799,7 +798,7 @@ private[pekko] class ClusterShardingGuardian extends Actor {
       settings: ClusterShardingSettings): Unit = {
     import settings.tuningParameters.coordinatorFailureBackoff
 
-    val encName = URLEncoder.encode(typeName, ByteString.UTF_8)
+    val encName = URLEncoder.encode(typeName, StandardCharsets.UTF_8)
     val cName = coordinatorSingletonManagerName(encName)
     if (settings.shouldHostCoordinator(cluster) && context.child(cName).isEmpty) {
       val coordinatorProps =
@@ -848,7 +847,7 @@ private[pekko] class ClusterShardingGuardian extends Actor {
           allocationStrategy,
           handOffStopMessage) =>
       try {
-        val encName = URLEncoder.encode(typeName, ByteString.UTF_8)
+        val encName = URLEncoder.encode(typeName, StandardCharsets.UTF_8)
         val cPath = coordinatorPath(encName)
         val shardRegion = context.child(encName).getOrElse {
           val remEntitiesStoreProvider = rememberEntitiesStoreProvider(typeName, settings)
@@ -880,12 +879,12 @@ private[pekko] class ClusterShardingGuardian extends Actor {
     case StartProxy(typeName, dataCenter, settings, extractEntityId, extractShardId) =>
       try {
 
-        val encName = URLEncoder.encode(s"${typeName}Proxy", ByteString.UTF_8)
-        val cPath = coordinatorPath(URLEncoder.encode(typeName, ByteString.UTF_8))
+        val encName = URLEncoder.encode(s"${typeName}Proxy", StandardCharsets.UTF_8)
+        val cPath = coordinatorPath(URLEncoder.encode(typeName, StandardCharsets.UTF_8))
         // it must be possible to start several proxies, one per data center
         val actorName = dataCenter match {
           case None    => encName
-          case Some(t) => URLEncoder.encode(typeName + "-" + t, ByteString.UTF_8)
+          case Some(t) => URLEncoder.encode(typeName + "-" + t, StandardCharsets.UTF_8)
         }
         val shardRegion = context.child(actorName).getOrElse {
           context.actorOf(

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ClusterSharding.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ClusterSharding.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.cluster.sharding
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/Shard.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/Shard.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.cluster.sharding
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util
 
 import scala.annotation.nowarn

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/Shard.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/Shard.scala
@@ -1128,7 +1128,7 @@ private[pekko] class Shard(
     entities.entity(id) match {
       case OptionVal.Some(child) => child
       case _                     =>
-        val name = URLEncoder.encode(id, "utf-8")
+        val name = URLEncoder.encode(id, StandardCharsets.UTF_8)
         val a = context.actorOf(entityProps(id), name)
         context.watchWith(a, EntityTerminated(a))
         log.debug("{}: Started entity [{}] with entity id [{}] in shard [{}]", typeName, a, id, shardId)

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
@@ -1341,7 +1341,7 @@ private[pekko] class ShardRegion(
         .orElse(entityProps match {
           case Some(props) if !shardsByRef.values.exists(_ == id) =>
             log.debug(ShardingLogMarker.shardStarted(typeName, id), "{}: Starting shard [{}] in region", typeName, id)
-            val name = URLEncoder.encode(id, "utf-8")
+            val name = URLEncoder.encode(id, StandardCharsets.UTF_8)
             val shard = context.watch(
               context.actorOf(
                 Shard

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.cluster.sharding
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 import scala.annotation.tailrec
 import scala.collection.immutable

--- a/cluster-tools/src/main/scala/org/apache/pekko/cluster/client/ClusterClient.scala
+++ b/cluster-tools/src/main/scala/org/apache/pekko/cluster/client/ClusterClient.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.cluster.client
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 import scala.collection.immutable
 import scala.collection.immutable.{ HashMap, HashSet }

--- a/cluster-tools/src/main/scala/org/apache/pekko/cluster/client/ClusterClient.scala
+++ b/cluster-tools/src/main/scala/org/apache/pekko/cluster/client/ClusterClient.scala
@@ -1007,7 +1007,7 @@ final class ClusterReceptionist(pubSubMediator: ActorRef, settings: ClusterRecep
   def matchingRole(m: Member): Boolean = role.forall(m.hasRole)
 
   def responseTunnel(client: ActorRef): ActorRef = {
-    val encName = URLEncoder.encode(client.path.toSerializationFormat, "utf-8")
+    val encName = URLEncoder.encode(client.path.toSerializationFormat, StandardCharsets.UTF_8)
     context.child(encName) match {
       case Some(tunnel) => tunnel
       case None         =>

--- a/cluster-tools/src/main/scala/org/apache/pekko/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/cluster-tools/src/main/scala/org/apache/pekko/cluster/pubsub/DistributedPubSubMediator.scala
@@ -341,7 +341,7 @@ object DistributedPubSubMediator {
       override def message = msg
     }
 
-    def encName(s: String) = URLEncoder.encode(s, "utf-8")
+    def encName(s: String) = URLEncoder.encode(s, StandardCharsets.UTF_8)
 
     def mkKey(ref: ActorRef): String = mkKey(ref.path)
 
@@ -845,7 +845,7 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings)
       if key.startsWith(topicPrefix)
       topic = key.substring(topicPrefix.length + 1)
       if !topic.contains('/') // exclude group topics
-    } yield URLDecoder.decode(topic, "utf-8")).toSet
+    } yield URLDecoder.decode(topic, StandardCharsets.UTF_8)).toSet
   }
 
   def registerTopic(ref: ActorRef): Unit = {

--- a/cluster-tools/src/main/scala/org/apache/pekko/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/cluster-tools/src/main/scala/org/apache/pekko/cluster/pubsub/DistributedPubSubMediator.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.cluster.pubsub
 
 import java.net.URLDecoder
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.ThreadLocalRandom
 
 import scala.collection.immutable

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.persistence.query.journal.leveldb.scaladsl
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 import scala.concurrent.duration._
 

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
@@ -31,7 +31,6 @@ import pekko.persistence.query.journal.leveldb.EventsByTagStage
 import pekko.persistence.query.scaladsl._
 import pekko.persistence.query.scaladsl.ReadJournal
 import pekko.stream.scaladsl.Source
-import pekko.util.ByteString
 
 import com.typesafe.config.Config
 
@@ -245,7 +244,7 @@ class LeveldbReadJournal(system: ExtendedActorSystem, config: Config)
                   writeJournalPluginId,
                   refreshInterval,
                   mat))
-              .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
+              .named("eventsByTag-" + URLEncoder.encode(tag, StandardCharsets.UTF_8))
 
           case NoOffset => eventsByTag(tag, Sequence(0L)) // recursive
           case _        =>
@@ -268,7 +267,7 @@ class LeveldbReadJournal(system: ExtendedActorSystem, config: Config)
             Source
               .fromGraph(
                 new EventsByTagStage(tag, seq.value, maxBufSize, Long.MaxValue, writeJournalPluginId, None, mat))
-              .named("currentEventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
+              .named("currentEventsByTag-" + URLEncoder.encode(tag, StandardCharsets.UTF_8))
           case NoOffset => currentEventsByTag(tag, Sequence(0L))
           case _        =>
             throw new IllegalArgumentException(

--- a/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/local/LocalSnapshotStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/local/LocalSnapshotStore.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.persistence.snapshot.local
 
 import java.io._
 import java.net.{ URLDecoder, URLEncoder }
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 
@@ -28,7 +29,6 @@ import pekko.persistence._
 import pekko.persistence.serialization._
 import pekko.persistence.snapshot._
 import pekko.serialization.SerializationExtension
-import pekko.util.ByteString.UTF_8
 
 import com.typesafe.config.Config
 
@@ -158,7 +158,7 @@ private[persistence] class LocalSnapshotStore(config: Config) extends SnapshotSt
   protected def snapshotFileForWrite(metadata: SnapshotMetadata, extension: String = ""): File =
     new File(
       snapshotDir(),
-      s"snapshot-${URLEncoder.encode(metadata.persistenceId, UTF_8)}-${metadata.sequenceNr}-${metadata.timestamp}$extension")
+      s"snapshot-${URLEncoder.encode(metadata.persistenceId, StandardCharsets.UTF_8)}-${metadata.sequenceNr}-${metadata.timestamp}$extension")
 
   private def snapshotMetadatas(
       persistenceId: String,
@@ -170,7 +170,7 @@ private[persistence] class LocalSnapshotStore(config: Config) extends SnapshotSt
         .map(_.getName)
         .flatMap { filename =>
           extractMetadata(filename).map {
-            case (pid, snr, tms) => SnapshotMetadata(URLDecoder.decode(pid, UTF_8), snr, tms)
+            case (pid, snr, tms) => SnapshotMetadata(URLDecoder.decode(pid, StandardCharsets.UTF_8), snr, tms)
           }
         }
         .filter(md => criteria.matches(md) && !saving.contains(md))

--- a/remote/src/main/scala/org/apache/pekko/remote/Remoting.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/Remoting.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.remote
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeoutException
 
@@ -39,7 +40,6 @@ import pekko.remote.Remoting.TransportSupervisor
 import pekko.remote.transport._
 import pekko.remote.transport.PekkoPduCodec.Message
 import pekko.remote.transport.Transport.{ ActorAssociationEventListener, AssociationEventListener, InboundAssociation }
-import pekko.util.ByteString.UTF_8
 import pekko.util.OptionVal
 
 import com.typesafe.config.Config
@@ -48,7 +48,7 @@ import com.typesafe.config.Config
  * INTERNAL API
  */
 private[remote] object AddressUrlEncoder {
-  def apply(address: Address): String = URLEncoder.encode(address.toString, UTF_8)
+  def apply(address: Address): String = URLEncoder.encode(address.toString, StandardCharsets.UTF_8)
 }
 
 /**

--- a/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.Optional
 
@@ -33,7 +34,6 @@ import pekko.annotation.InternalApi
 import pekko.event.Logging
 import pekko.japi.function
 import pekko.stream.impl.TraversalBuilder
-import pekko.util.ByteString
 import pekko.util.Helpers
 import pekko.util.LineNumbers
 
@@ -242,7 +242,7 @@ final class Attributes private[pekko] (
   }
 
   @InternalApi private[pekko] def nameForActorRef(default: String = "unnamed"): String = {
-    getName().map(name => URLEncoder.encode(name, ByteString.UTF_8)).getOrElse(default)
+    getName().map(name => URLEncoder.encode(name, StandardCharsets.UTF_8)).getOrElse(default)
   }
 
   /**


### PR DESCRIPTION
### Motivation

Multiple files pass charset as a `String` (`"utf-8"`) or via `ByteString.UTF_8` (which is `StandardCharsets.UTF_8.name()`) to `URLEncoder.encode` and `URLDecoder.decode`. JDK 10 added overloads that accept a `Charset` object directly, avoiding the checked `UnsupportedEncodingException` declaration.

### Modification

Replace `"utf-8"` and `ByteString.UTF_8` string arguments with `StandardCharsets.UTF_8` Charset object in 17 call sites across 8 files:
- `cluster-sharding`: `Shard.scala`, `ShardRegion.scala`, `ClusterSharding.scala`
- `cluster-sharding-typed`: `ClusterShardingImpl.scala`
- `cluster-tools`: `ClusterClient.scala`, `DistributedPubSubMediator.scala`
- `persistence-query`: `LeveldbReadJournal.scala`
- `stream`: `Attributes.scala`

Remove 4 unused `ByteString` imports.

### Result

Type-safe charset specification, no `UnsupportedEncodingException` declaration needed, removes `ByteString` dependency where it was only used for charset name constants.

### Tests

- `sbt "cluster-sharding/compile" "cluster-sharding-typed/compile" "cluster-tools/compile" "persistence-query/compile" "stream/compile"` — all passed

### References

Refs #3136