### PR TITLE
fix: harden EndpointReader against NonFatal dispatch errors and unwrap WrappedMessage in writer logs (backport #3166)

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/Endpoint.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/Endpoint.scala
@@ -913,7 +913,7 @@ private[remote] class EndpointWriter(
           if (pduSize > transport.maximumPayloadBytes) {
             val reasonText =
               s"Discarding oversized payload sent to ${s.recipient}: max allowed size ${transport
-                  .maximumPayloadBytes} bytes, actual size of encoded ${s.message.getClass} was ${pdu.size} bytes."
+                  .maximumPayloadBytes} bytes, actual size of encoded ${WrappedMessage.unwrap(s.message).getClass} was ${pdu.size} bytes."
             log.error(
               new OversizedPayloadException(reasonText),
               "Transient association error (association remains live)")
@@ -940,13 +940,13 @@ private[remote] class EndpointWriter(
         log.error(
           e,
           "Serializer not defined for message type [{}]. Transient association error (association remains live)",
-          s.message.getClass)
+          WrappedMessage.unwrap(s.message).getClass)
         true
       case e: IllegalArgumentException =>
         log.error(
           e,
           "Serializer not defined for message type [{}]. Transient association error (association remains live)",
-          s.message.getClass)
+          WrappedMessage.unwrap(s.message).getClass)
         true
       case e: MessageSerializer.SerializationException =>
         log.error(e, "{} Transient association error (association remains live)", e.getMessage)
@@ -1154,8 +1154,7 @@ private[remote] class EndpointReader(
           } else
             try msgDispatch.dispatch(msg.recipient, msg.recipientAddress, msg.serializedMessage, msg.senderOption)
             catch {
-              case e: NotSerializableException => logTransientSerializationError(msg, e)
-              case e: IllegalArgumentException => logTransientSerializationError(msg, e)
+              case NonFatal(e) => logTransientSerializationError(msg, e)
             }
 
         case None =>
@@ -1175,10 +1174,10 @@ private[remote] class EndpointReader(
 
   }
 
-  private def logTransientSerializationError(msg: PekkoPduCodec.Message, error: Exception): Unit = {
+  private def logTransientSerializationError(msg: PekkoPduCodec.Message, error: Throwable): Unit = {
     val sm = msg.serializedMessage
     log.warning(
-      "Serializer not defined for message with serializer id [{}] and manifest [{}]. " +
+      "Could not deserialize message with serializer id [{}] and manifest [{}]. " +
       "Transient association error (association remains live). {}",
       sm.getSerializerId,
       if (sm.hasMessageManifest) sm.getMessageManifest.toStringUtf8 else "",
@@ -1238,7 +1237,10 @@ private[remote] class EndpointReader(
     // Notify writer that some messages can be acked
     context.parent ! OutboundAck(ack)
     deliver.foreach { m =>
-      msgDispatch.dispatch(m.recipient, m.recipientAddress, m.serializedMessage, m.senderOption)
+      try msgDispatch.dispatch(m.recipient, m.recipientAddress, m.serializedMessage, m.senderOption)
+      catch {
+        case NonFatal(e) => logTransientSerializationError(m, e)
+      }
     }
   }
 

--- a/remote/src/test/scala/org/apache/pekko/remote/TransientSerializationErrorSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/TransientSerializationErrorSpec.scala
@@ -30,6 +30,7 @@ object TransientSerializationErrorSpec {
   object ToBinaryIllegal
   object NotDeserializable
   object IllegalOnDeserialize
+  object RuntimeOnDeserialize
 
   class TestSerializer(@unused system: ExtendedActorSystem) extends SerializerWithStringManifest {
     def identifier: Int = 666
@@ -40,6 +41,7 @@ object TransientSerializationErrorSpec {
       case ToBinaryIllegal         => "TI"
       case NotDeserializable       => "ND"
       case IllegalOnDeserialize    => "IOD"
+      case RuntimeOnDeserialize    => "ROD"
       case _                       => throw new NotSerializableException()
     }
     def toBinary(o: AnyRef): Array[Byte] = o match {
@@ -51,6 +53,7 @@ object TransientSerializationErrorSpec {
       manifest match {
         case "ND"  => throw new NotSerializableException() // Not sure this applies here
         case "IOD" => throw new IllegalArgumentException()
+        case "ROD" => throw new RuntimeException("simulated deserialization failure")
         case _     => throw new NotSerializableException()
       }
     }
@@ -76,6 +79,7 @@ abstract class AbstractTransientSerializationErrorSpec(config: Config)
           "org.apache.pekko.remote.TransientSerializationErrorSpec$ToBinaryIllegal$" = test
           "org.apache.pekko.remote.TransientSerializationErrorSpec$NotDeserializable$" = test
           "org.apache.pekko.remote.TransientSerializationErrorSpec$IllegalOnDeserialize$" = test
+          "org.apache.pekko.remote.TransientSerializationErrorSpec$RuntimeOnDeserialize$" = test
         }
       }
     }
@@ -109,7 +113,8 @@ abstract class AbstractTransientSerializationErrorSpec(config: Config)
         ToBinaryIllegal,
         ToBinaryNotSerializable,
         NotDeserializable,
-        IllegalOnDeserialize).foreach(msg => selection.tell(msg, this.testActor))
+        IllegalOnDeserialize,
+        RuntimeOnDeserialize).foreach(msg => selection.tell(msg, this.testActor))
 
       // make sure we still have a connection
       selection.tell("ping", this.testActor)


### PR DESCRIPTION
### Motivation

Backport of #3166 to the 1.7.x release branch.

`EndpointReader` only caught `NotSerializableException` and `IllegalArgumentException` during non-reliable message dispatch, allowing other `NonFatal` deserialization failures to escape and stop the endpoint. The reliable delivery path (`deliverAndAck`) did not protect dispatch at all. Additionally, `EndpointWriter` error logs showed the outer wrapper class instead of the actual message type for wrapped messages.

### Modification

- `EndpointReader`: catch `NonFatal` dispatch failures on both non-reliable and reliable delivery paths and log them as transient deserialization errors
- `EndpointWriter`: use `WrappedMessage.unwrap()` to log the inner message class in oversized payload and serialization error messages
- Change `logTransientSerializationError` parameter from `Exception` to `Throwable`
- Update log message from "Serializer not defined" to "Could not deserialize" to cover all deserialization failure scenarios

### Result

Transient deserialization failures no longer tear down the classic remoting endpoint, and error logs now show the actual message type for wrapped messages.

### Tests

- `sbt "remote / Test / testOnly org.apache.pekko.remote.TransientSerializationErrorSpec"`

### References

Refs #3166 - backport to 1.7.x