### PR TITLE
perf: add Thread.onSpinWait() to CAS spin loops

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
@@ -255,7 +255,7 @@ abstract class MessageDispatcher(val configurator: MessageDispatcherConfigurator
           try {
             if (inhabitants == 0) shutdown() // Warning, racy
           } finally {
-            while (!updateShutdownSchedule(shutdownSchedule, UNSCHEDULED)) {}
+            while (!updateShutdownSchedule(shutdownSchedule, UNSCHEDULED)) { Thread.onSpinWait() }
           }
         case RESCHEDULED =>
           if (updateShutdownSchedule(RESCHEDULED, SCHEDULED)) scheduleShutdownAction()

--- a/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
@@ -190,18 +190,22 @@ abstract class MessageDispatcher(val configurator: MessageDispatcherConfigurator
     case _                    => eventStream.publish(Error(t, getClass.getName, getClass, t.getMessage))
   }
 
-  @tailrec
   private final def ifSensibleToDoSoThenScheduleShutdown(): Unit = {
-    if (inhabitants <= 0) shutdownSchedule match {
-      case UNSCHEDULED =>
-        if (updateShutdownSchedule(UNSCHEDULED, SCHEDULED)) scheduleShutdownAction()
-        else ifSensibleToDoSoThenScheduleShutdown()
-      case SCHEDULED =>
-        if (updateShutdownSchedule(SCHEDULED, RESCHEDULED)) ()
-        else ifSensibleToDoSoThenScheduleShutdown()
-      case RESCHEDULED =>
-      case unexpected  =>
-        throw new IllegalArgumentException(s"Unexpected actor class marker: $unexpected") // will not happen, for exhaustiveness check
+    while (inhabitants <= 0) {
+      shutdownSchedule match {
+        case UNSCHEDULED =>
+          if (updateShutdownSchedule(UNSCHEDULED, SCHEDULED)) {
+            scheduleShutdownAction()
+            return
+          }
+        case SCHEDULED =>
+          if (updateShutdownSchedule(SCHEDULED, RESCHEDULED)) return
+        case RESCHEDULED =>
+          return
+        case unexpected =>
+          throw new IllegalArgumentException(s"Unexpected actor class marker: $unexpected") // will not happen, for exhaustiveness check
+      }
+      Thread.onSpinWait()
     }
   }
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala
@@ -203,7 +203,7 @@ abstract class MessageDispatcher(val configurator: MessageDispatcherConfigurator
         case RESCHEDULED =>
           return
         case unexpected =>
-          throw new IllegalArgumentException(s"Unexpected actor class marker: $unexpected") // will not happen, for exhaustiveness check
+          throw new IllegalArgumentException(s"Unexpected shutdown schedule marker: $unexpected") // will not happen, for exhaustiveness check
       }
       Thread.onSpinWait()
     }
@@ -266,7 +266,7 @@ abstract class MessageDispatcher(val configurator: MessageDispatcherConfigurator
           else run()
         case UNSCHEDULED =>
         case unexpected  =>
-          throw new IllegalArgumentException(s"Unexpected actor class marker: $unexpected") // will not happen, for exhaustiveness check
+          throw new IllegalArgumentException(s"Unexpected shutdown schedule marker: $unexpected") // will not happen, for exhaustiveness check
       }
     }
   }

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
@@ -150,14 +150,19 @@ private[pekko] abstract class Mailbox(val messageQueue: MessageQueue)
    *
    * @return true if the suspend count reached zero
    */
