### PR TITLE
perf: use Arrays.copyOf/copyOfRange instead of manual new Array + arraycopy

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -2795,7 +2795,7 @@ final class ByteStringBuilder extends Builder[Byte, ByteString] {
   }
 
   private def resizeTemp(size: Int): Unit = {
-    val newtemp = java.util.Arrays.copyOf(_temp, size)
+    val newtemp = if (_temp eq null) new Array[Byte](size) else java.util.Arrays.copyOf(_temp, size)
     _temp = newtemp
     _tempCapacity = _temp.length
   }

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -2728,8 +2728,7 @@ object CompactByteString {
     val copyLength = Math.max(Math.min(array.length - copyOffset, length), 0)
     if (copyLength == 0) empty
     else {
-      val copyArray = new Array[Byte](copyLength)
-      System.arraycopy(array, copyOffset, copyArray, 0, copyLength)
+      val copyArray = java.util.Arrays.copyOfRange(array, copyOffset, copyOffset + copyLength)
       ByteString.ByteString1C(copyArray)
     }
   }
@@ -2789,16 +2788,14 @@ final class ByteStringBuilder extends Builder[Byte, ByteString] {
 
   private def clearTemp(): Unit = {
     if (_tempLength > 0) {
-      val arr = new Array[Byte](_tempLength)
-      System.arraycopy(_temp, 0, arr, 0, _tempLength)
+      val arr = java.util.Arrays.copyOf(_temp, _tempLength)
       _builder += ByteString1(arr)
       _tempLength = 0
     }
   }
 
   private def resizeTemp(size: Int): Unit = {
-    val newtemp = new Array[Byte](size)
-    if (_tempLength > 0) System.arraycopy(_temp, 0, newtemp, 0, _tempLength)
+    val newtemp = java.util.Arrays.copyOf(_temp, size)
     _temp = newtemp
     _tempCapacity = _temp.length
   }

--- a/persistence/src/main/scala/org/apache/pekko/persistence/serialization/SnapshotSerializer.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/serialization/SnapshotSerializer.scala
@@ -106,8 +106,7 @@ class SnapshotSerializer(val system: ExtendedActorSystem) extends BaseSerializer
     val manifest =
       if (remaining == 0) ""
       else {
-        val manifestBytes = new Array[Byte](remaining)
-        System.arraycopy(bytes, 4, manifestBytes, 0, remaining)
+        val manifestBytes = java.util.Arrays.copyOfRange(bytes, 4, 4 + remaining)
         migrateManifestToPekkoIfNecessary(new String(manifestBytes, UTF_8))
       }
     (serializerId, manifest)

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/ImmutableLongMap.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/ImmutableLongMap.scala
@@ -69,8 +69,7 @@ private[pekko] class ImmutableLongMap[A >: Null] private (private val keys: Arra
       val i = Arrays.binarySearch(keys, key)
       if (i >= 0) {
         // existing key, replace value
-        val newValues = new Array[A](values.length)
-        System.arraycopy(values, 0, newValues, 0, values.length)
+        val newValues = values.clone()
         newValues(i) = value
         new ImmutableLongMap(keys, newValues)
       } else {


### PR DESCRIPTION
### Motivation

Several places allocate a new array then immediately copy from an existing array using `System.arraycopy`. `java.util.Arrays.copyOf` and `copyOfRange` combine allocation and copy in a single call that the JIT can intrinsify more effectively.

### Modification

- `ByteString.scala`: 3 sites (`clearTemp`, `resizeTemp`, `fromArray`) — replace `new Array[Byte]` + `System.arraycopy` with `java.util.Arrays.copyOf` / `copyOfRange`
- `ImmutableLongMap.scala`: replace full array copy with `values.clone()`
- `SnapshotSerializer.scala`: replace partial copy with `java.util.Arrays.copyOfRange`

### Result

Fewer lines, potentially faster due to JIT intrinsification of the combined allocate+copy operation. `ByteString` builder operations benefit most as they are in frequently-called paths.

### Tests

- `sbt "actor/compile" "remote/compile" "persistence/compile"` — passed

### References

Refs #3136