### PR TITLE
Fix double close in unfoldResource

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/UnfoldResourceSourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/UnfoldResourceSourceSpec.scala
@@ -35,7 +35,7 @@ import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.TestSubscriber
 import pekko.stream.testkit.Utils._
 import pekko.stream.testkit.scaladsl.TestSink
-import pekko.testkit.EventFilter
+import pekko.testkit.{ EventFilter, TestProbe }
 import pekko.util.ByteString
 
 class UnfoldResourceSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
@@ -196,18 +196,63 @@ class UnfoldResourceSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
     "fail when close throws exception" in {
       val out = TestSubscriber.probe[String]()
 
-      EventFilter[TE](occurrences = 1).intercept {
-        Source
-          .unfoldResource[String, Iterator[String]](
-            () => Iterator("a"),
-            it => if (it.hasNext) Some(it.next()) else None,
-            _ => throw TE(""))
-          .runWith(Sink.fromSubscriber(out))
+      Source
+        .unfoldResource[String, Iterator[String]](
+          () => Iterator("a"),
+          it => if (it.hasNext) Some(it.next()) else None,
+          _ => throw TE(""))
+        .runWith(Sink.fromSubscriber(out))
 
-        out.request(61)
-        out.expectNext("a")
-        out.expectError(TE(""))
-      }
+      out.request(61)
+      out.expectNext("a")
+      out.expectError(TE(""))
+    }
+
+    "not close the resource twice when close fails during completion" in {
+      val closedCounter = new AtomicInteger(0)
+      val closeProbe = TestProbe()
+      val probe = Source
+        .unfoldResource[Int, Iterator[Int]](
+          () => Iterator.single(1),
+          it => if (it.hasNext) Some(it.next()) else None,
+          { _ =>
+            val closeCount = closedCounter.incrementAndGet()
+            closeProbe.ref ! closeCount
+            throw TE("close failed")
+          })
+        .runWith(TestSink[Int]())
+
+      probe.request(1)
+      probe.expectNext(1)
+      probe.request(1)
+      probe.expectError(TE("close failed"))
+
+      closeProbe.expectMsg(1)
+      closeProbe.expectNoMessage(200.millis)
+      closedCounter.get() should ===(1)
+    }
+
+    "not close the resource twice when close fails during downstream cancel" in {
+      val closedCounter = new AtomicInteger(0)
+      val closeProbe = TestProbe()
+      val probe = Source
+        .unfoldResource[Int, Iterator[Int]](
+          () => Iterator.continually(1),
+          it => Some(it.next()),
+          { _ =>
+            val closeCount = closedCounter.incrementAndGet()
+            closeProbe.ref ! closeCount
+            throw TE("close failed")
+          })
+        .runWith(TestSink[Int]())
+
+      probe.request(1)
+      probe.expectNext(1)
+      probe.cancel()
+      closeProbe.expectMsg(1)
+
+      closeProbe.expectNoMessage(200.millis)
+      closedCounter.get() should ===(1)
     }
 
     // issue #24924

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/UnfoldResourceSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/UnfoldResourceSource.scala
@@ -82,14 +82,15 @@ import pekko.stream.stage._
         open = true
       }
 
-      private def closeStage(): Unit =
+      private def closeStage(): Unit = {
+        open = false
         try {
           close(resource)
-          open = false
           completeStage()
         } catch {
           case NonFatal(ex) => failStage(ex)
         }
+      }
 
       override def postStop(): Unit = {
         if (open) close(resource)


### PR DESCRIPTION
### Motivation
Source.unfoldResource can close the same resource twice when close(resource) fails. closeStage left the stage marked as open until after close returned, so postStop retried close after the failure.

### Modification
Mark the resource as no longer open before invoking close(resource) in closeStage.

Add regression coverage for close failures during normal completion and downstream cancellation.

### Result
UnfoldResourceSource now propagates the close failure without attempting to close the same resource again from postStop.

### Tests
- `rtk sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.UnfoldResourceSourceSpec"` / passed
- `rtk scalafmt --mode diff-ref=origin/main` / passed with JDK Unsafe deprecation warnings
- `rtk scalafmt --list --mode diff-ref=origin/main` / passed with JDK Unsafe deprecation warnings
- `rtk git diff --check` / passed
- `rtk sbt headerCreateAll` / passed
- `rtk sbt "+headerCheckAll"` / passed
- `rtk sbt checkCodeStyle` / passed
- `rtk qodercli --help` and qodercli stdout review with `/tmp/project-review.diff` / No must-fix findings
- `rtk sbt validatePullRequest` / not completed locally: arm64 host cannot load `leveldbjni-all:1.8` native library. The extracted binary reports x86_64/i386 while this host needs arm64; command was stopped after that environment failure.

### References
Fixes #3162