### PR TITLE
refactor: use ProcessHandle.current().pid() instead of RuntimeMXBean hack

### DIFF
--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testkit/PerfFlamesSupport.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testkit/PerfFlamesSupport.scala
@@ -38,9 +38,7 @@ private[pekko] trait PerfFlamesSupport { self: MultiNodeSpec =>
 
       val afterDelay = pekko.pattern.after(delay, system.scheduler)(Future.successful("GO!"))
       afterDelay.onComplete { _ =>
-        import java.lang.management._
-        val name = ManagementFactory.getRuntimeMXBean.getName
-        val pid = name.substring(0, name.indexOf('@')).toInt
+        val pid = ProcessHandle.current().pid()
 
         val perfCommand = s"$perfJavaFlamesPath $pid"
         println(s"[perf @ $myself($pid)][OUT]: " + perfCommand)


### PR DESCRIPTION
### Motivation

`PerfFlamesSupport.scala` parses the PID from `RuntimeMXBean.getName()` which returns `"pid@hostname"` — a pre-JDK 9 hack that depends on an undocumented string format.

### Modification

Replace with `ProcessHandle.current().pid()` (JDK 9), the official API for retrieving the current process ID.

### Result

Cleaner, more reliable PID retrieval without string parsing.

### Tests

- `sbt "multi-node-testkit/compile"` — passed

### References

Refs #3136