-  @tailrec
-  final def resume(): Boolean = currentStatus match {
-    case Closed =>
-      setStatus(Closed); false
-    case s =>
+  final def resume(): Boolean = {
+    var s = currentStatus
+    while (true) {
+      if (s == Closed) {
+        setStatus(Closed)
+        return false
+      }
       val next = if (s < suspendUnit) s else s - suspendUnit
-      if (updateStatus(s, next)) next < suspendUnit
-      else resume()
+      if (updateStatus(s, next)) return next < suspendUnit
+      Thread.onSpinWait()
+      s = currentStatus
+    }
+    false // unreachable
   }
 
   /**
@@ -166,24 +171,36 @@ private[pekko] abstract class Mailbox(val messageQueue: MessageQueue)
    *
    * @return true if the previous suspend count was zero
    */
-  @tailrec
-  final def suspend(): Boolean = currentStatus match {
-    case Closed =>
-      setStatus(Closed); false
-    case s =>
-      if (updateStatus(s, s + suspendUnit)) s < suspendUnit
-      else suspend()
+  final def suspend(): Boolean = {
+    var s = currentStatus
+    while (true) {
+      if (s == Closed) {
+        setStatus(Closed)
+        return false
+      }
+      if (updateStatus(s, s + suspendUnit)) return s < suspendUnit
+      Thread.onSpinWait()
+      s = currentStatus
+    }
+    false // unreachable
   }
 
   /**
    * set new primary status Closed. Caller does not need to worry about whether
    * status was Scheduled or not.
    */
-  @tailrec
-  final def becomeClosed(): Boolean = currentStatus match {
-    case Closed =>
-      setStatus(Closed); false
-    case s => updateStatus(s, Closed) || becomeClosed()
+  final def becomeClosed(): Boolean = {
+    var s = currentStatus
+    while (true) {
+      if (s == Closed) {
+        setStatus(Closed)
+        return false
+      }
+      if (updateStatus(s, Closed)) return true
+      Thread.onSpinWait()
+      s = currentStatus
+    }
+    false // unreachable
   }
 
   /**

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
@@ -189,24 +189,28 @@ private[pekko] abstract class Mailbox(val messageQueue: MessageQueue)
   /**
    * Set Scheduled status, keeping primary status as is.
    */
-  @tailrec
   final def setAsScheduled(): Boolean = {
-    val s = currentStatus
-    /*
-     * Only try to add Scheduled bit if pure Open/Suspended, not Closed or with
-     * Scheduled bit already set.
-     */
-    if ((s & shouldScheduleMask) != Open) false
-    else updateStatus(s, s | Scheduled) || setAsScheduled()
+    var s = currentStatus
+    while ({
+      if ((s & shouldScheduleMask) != Open) return false
+      !updateStatus(s, s | Scheduled)
+    }) {
+      Thread.onSpinWait()
+      s = currentStatus
+    }
+    true
   }
 
   /**
    * Reset Scheduled status, keeping primary status as is.
    */
-  @tailrec
   final def setAsIdle(): Boolean = {
-    val s = currentStatus
-    updateStatus(s, s & ~Scheduled) || setAsIdle()
+    var s = currentStatus
+    while (!updateStatus(s, s & ~Scheduled)) {
+      Thread.onSpinWait()
+      s = currentStatus
+    }
+    true
   }
   /*
    * AtomicReferenceFieldUpdater for system queue.

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala
@@ -162,7 +162,7 @@ private[pekko] abstract class Mailbox(val messageQueue: MessageQueue)
       Thread.onSpinWait()
       s = currentStatus
     }
-    false // unreachable
+    throw new IllegalStateException("unreachable")
   }
 
   /**
@@ -182,7 +182,7 @@ private[pekko] abstract class Mailbox(val messageQueue: MessageQueue)
       Thread.onSpinWait()
       s = currentStatus
     }
-    false // unreachable
+    throw new IllegalStateException("unreachable")
   }
 
   /**
@@ -200,7 +200,7 @@ private[pekko] abstract class Mailbox(val messageQueue: MessageQueue)
       Thread.onSpinWait()
       s = currentStatus
     }
-    false // unreachable
+    throw new IllegalStateException("unreachable")
   }
 
   /**
@@ -208,14 +208,13 @@ private[pekko] abstract class Mailbox(val messageQueue: MessageQueue)
    */
   final def setAsScheduled(): Boolean = {
     var s = currentStatus
-    while ({
+    while (true) {
       if ((s & shouldScheduleMask) != Open) return false
-      !updateStatus(s, s | Scheduled)
-    }) {
+      if (updateStatus(s, s | Scheduled)) return true
       Thread.onSpinWait()
       s = currentStatus
     }
-    true
+    throw new IllegalStateException("unreachable")
   }
 
   /**


### PR DESCRIPTION
### Motivation

CAS retry loops in `AbstractDispatcher` and `Mailbox` spin without any CPU hint when contention causes `compareAndSet` to fail. JDK 9's `Thread.onSpinWait()` hints to the CPU that we're in a spin-wait loop, improving power efficiency and reducing context-switch latency.

### Modification

- `AbstractDispatcher.scala`: Add `onSpinWait()` in shutdown schedule CAS retry loop body
- `Mailbox.scala`: Convert `setAsScheduled()` and `setAsIdle()` from `@tailrec` recursive CAS loops to while loops with `onSpinWait()`, re-reading `currentStatus` on each retry

### Result

Better CPU behavior under contention on the message dispatch hot path (`setAsScheduled` is called on every `registerForExecution`). The `onSpinWait` pattern is already established in the codebase (`AbstractNodeQueue`, `AbstractBoundedNodeQueue`, `AffinityPool`).

### Tests

- `sbt "actor/compile"` — passed

### References

Refs #3136