### PR TITLE
fix: improve TLS observability - handshake failure logging and fail-fast SSL init

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettySSLSupport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettySSLSupport.scala
@@ -68,11 +68,10 @@ private[pekko] object NettySSLSupport {
     val handler = new SslHandler(sslEngine)
     handler.handshakeFuture().addListener((future: Future[Channel]) => {
       if (!future.isSuccess) {
-        val cause = if (future.cause() != null) future.cause() else null
         log.warning(
-          "TLS handshake failed for remote address [{}]. {}",
+          "TLS handshake failed for remote address [{}]: {}",
           sslEngine.getPeerHost,
-          if (cause != null) cause.getMessage else "unknown cause")
+          if (future.cause() != null) future.cause().getMessage else "unknown cause")
         handler.closeOutbound().channel().close()
       }
     })

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettySSLSupport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettySSLSupport.scala
@@ -21,6 +21,7 @@ import io.netty.handler.ssl.SslHandler
 import io.netty.util.concurrent.Future
 
 import com.typesafe.config.Config
+import org.apache.pekko.event.MarkerLoggingAdapter
 
 /**
  * INTERNAL API
@@ -60,13 +61,18 @@ private[pekko] object NettySSLSupport {
   /**
    * Construct a SSLHandler which can be inserted into a Netty server/client pipeline
    */
