### PR TITLE
refactor: use RandomGenerator interface instead of java.util.Random

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/io/dns/IdGenerator.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/IdGenerator.scala
@@ -18,8 +18,8 @@
 package org.apache.pekko.io.dns
 
 import java.security.SecureRandom
-import java.util.Random
 import java.util.concurrent.ThreadLocalRandom
+import java.util.random.RandomGenerator
 
 import org.apache.pekko.annotation.InternalApi
 
@@ -62,10 +62,10 @@ private[pekko] object IdGenerator {
   /**
    * @return a random sequence of ids for production
    */
-  def random(rand: java.util.Random): IdGenerator =
+  def random(rand: RandomGenerator): IdGenerator =
     () => (rand.nextInt(UnsignedShortBound) + Short.MinValue).toShort
 
-  private[pekko] class EnhancedDoubleHashGenerator(seed: Random) extends IdGenerator {
+  private[pekko] class EnhancedDoubleHashGenerator(seed: RandomGenerator) extends IdGenerator {
 
     /**
      * An efficient thread safe generator of pseudo random shorts based on


### PR DESCRIPTION
### Motivation

`IdGenerator` uses `java.util.Random` as the parameter type for random number generators. JDK 17 introduced `java.util.random.RandomGenerator` as a common interface implemented by `Random`, `ThreadLocalRandom`, `SecureRandom`, and `SplittableRandom`.

### Modification

Change the parameter type from `java.util.Random` to `RandomGenerator` in:
- `random()` factory method
- `EnhancedDoubleHashGenerator` constructor

### Result

More flexible random generator API. All existing callers (`ThreadLocalRandom.current()`, `new SecureRandom()`) already implement `RandomGenerator`, so this is source and binary compatible.

### Tests

- `sbt "actor/compile"` — passed

### References

Refs #3136