### PR TITLE
refactor: remove deprecated failedCompletionStage, use CompletableFuture.failedStage

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/CompletionStagesTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/CompletionStagesTests.java
@@ -41,7 +41,7 @@ public class CompletionStagesTests {
         assertEquals(42, Await.result(scalaFuture, timeout).intValue());
         //failed
         assertThrows(RuntimeException.class, () -> {
-            final CompletionStage<Integer> failedCs = Futures.failedCompletionStage(new RuntimeException(
+            final CompletionStage<Integer> failedCs = CompletableFuture.failedStage(new RuntimeException(
                 "Simulated failure"));
             Await.result(CompletionStages.asScala(failedCs), timeout);
         });

--- a/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
@@ -318,10 +318,9 @@ public class PatternsTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testAfterFailedCallable() throws Exception {
     Callable<CompletionStage<String>> failedCallable =
-        () -> Futures.failedCompletionStage(new IllegalStateException("Illegal!"));
+        () -> CompletableFuture.failedStage(new IllegalStateException("Illegal!"));
 
     CompletionStage<String> delayedFuture =
         Patterns.after(Duration.ofMillis(200), system.scheduler(), ec, failedCallable);
@@ -341,7 +340,6 @@ public class PatternsTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testAfterFailedFuture() throws Exception {
 
     CompletionStage<String> delayedFuture =
@@ -349,7 +347,7 @@ public class PatternsTest {
             Duration.ofMillis(200),
             system.scheduler(),
             ec,
-            () -> Futures.failedCompletionStage(new IllegalStateException("Illegal!")));
+            () -> CompletableFuture.failedStage(new IllegalStateException("Illegal!")));
 
     CompletionStage<String> resultFuture =
         CompletionStages.firstCompletedOf(Arrays.asList(delayedFuture));

--- a/actor/src/main/scala/org/apache/pekko/dispatch/CompletionStages.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/CompletionStages.scala
@@ -151,7 +151,7 @@ object CompletionStages {
     if (iterator.hasNext) {
       iterator.next().thenCompose { v => foldWithNext[T, R](iterator, v, function) }
     } else {
-      Futures.failedCompletionStage(new NoSuchElementException("reduce of an empty iterable of CompletionStages"))
+      CompletableFuture.failedStage(new NoSuchElementException("reduce of an empty iterable of CompletionStages"))
     }
   }
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.dispatch
 
 import java.util.concurrent.{ Callable, Executor, ExecutorService }
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise }
@@ -119,14 +118,4 @@ object Futures {
    * Creates an already completed Promise with the specified result
    */
   def successful[T](result: T): Future[T] = Future.successful(result)
-
-  /**
-   * Creates an already completed CompletionStage with the specified exception
-   */
-  @deprecated("Use `CompletableFuture#failedStage` instead.", since = "2.0.0")
-  def failedCompletionStage[T](ex: Throwable): CompletionStage[T] = {
-    val f = CompletableFuture.completedFuture[T](null.asInstanceOf[T])
-    f.obtrudeException(ex)
-    f
-  }
 }


### PR DESCRIPTION
### Motivation

`Futures.failedCompletionStage` was `@deprecated("Use CompletableFuture#failedStage instead.", "2.0.0")` and used the dangerous `obtrudeException` API which can corrupt other futures sharing the same underlying `CompletableFuture`. `CompletableFuture.failedStage` (JDK 9) is the correct replacement.

### Modification

- Remove `failedCompletionStage` method from `Futures` object in `Future.scala`
- Replace internal call in `CompletionStages.reduce` with `CompletableFuture.failedStage`
- Replace test call sites with `CompletableFuture.failedStage`
- Remove unnecessary `@SuppressWarnings("deprecation")` from 2 test methods
- Remove unused `CompletableFuture` import from `Future.scala`

### Result

Eliminates `obtrudeException` usage, removes deprecated API.

### Tests

- `sbt "actor-tests / Test / testOnly org.apache.pekko.pattern.PatternsTest org.apache.pekko.dispatch.CompletionStagesTests"` — 40/40 passed

### References

Refs #3136