-  def apply(sslEngineProvider: SSLEngineProvider, isClient: Boolean): SslHandler = {
+  def apply(sslEngineProvider: SSLEngineProvider, isClient: Boolean, log: MarkerLoggingAdapter): SslHandler = {
     val sslEngine =
       if (isClient) sslEngineProvider.createClientSSLEngine()
       else sslEngineProvider.createServerSSLEngine()
     val handler = new SslHandler(sslEngine)
     handler.handshakeFuture().addListener((future: Future[Channel]) => {
       if (!future.isSuccess) {
+        val cause = if (future.cause() != null) future.cause() else null
+        log.warning(
+          "TLS handshake failed for remote address [{}]. {}",
+          sslEngine.getPeerHost,
+          if (cause != null) cause.getMessage else "unknown cause")
         handler.closeOutbound().channel().close()
       }
     })

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettySSLSupport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettySSLSupport.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.remote.transport.netty
 
+import java.net.SocketAddress
+
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
@@ -68,13 +70,20 @@ private[pekko] object NettySSLSupport {
     val handler = new SslHandler(sslEngine)
     handler.handshakeFuture().addListener((future: Future[Channel]) => {
       if (!future.isSuccess) {
+        val channel = handler.closeOutbound().channel()
         log.warning(
           "TLS handshake failed for remote address [{}]: {}",
-          sslEngine.getPeerHost,
-          if (future.cause() != null) future.cause().getMessage else "unknown cause")
-        handler.closeOutbound().channel().close()
+          formatRemoteAddress(channel.remoteAddress()),
+          formatCause(future.cause()))
+        channel.close()
       }
     })
     handler
   }
+
+  private[netty] def formatRemoteAddress(remoteAddress: SocketAddress): String =
+    Option(remoteAddress).map(_.toString).getOrElse("unknown")
+
+  private[netty] def formatCause(cause: Throwable): String =
+    Option(cause).flatMap(t => Option(t.getMessage).orElse(Some(t.toString))).getOrElse("unknown cause")
 }

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettyTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettyTransport.scala
@@ -423,7 +423,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
   private def sslHandler(isClient: Boolean): SslHandler = {
     sslEngineProvider match {
       case OptionVal.Some(sslProvider) =>
-        NettySSLSupport(sslProvider, isClient)
+        NettySSLSupport(sslProvider, isClient, log)
       case _ =>
         throw new IllegalStateException("Expected enable-ssl=on")
     }

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/SSLEngineProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/SSLEngineProvider.scala
@@ -62,7 +62,7 @@ class ConfigSSLEngineProvider(protected val log: MarkerLoggingAdapter, private v
 
   import settings._
 
-  private lazy val sslContext: SSLContext = {
+  private val sslContext: SSLContext = {
     try {
       val rng = createSecureRandom()
       val ctx = SSLContext.getInstance(SSLProtocol)

--- a/remote/src/test/scala/org/apache/pekko/remote/ConfigSSLEngineProviderSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/ConfigSSLEngineProviderSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package org.apache.pekko.remote
+
+import scala.annotation.nowarn
+
+import org.apache.pekko
+import pekko.remote.transport.netty.ConfigSSLEngineProvider
+import pekko.testkit.PekkoSpec
+
+import com.typesafe.config.ConfigFactory
+
+@nowarn("msg=deprecated")
+class ConfigSSLEngineProviderSpec
+    extends PekkoSpec(
+      ConfigFactory.parseString("""
+    pekko {
+      actor.provider = remote
+      remote.classic.netty.ssl.security {
+        key-store = "/nonexistent/keystore.jks"
+        key-store-password = "changeme"
+        key-password = "changeme"
+        trust-store = "/nonexistent/truststore.jks"
+        trust-store-password = "changeme"
+        protocol = "TLSv1.3"
+        enabled-algorithms = [TLS_AES_128_GCM_SHA256]
+        random-number-generator = ""
+        require-mutual-authentication = off
+      }
+    }
+  """)) {
+
+  "ConfigSSLEngineProvider" must {
+    "fail fast when keystore cannot be loaded" in {
+      intercept[RemoteTransportException] {
+        new ConfigSSLEngineProvider(system)
+      }.getMessage should include("could not be established")
+    }
+  }
+}

--- a/remote/src/test/scala/org/apache/pekko/remote/transport/netty/NettySSLSupportSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/transport/netty/NettySSLSupportSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.remote.transport.netty
+
+import java.net.InetSocketAddress
+
+import scala.annotation.nowarn
+
+import org.apache.pekko.testkit.PekkoSpec
+
+@nowarn("msg=deprecated")
+class NettySSLSupportSpec extends PekkoSpec {
+
+  "NettySSLSupport" must {
+    "format channel remote address for handshake failure logs" in {
+      NettySSLSupport.formatRemoteAddress(new InetSocketAddress("127.0.0.1", 2552)) should ===("/127.0.0.1:2552")
+    }
+
+    "fall back when channel remote address is unavailable" in {
+      NettySSLSupport.formatRemoteAddress(null) should ===("unknown")
+    }
+
+    "fall back when handshake failure cause is unavailable or has no message" in {
+      NettySSLSupport.formatCause(null) should ===("unknown cause")
+      NettySSLSupport.formatCause(new RuntimeException(null: String)) should ===("java.lang.RuntimeException")
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

Classic remoting TLS handshake failures were silently swallowed: the `NettySSLSupport` handshake listener closed the channel without logging the failure reason or peer address. Additionally, `SSLContext` was lazily initialized, meaning keystore/truststore errors were only discovered on the first connection attempt rather than at startup.

### Modification

- `NettySSLSupport`: add `MarkerLoggingAdapter` parameter, log TLS handshake failures with the Netty channel remote address and cause
- `NettyTransport`: pass log to `NettySSLSupport`
- `ConfigSSLEngineProvider`: change `sslContext` from `lazy val` to `val` for eager initialization (fail-fast at provider construction time)
- Add focused coverage for fail-fast SSL init and TLS handshake log formatting fallbacks

### Result

TLS handshake failures now produce actionable warning logs with the remote socket address and error cause when available, with stable fallback text otherwise. Keystore/truststore configuration errors are detected at startup rather than on first connection.

### Tests

- `sbt "remote / Test / testOnly org.apache.pekko.remote.ConfigSSLEngineProviderSpec org.apache.pekko.remote.transport.netty.NettySSLSupportSpec"` — 4 tests passed
- `sbt "remote / Test / testOnly org.apache.pekko.remote.Ticket1978ConfigSpec"` — 1 test passed
- `sbt "remote / Test / testOnly org.apache.pekko.remote.transport.netty.NettySSLSupportSpec"` — 3 tests passed after final cleanup
- `scalafmt --list --mode diff-ref=origin/main` — passed
- `git diff --check` — passed
- `sbt +headerCheckAll` — passed
- `sbt +mimaReportBinaryIssues` — passed for Scala 2.13 and Scala 3.3
- `qodercli -p --output-format stream-json --cwd "$PWD" --attachment /tmp/project-review.diff` — No must-fix findings

### References

Fixes #3162