### PR TITLE
feat: add supervision strategy support for groupedWeightedWithin costFn

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeightedWithin.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeightedWithin.md
@@ -15,6 +15,7 @@ Chunk up this stream into groups of elements received within a time window, or l
 Chunk up this stream into groups of elements received within a time window, or limited by the weight and number of 
 the elements, whatever happens first. Empty groups will not be emitted if no elements are received from upstream.
 The last group before end-of-stream will contain the buffered elements since the previously emitted group.
+The `groupedWeightedWithin` operator adheres to the ActorAttributes.SupervisionStrategy attribute. On `Supervision.Resume` the offending element is skipped and the current group is kept; on `Supervision.Restart` the current group is dropped.
 
 See also:
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedWithinSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedWithinSpec.scala
@@ -19,6 +19,8 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 
 import org.apache.pekko
+import pekko.stream.ActorAttributes
+import pekko.stream.Supervision
 import pekko.stream.ThrottleMode
 import pekko.stream.testkit._
 import pekko.testkit.TimingTest
@@ -334,6 +336,131 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
       downstream.request(1)
       // no split
       downstream.expectNext(Vector(7, 2): immutable.Seq[Long])
+      downstream.expectComplete()
+    }
+
+    // These supervision tests use a 30.seconds window that never fires, so they are deterministic and
+    // intentionally NOT tagged TimingTest — they must run in PR validation as regression guards.
+    "stop when cost function throws and supervision is Stop" in {
+      val ex = new RuntimeException("cost function boom")
+      val upstream = TestPublisher.probe[Long]()
+      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      Source
+        .fromPublisher(upstream)
+        .groupedWeightedWithin(100, 3, 30.seconds) { elem =>
+          if (elem == 99L) throw ex
+          else elem
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
+        .to(Sink.fromSubscriber(downstream))
+        .run()
+
+      downstream.ensureSubscription()
+      downstream.request(1)
+      upstream.sendNext(1L)
+      upstream.sendNext(99L)
+      downstream.expectError(ex)
+    }
+
+    "stop when cost function throws with default supervision" in {
+      val ex = new RuntimeException("cost function boom")
+      Source(List(1L, 99L, 2L))
+        .groupedWeightedWithin(100, 3, 30.seconds) { elem =>
+          if (elem == 99L) throw ex
+          else elem
+        }
+        .runWith(Sink.ignore)
+        .failed
+        .futureValue shouldBe ex
+    }
+
+    "resume when cost function throws and keep current group" in {
+      val ex = new RuntimeException("cost function boom")
+      val upstream = TestPublisher.probe[Long]()
+      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      Source
+        .fromPublisher(upstream)
+        .groupedWeightedWithin(100, 3, 30.seconds) { elem =>
+          if (elem == 99L) throw ex
+          else elem
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .to(Sink.fromSubscriber(downstream))
+        .run()
+
+      downstream.ensureSubscription()
+      upstream.sendNext(1L)
+      upstream.sendNext(2L)
+      upstream.sendNext(99L)
+      upstream.sendNext(3L)
+      upstream.sendNext(4L)
+      upstream.sendNext(5L)
+      upstream.sendComplete()
+
+      downstream.request(1)
+      downstream.expectNext(Vector(1L, 2L, 3L): immutable.Seq[Long])
+      downstream.request(1)
+      downstream.expectNext(Vector(4L, 5L): immutable.Seq[Long])
+      downstream.expectComplete()
+    }
+
+    "resume keeps weight accounting when cost function throws" in {
+      val ex = new RuntimeException("cost function boom")
+      val upstream = TestPublisher.probe[Long]()
+      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      Source
+        .fromPublisher(upstream)
+        // maxWeight=5, large maxNumber so grouping is weight-driven; identity cost
+        .groupedWeightedWithin(5, 100, 30.seconds) { elem =>
+          if (elem == 99L) throw ex
+          else elem
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .to(Sink.fromSubscriber(downstream))
+        .run()
+
+      downstream.ensureSubscription()
+      upstream.sendNext(2L)
+      upstream.sendNext(2L)
+      upstream.sendNext(99L) // skipped; its weight must NOT be counted, [2,2] (weight 4) kept
+      upstream.sendNext(3L) // 4 + 3 = 7 > maxWeight 5 -> [2,2] flushed, 3 starts a new group
+      upstream.sendComplete()
+
+      downstream.request(1)
+      downstream.expectNext(Vector(2L, 2L): immutable.Seq[Long])
+      downstream.request(1)
+      downstream.expectNext(Vector(3L): immutable.Seq[Long])
+      downstream.expectComplete()
+    }
+
+    "restart when cost function throws and drop current group" in {
+      val ex = new RuntimeException("cost function boom")
+      val upstream = TestPublisher.probe[Long]()
+      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      Source
+        .fromPublisher(upstream)
+        .groupedWeightedWithin(100, 3, 30.seconds) { elem =>
+          if (elem == 99L) throw ex
+          else elem
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .to(Sink.fromSubscriber(downstream))
+        .run()
+
+      downstream.ensureSubscription()
+      upstream.sendNext(1L)
+      upstream.sendNext(2L)
+      upstream.sendNext(99L)
+      upstream.sendNext(3L)
+      upstream.sendNext(4L)
+      upstream.sendNext(5L)
+      upstream.sendNext(6L)
+      upstream.sendComplete()
+
+      downstream.request(1)
+      downstream.expectNext(Vector(3L, 4L, 5L): immutable.Seq[Long])
+      downstream.request(1)
+      downstream.expectNext(Vector(6L): immutable.Seq[Long])
       downstream.expectComplete()
     }
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -1845,6 +1845,7 @@ private[stream] object Collect {
       private var totalWeight = 0L
       private var totalNumber = 0
       private var hasElements = false
+      private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
       private val contextPropagation = ContextPropagation()
 
       override def preStart() = {
@@ -1853,8 +1854,28 @@ private[stream] object Collect {
       }
 
       private def nextElement(elem: T): Unit = {
+        // costFn is user code and may throw; honor supervision strategy.
+        val cost =
+          try costFn(elem)
+          catch {
+            case NonFatal(ex) =>
+              decider(ex) match {
+                case Supervision.Stop =>
+                  failStage(ex)
+                  return
+                case Supervision.Resume =>
+                  // skip the offending element and keep the current group
+                  if (!hasBeenPulled(in)) pull(in)
+                  return
+                case Supervision.Restart =>
+                  // drop the current group and reset the time window, then continue from a fresh accumulator
+                  resetGroupState()
+                  scheduleWithFixedDelay(GroupedWeightedWithin.groupedWeightedWithinTimer, interval, interval)
+                  if (!hasBeenPulled(in)) pull(in)
+                  return
+              }
+          }
         groupEmitted = false
-        val cost = costFn(elem)
         if (cost < 0L)
           failStage(new IllegalArgumentException(s"Negative weight [$cost] for element [$elem] is not allowed"))
         else {
@@ -1895,6 +1916,17 @@ private[stream] object Collect {
             tryCloseGroup()
           }
         }
+      }
+
+      private def resetGroupState(): Unit = {
+        builder.clear()
+        pending = null.asInstanceOf[T]
+        pendingWeight = 0L
+        pushEagerly = false
+        groupEmitted = true
+        totalWeight = 0L
+        totalNumber = 0
+        hasElements = false
       }
 
       private def tryCloseGroup(): Unit = {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -1699,6 +1699,10 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * The last group before end-of-stream will contain the buffered elements
    * since the previously emitted group.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
+   *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *
    * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than `maxWeight`
@@ -1722,6 +1726,10 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Empty groups will not be emitted if no elements are received from upstream.
    * The last group before end-of-stream will contain the buffered elements
    * since the previously emitted group.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
    *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -3583,6 +3583,10 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * The last group before end-of-stream will contain the buffered elements
    * since the previously emitted group.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
+   *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *
    * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than `maxWeight`
@@ -3606,6 +3610,10 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Empty groups will not be emitted if no elements are received from upstream.
    * The last group before end-of-stream will contain the buffered elements
    * since the previously emitted group.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
    *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -1093,6 +1093,10 @@ final class SubFlow[In, Out, Mat](
    * The last group before end-of-stream will contain the buffered elements
    * since the previously emitted group.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
+   *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *
    * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than `maxWeight`
@@ -1116,6 +1120,10 @@ final class SubFlow[In, Out, Mat](
    * Empty groups will not be emitted if no elements are received from upstream.
    * The last group before end-of-stream will contain the buffered elements
    * since the previously emitted group.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
    *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -1079,6 +1079,10 @@ final class SubSource[Out, Mat](
    * The last group before end-of-stream will contain the buffered elements
    * since the previously emitted group.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
+   *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *
    * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than `maxWeight`
@@ -1102,6 +1106,10 @@ final class SubSource[Out, Mat](
    * Empty groups will not be emitted if no elements are received from upstream.
    * The last group before end-of-stream will contain the buffered elements
    * since the previously emitted group.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
    *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -2207,6 +2207,10 @@ trait FlowOps[+Out, +Mat] {
    * `maxWeight` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
+   *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *
    * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than `maxWeight`
@@ -2227,6 +2231,10 @@ trait FlowOps[+Out, +Mat] {
    *
    * `maxWeight` must be positive, `maxNumber` must be positive, and `d` must be greater than 0 seconds,
    * otherwise IllegalArgumentException is thrown.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is skipped and the current group is kept; on `Supervision.Restart` the current
+   * group is dropped.
    *
    * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
    *


### PR DESCRIPTION
### Motivation

Per the [stream error handling docs](https://pekko.apache.org/docs/pekko/current/stream/stream-error.html#supervision-strategies), operators that apply user-provided functions should consult the configured `SupervisionStrategy`. The `groupedWeightedWithin` operator's `costFn` was called without a try-catch, so any exception failed the stream **unconditionally** — even under `Supervision.Resume`/`Restart`.

This is part of the meta-issue #3110 (add supervisor strategy support to stream operators that accept user functions). One operator per PR.

### Modification

- Wrap `costFn(elem)` inside `GroupedWeightedWithin.nextElement()` with a `try`/`catch` (`NonFatal`) that consults the `SupervisionStrategy` decider. The cost is computed **before** any state mutation, so the happy path is unchanged:
  - **Stop** → fail the stage (unchanged fail-fast behavior)
  - **Resume** → skip the offending element, **keep** the current group (weight/number accounting is preserved)
  - **Restart** → **drop** the in-progress group via a new `resetGroupState()` helper, and **reschedule** the time-window timer so the fresh group gets a full window
- `decider` is a `lazy val` → zero overhead on the happy path.
- Document supervision adherence on **both** `groupedWeightedWithin` overloads in the Scala/Java DSL scaladoc and the operator reference page.

### Result

`groupedWeightedWithin` now adheres to the `SupervisionStrategy` attribute with well-defined Resume/Restart semantics.

### Tests

- `sbt "stream-tests/Test/testOnly org.apache.pekko.stream.scaladsl.FlowGroupedWithinSpec"` — **21/21 passed**, including 5 new deterministic directional tests (Stop, default Stop, Resume keeps group, Resume preserves weight accounting, Restart drops group). They use a 30s window that never fires, so they are deterministic and run in PR validation (intentionally not tagged `TimingTest`).
- `sbt "stream/mimaReportBinaryIssues"` — clean (binary compatible)

### References

Refs #3110

This is a clean-room implementation written directly for Apache Pekko.
