### PR TITLE
feat: add supervision strategy support for groupedWeighted costFn

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeighted.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeighted.md
@@ -14,6 +14,10 @@ Accumulate incoming events until the combined weight of elements is greater than
 
 Chunk up this stream into groups of elements that have a cumulative weight greater than or equal to the `minWeight`, with the last group possibly smaller than requested `minWeight` due to end-of-stream.
 
+The `groupedWeighted` operator adheres to the ActorAttributes.SupervisionStrategy attribute.
+A `Supervision.Restart` decision discards the elements accumulated in the current group, while
+`Supervision.Resume` skips the failing element and keeps the current group.
+
 See also:
 
 * @ref[grouped](grouped.md) for a variant that groups based on number of elements

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedWeightedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedWeightedSpec.scala
@@ -19,6 +19,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.pekko
+import pekko.stream.{ ActorAttributes, Supervision }
 import pekko.stream.testkit.{ ScriptedTest, StreamSpec, TestPublisher, TestSubscriber }
 import pekko.testkit.TimingTest
 
@@ -110,6 +111,54 @@ class FlowGroupedWeightedSpec extends StreamSpec("""
       val error = c.expectError()
       error shouldBe an[IllegalArgumentException]
       error.getMessage should be("Negative weight [-1] for element [1] is not allowed")
+    }
+
+    "fail the stream when costFn throws and supervision is Stop" in {
+      val ex = new RuntimeException("boom")
+      val result = Source(1 to 5)
+        .groupedWeighted(10)(i => if (i == 3) throw ex else i.toLong)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
+        .runWith(Sink.ignore)
+
+      result.failed.futureValue shouldBe ex
+    }
+
+    "fail the stream when costFn throws and no supervision attribute is set (default Stop)" in {
+      val ex = new RuntimeException("boom")
+      val result = Source(1 to 5)
+        .groupedWeighted(10)(i => if (i == 3) throw ex else i.toLong)
+        .runWith(Sink.ignore)
+
+      result.failed.futureValue shouldBe ex
+    }
+
+    "resume and keep the partially accumulated group when costFn throws (Resume)" in {
+      // minWeight=10 so [1,2] stay buffered when element 3 throws; Resume must keep them.
+      val result = Source(1 to 5)
+        .groupedWeighted(10)(i => if (i == 3) throw new RuntimeException("boom") else i.toLong)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(Sink.seq)
+
+      result.futureValue shouldBe Seq(Seq(1, 2, 4, 5)) // 3 skipped, [1,2] preserved, then 4,5 fill the group
+    }
+
+    "resume and flush the buffered group at completion when costFn throws on the last element (Resume)" in {
+      // minWeight=100 is never reached, so the group is flushed only at upstream finish.
+      val result = Source(1 to 5)
+        .groupedWeighted(100)(i => if (i == 5) throw new RuntimeException("boom") else i.toLong)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(Sink.seq)
+
+      result.futureValue shouldBe Seq(Seq(1, 2, 3, 4)) // 5 skipped, [1,2,3,4] flushed at completion
+    }
+
+    "restart and drop the current group when costFn throws and supervision is Restart" in {
+      val result = Source(1 to 5)
+        .groupedWeighted(6)(i => if (i == 3) throw new RuntimeException("boom") else i.toLong)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .runWith(Sink.seq)
+
+      result.futureValue shouldBe Seq(Seq(4, 5))
     }
   }
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -804,16 +804,35 @@ private[stream] object Collect {
   val out = Outlet[immutable.Seq[T]]("GroupedWeighted.out")
   override val shape: FlowShape[T, immutable.Seq[T]] = FlowShape(in, out)
 
-  override def initialAttributes: Attributes = DefaultAttributes.groupedWeighted
+  override def initialAttributes: Attributes = DefaultAttributes.groupedWeighted and SourceLocation.forLambda(costFn)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with OutHandler {
       private var builder = Vector.newBuilder[T]
       private var left: Long = minWeight
+      private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
 
       override def onPush(): Unit = {
         val elem = grab(in)
-        val cost = costFn(elem)
+        // costFn is user code and may throw, so honor supervision the same way as other user-provided operators.
+        val cost =
+          try costFn(elem)
+          catch {
+            case NonFatal(ex) =>
+              decider(ex) match {
+                case Supervision.Stop =>
+                  failStage(ex)
+                  return
+                case Supervision.Resume =>
+                  pull(in)
+                  return
+                case Supervision.Restart =>
+                  builder.clear()
+                  left = minWeight
+                  pull(in)
+                  return
+              }
+          }
         if (cost < 0L)
           failStage(new IllegalArgumentException(s"Negative weight [$cost] for element [$elem] is not allowed"))
         else {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -1322,6 +1322,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * `costFn` must return a non-negative result for all inputs, otherwise the stage will fail
    * with an IllegalArgumentException.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
    * '''Emits when''' the cumulative weight of elements is greater than or equal to the `minWeight` or upstream completed
    *
    * '''Backpressures when''' a buffered group weighs more than `minWeight` and downstream backpressures

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -3218,6 +3218,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * `costFn` must return a non-negative result for all inputs, otherwise the stage will fail
    * with an IllegalArgumentException.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
    * '''Emits when''' the cumulative weight of elements is greater than or equal to the `minWeight` or upstream completed
    *
    * '''Backpressures when''' a buffered group weighs more than `minWeight` and downstream backpressures

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -724,6 +724,8 @@ final class SubFlow[In, Out, Mat](
    * `costFn` must return a non-negative result for all inputs, otherwise the stage will fail
    * with an IllegalArgumentException.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
    * '''Emits when''' the cumulative weight of elements is greater than or equal to the `minWeight` or upstream completed
    *
    * '''Backpressures when''' a buffered group weighs more than `minWeight` and downstream backpressures

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -714,6 +714,8 @@ final class SubSource[Out, Mat](
    * `costFn` must return a non-negative result for all inputs, otherwise the stage will fail
    * with an IllegalArgumentException.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
    * '''Emits when''' the cumulative weight of elements is greater than or equal to the `minWeight` or upstream completed
    *
    * '''Backpressures when''' a buffered group weighs more than `minWeight` and downstream backpressures

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1840,6 +1840,8 @@ trait FlowOps[+Out, +Mat] {
    * `costFn` must return a non-negative result for all inputs, otherwise the stage will fail
    * with an IllegalArgumentException.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
    * '''Emits when''' the cumulative weight of elements is greater than or equal to the `minWeight` or upstream completed
    *
    * '''Backpressures when''' a buffered group weighs more than `minWeight` and downstream backpressures


### PR DESCRIPTION
### Motivation

Per the [stream error handling docs](https://pekko.apache.org/docs/pekko/current/stream/stream-error.html#supervision-strategies), operators that apply user-provided functions should consult the configured `SupervisionStrategy`. The `groupedWeighted` operator's `costFn` was called without a try-catch, so any exception failed the stream **unconditionally** — even when `Supervision.Resume` or `Supervision.Restart` was configured. This was inconsistent with `map`, `filter`, `batch`, etc.

This is part of the meta-issue #3110 (add supervisor strategy support to stream operators that accept user functions). One operator per PR.

### Modification

- Wrap `costFn(elem)` in `GroupedWeighted.onPush()` with a `try`/`catch` (`NonFatal`) that consults the `SupervisionStrategy` decider:
  - **Stop** → fail the stage (unchanged fail-fast behavior)
  - **Resume** → skip the offending element, **keep** the current partial group
  - **Restart** → **drop** the accumulated group and reset the weight counter
- `decider` is a `lazy val`, so there is **zero overhead on the happy path** (it is only resolved when an exception actually occurs).
- Add `SourceLocation.forLambda(costFn)` to `initialAttributes` for better failure attribution, matching the sibling `groupedWeightedWithin`.
- Document supervision adherence in the Scala/Java DSL scaladoc and the `groupedWeighted` operator reference page (required by the supervision documentation policy in `stream-error.md`).

### Result

`groupedWeighted` now adheres to the `SupervisionStrategy` attribute with well-defined group semantics under Resume/Restart, consistent with the rest of the stream operators.

### Tests

- `sbt "stream-tests/Test/testOnly org.apache.pekko.stream.scaladsl.FlowGroupedWeightedSpec"` — **14/14 passed**, including 5 new directional tests:
  - fails on `costFn` throw with `Supervision.Stop`
  - fails with no supervision attribute set (default Stop) — back-compat guard
  - `Resume` keeps the partially accumulated group and skips the failing element
  - `Resume` flushes the buffered group at completion when the last element throws
  - `Restart` drops the current group
- `sbt "stream/mimaReportBinaryIssues"` — clean (binary compatible)

### References

Refs #3110

This is a clean-room implementation written directly for Apache Pekko.
