### PR TITLE
Remove fanout publisher sink wrapper

### DIFF
--- a/stream/src/main/mima-filters/2.0.x.backwards.excludes/remove-fanout-publisher-sink.excludes
+++ b/stream/src/main/mima-filters/2.0.x.backwards.excludes/remove-fanout-publisher-sink.excludes
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Remove the remaining SinkModule wrapper around the GraphStage fanout publisher bridge
 ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.FanoutPublisherSink")

--- a/stream/src/main/mima-filters/2.0.x.backwards.excludes/remove-fanout-publisher-sink.excludes
+++ b/stream/src/main/mima-filters/2.0.x.backwards.excludes/remove-fanout-publisher-sink.excludes
@@ -1,0 +1,2 @@
+# Remove the remaining SinkModule wrapper around the GraphStage fanout publisher bridge
+ProblemFilters.exclude[MissingClassProblem]("org.apache.pekko.stream.impl.FanoutPublisherSink")

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
@@ -110,26 +110,6 @@ import org.reactivestreams.Subscriber
 
 /**
  * INTERNAL API
- */
-@InternalApi private[pekko] final class FanoutPublisherSink[In](val attributes: Attributes, shape: SinkShape[In])
-    extends SinkModule[In, Publisher[In]](shape) {
-
-  override def create(context: MaterializationContext): (Subscriber[In], Publisher[In]) = {
-    context.materializer.materialize(
-      Source
-        // Keep the SinkModule ABI but route the runtime through the new GraphStage bridge instead
-        // of reviving the legacy FanoutProcessorImpl / ActorPublisher path.
-        .asSubscriber[In]
-        .toMat(Sink.fromGraph(new FanoutPublisherBridgeStage[In]))(Keep.both),
-      context.effectiveAttributes)
-  }
-
-  override def withAttributes(attr: Attributes): SinkModule[In, Publisher[In]] =
-    new FanoutPublisherSink[In](attr, amendShape(attr))
-}
-
-/**
- * INTERNAL API
  * Attaches a subscriber to this stream.
  */
 @InternalApi private[pekko] final class SubscriberSink[In](

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
@@ -302,9 +302,8 @@ object Sink {
    * reject any additional `Subscriber`s.
    */
   def asPublisher[T](fanout: Boolean): Sink[T, Publisher[T]] =
-    fromGraph(
-      if (fanout) new FanoutPublisherSink[T](DefaultAttributes.fanoutPublisherSink, shape("FanoutPublisherSink"))
-      else new PublisherSink[T](DefaultAttributes.publisherSink, shape("PublisherSink")))
+    if (fanout) Flow[T].async.toMat(Sink.fromGraph(new FanoutPublisherBridgeStage[T]))(Keep.right)
+    else fromGraph(new PublisherSink[T](DefaultAttributes.publisherSink, shape("PublisherSink")))
 
   /**
    * A `Sink` that materializes this `Sink` itself as a `Source`.


### PR DESCRIPTION
### Motivation
Refs #2860 tracks converting old stream internals to GraphStages. After the fanout publisher runtime moved to `FanoutPublisherBridgeStage`, `Sink.asPublisher(fanout = true)` still kept `FanoutPublisherSink` as an internal `SinkModule` wrapper.

### Modification
- Build the fanout publisher sink directly from `Flow[T].async` and `FanoutPublisherBridgeStage`.
- Delete the remaining `FanoutPublisherSink` wrapper.
- Add a MiMa filter for the removed internal class.

### Result
The fanout publisher path now composes directly from the GraphStage bridge while preserving the async/request boundary covered by the existing fanout and FlowSpec tests. The public `Sink.asPublisher` API is unchanged.

### Tests
- `rtk env JAVA_HOME=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home PATH=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home/bin:$PATH sbt "stream-tests / Test / testOnly org.apache.pekko.stream.impl.FanoutPublisherBehaviorSpec"` - passed
- `rtk env JAVA_HOME=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home PATH=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home/bin:$PATH sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.PublisherSinkSpec org.apache.pekko.stream.scaladsl.SinkSpec org.apache.pekko.stream.scaladsl.FlowSpec org.apache.pekko.stream.impl.TimeoutsSpec"` - passed
- `rtk env JAVA_HOME=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home PATH=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home/bin:$PATH sbt "stream-tests-tck / Test / testOnly org.apache.pekko.stream.tck.FanoutPublisherTest"` - passed
- `rtk env JAVA_HOME=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home PATH=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home/bin:$PATH sbt "stream / mimaReportBinaryIssues"` - passed
- `rtk env JAVA_HOME=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home PATH=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home/bin:$PATH sbt headerCreateAll` - passed
- `rtk env JAVA_HOME=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home PATH=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home/bin:$PATH sbt "+headerCheckAll"` - passed
- `rtk scalafmt --list --mode diff-ref=origin/main` - passed
- `rtk git diff --check` - passed
- `rtk env JAVA_HOME=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home PATH=/Users/hepin/Library/Java/JavaVirtualMachines/azul-17.0.17/Contents/Home/bin:$PATH sbt validatePullRequest` - not completed locally: `JournalNoCompactionSpec` hit macOS ARM64 `leveldbjni` native library incompatibility (`libleveldbjni` contains x86_64/i386, needs arm64); command was stopped after the environment failure
- Qoder stdout review with `/tmp/project-review.diff` attachment - No must-fix findings (`/tmp/project-qoder-review.log`)

### References
Refs #2860