### PR TITLE
fix: use Timers for finishConnect retry instead of raw scheduler callback

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/io/TcpConnectionSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/TcpConnectionSpec.scala
@@ -697,6 +697,48 @@ class TcpConnectionSpec extends PekkoSpec("""
       }
     }
 
+    "report failed connection when finishConnect retries are exhausted" in
+    new UnacceptedConnectionTest() {
+      override lazy val connectionActor = createConnectionActor(serverAddress = UnboundAddress)
+      run {
+        val sel = SelectorProvider.provider().openSelector()
+        try {
+          val key = clientSideChannel.register(sel, SelectionKey.OP_CONNECT | SelectionKey.OP_READ)
+          sel.select(3000)
+          key.isConnectable should ===(true)
+          connectionActor.toString // force the lazy val
+          Thread.sleep(300)
+
+          // First ChannelConnectable: finishConnect() either throws (connection refused)
+          // or returns false (connection still pending, schedules timer-based retry).
+          selector.send(connectionActor, ChannelConnectable)
+
+          // If finishConnect returned false, wait for the timer-based retry to re-register.
+          // Each retry fires after 1ms via timers.startSingleTimer (self-message).
+          var retriesObserved = 0
+          var outcome: Option[AnyRef] = None
+          val deadline = System.nanoTime() + 5.seconds.toNanos
+          while (outcome.isEmpty && System.nanoTime() < deadline) {
+            registerCallReceiver.expectNoMessage(50.millis)
+            if (registerCallReceiver.msgAvailable) {
+              registerCallReceiver.receiveWhile(100.millis) {
+                case Registration(_, ops) if ops == OP_CONNECT =>
+                  retriesObserved += 1
+                  selector.send(connectionActor, ChannelConnectable)
+              }
+            }
+            if (userHandler.msgAvailable) {
+              outcome = Some(userHandler.expectMsgType[CommandFailed])
+            }
+          }
+
+          outcome shouldBe defined
+          watch(connectionActor)
+          expectTerminated(connectionActor)
+        } finally sel.close()
+      }
+    }
+
     "close the connection when connection handler dies while connected" in new EstablishedConnectionTest() {
       run {
         watch(connectionHandler.ref)

--- a/actor/src/main/scala/org/apache/pekko/io/TcpOutgoingConnection.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/TcpOutgoingConnection.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 import scala.util.control.{ NoStackTrace, NonFatal }
 
 import org.apache.pekko
-import pekko.actor.{ ActorRef, ReceiveTimeout }
+import pekko.actor.{ ActorRef, ReceiveTimeout, Timers }
 import pekko.actor.Status.Failure
 import pekko.annotation.InternalApi
 import pekko.io.SelectionHandler._
@@ -42,7 +42,8 @@ private[io] class TcpOutgoingConnection(
     extends TcpConnection(
       _tcp,
       SocketChannel.open().configureBlocking(false).asInstanceOf[SocketChannel],
-      connect.pullMode) {
+      connect.pullMode)
+    with Timers {
 
   import TcpOutgoingConnection._
   import connect._
@@ -126,9 +127,7 @@ private[io] class TcpOutgoingConnection(
             completeConnect(registration, commander, options)
           } else {
             if (remainingFinishConnectRetries > 0) {
-              context.system.scheduler.scheduleOnce(1.millisecond) {
-                channelRegistry.register(channel, SelectionKey.OP_CONNECT)
-              }(context.dispatcher)
+              timers.startSingleTimer(RetryFinishConnect, RetryFinishConnect, 1.millisecond)
               context.become(connecting(registration, remainingFinishConnectRetries - 1))
             } else {
               log.debug(
@@ -137,6 +136,10 @@ private[io] class TcpOutgoingConnection(
               stop(FinishConnectNeverReturnedTrueException)
             }
           }
+        }
+      case RetryFinishConnect =>
+        reportConnectFailure {
+          channelRegistry.register(channel, SelectionKey.OP_CONNECT)
         }
       case ReceiveTimeout =>
         connectionTimeout()
@@ -154,6 +157,8 @@ private[io] class TcpOutgoingConnection(
 private[io] object TcpOutgoingConnection {
   val FinishConnectNeverReturnedTrueException =
     new ConnectException("Could not establish connection because finishConnect never returned true") with NoStackTrace
+
+  private case object RetryFinishConnect
 
   def connectTimeoutExpired(timeout: Option[FiniteDuration]) =
     new ConnectException(s"Connect timeout of $timeout expired") with NoStackTrace


### PR DESCRIPTION
### Motivation

`TcpOutgoingConnection` retries a failed `finishConnect` by scheduling a callback via `context.system.scheduler.scheduleOnce` that calls `channelRegistry.register(channel, SelectionKey.OP_CONNECT)` **outside the actor's message loop**. If that callback throws (e.g. `IllegalArgumentException`, `CancelledKeyException` racing with `postStop`, or any `RuntimeException`), the exception is caught by the scheduler/dispatcher error handler and **never re-enters the actor's supervision**. As a result, `Tcp.CommandFailed` is never delivered and the commander can stay stuck in the `connecting` state indefinitely.

See the original field report and analysis in [akkadotnet/akka.net#8195](https://github.com/akkadotnet/akka.net/issues/8195) — the Pekko code has the same structural issue.

### Modification

1. Mix in the `Timers` trait on `TcpOutgoingConnection`.
2. Replace `context.system.scheduler.scheduleOnce(1.millisecond) { channelRegistry.register(...) }` with `timers.startSingleTimer(RetryFinishConnect, RetryFinishConnect, 1.millisecond)`, which sends a private self-message processed inside the actor's message loop.
3. Handle `RetryFinishConnect` in the `connecting` state, wrapped in `reportConnectFailure` so any exception surfaces as `CommandFailed` to the commander.

Benefits over the previous approach:
- **Exceptions are caught**: `reportConnectFailure` wraps the `channelRegistry.register` call, ensuring any `NonFatal` exception is converted to `CommandFailed`.
- **Lifecycle-safe**: `Timers` automatically cancels pending timers when the actor stops, removing the latent window where a stale callback could register against a channel being torn down.
- **Consistent with actor model**: the retry runs as a self-message inside the actor's message loop, not as an external callback.

### Result

Exceptions thrown during the `finishConnect` retry path now correctly surface as `Tcp.CommandFailed` to the commander, preventing indefinite hangs in the `connecting` state.

### Tests

- `sbt 'actor-tests / Test / testOnly org.apache.pekko.io.TcpConnectionSpec'` → 35/35 passed (including new test `report failed connection when finishConnect retries are exhausted`)

### References

Fixes #3135