### PR TITLE
feat: add supervision strategy support for groupedAdjacentBy/Weighted

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentBy.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentBy.md
@@ -14,7 +14,7 @@ Partitions this stream into chunks by a delimiter function.
 
 Partitions this stream into chunks by a delimiter function.
 
-Adheres to the ActorAttributes.SupervisionStrategy attribute (applied to the key function).
+Adheres to the ActorAttributes.SupervisionStrategy attribute (applied to the key function). On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
 
 See also:
 

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentBy.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentBy.md
@@ -14,6 +14,8 @@ Partitions this stream into chunks by a delimiter function.
 
 Partitions this stream into chunks by a delimiter function.
 
+Adheres to the ActorAttributes.SupervisionStrategy attribute (applied to the key function).
+
 See also:
 
 * @ref[groupedAdjacentByWeighted](groupedAdjacentByWeighted.md) for a variant that groups with weight limit too.

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentByWeighted.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentByWeighted.md
@@ -11,7 +11,9 @@ Partitions this stream into chunks by a delimiter function and a weight limit.
 
 ## Description
 
-Partitions this stream into chunks by a delimiter function.
+Partitions this stream into chunks by a delimiter function and a weight limit.
+
+Adheres to the ActorAttributes.SupervisionStrategy attribute (applied to both the key and cost functions). On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
 
 See also:
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedAdjacentByWeightedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedAdjacentByWeightedSpec.scala
@@ -18,6 +18,7 @@
 package org.apache.pekko.stream.scaladsl
 
 import org.apache.pekko
+import pekko.stream.{ ActorAttributes, Supervision }
 import pekko.stream.testkit.{ ScriptedTest, StreamSpec }
 import pekko.stream.testkit.scaladsl.TestSink
 
@@ -92,6 +93,92 @@ class FlowGroupedAdjacentByWeightedSpec extends StreamSpec("""
         .expectNext(Seq("Hi", "Hi"))
         .expectNext(Seq("Greetings"))
         .expectNext(Seq("Hey"))
+        .expectComplete()
+    }
+
+    "fail when costFn throws and supervision decides to stop" in {
+      val ex = new RuntimeException("cost boom")
+      Source(List(1, 2, 3))
+        .groupedAdjacentByWeighted(_ => "k", 2)(elem => if (elem == 2) throw ex else 1L)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
+        .runWith(TestSink[Seq[Int]]())
+        .request(10)
+        .expectError(ex)
+    }
+
+    "fail when costFn throws with default supervision strategy" in {
+      val ex = new RuntimeException("cost boom")
+      Source(List(1, 2, 3))
+        .groupedAdjacentByWeighted(_ => "k", 2)(elem => if (elem == 2) throw ex else 1L)
+        .runWith(TestSink[Seq[Int]]())
+        .request(10)
+        .expectError(ex)
+    }
+
+    "resume when costFn throws and keep surrounding groups" in {
+      val ex = new RuntimeException("cost boom")
+      Source(List(1, 2, 3, 4, 5))
+        .groupedAdjacentByWeighted(_ => "k", 2)(elem => if (elem == 3) throw ex else 1L)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(TestSink[Seq[Int]]())
+        .request(10)
+        .expectNext(Seq(1, 2))
+        .expectNext(Seq(4, 5))
+        .expectComplete()
+    }
+
+    "restart when costFn throws and drop current in-progress group" in {
+      val ex = new RuntimeException("cost boom")
+      Source(List(1, 2, 3, 4, 5))
+        .groupedAdjacentByWeighted(_ => "k", 2)(elem => if (elem == 3) throw ex else 1L)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .runWith(TestSink[Seq[Int]]())
+        .request(10)
+        .expectNext(Seq(4, 5))
+        .expectComplete()
+    }
+
+    "fail when groupedAdjacentBy key function throws and supervision decides to stop" in {
+      val ex = new RuntimeException("key boom")
+      Source(List(1, 1, 2, 3))
+        .groupedAdjacentBy(elem => if (elem == 2) throw ex else elem)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
+        .runWith(TestSink[Seq[Int]]())
+        .request(10)
+        .expectError(ex)
+    }
+
+    "resume when groupedAdjacentBy key function throws and skip offending elements" in {
+      val ex = new RuntimeException("key boom")
+      Source(List(1, 1, 2, 2, 3, 3))
+        .groupedAdjacentBy(elem => if (elem == 2) throw ex else elem)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(TestSink[Seq[Int]]())
+        .request(10)
+        .expectNext(Seq(1, 1))
+        .expectNext(Seq(3, 3))
+        .expectComplete()
+    }
+
+    "resume when the key function throws on the last element and flush the kept group at completion" in {
+      val ex = new RuntimeException("key boom")
+      Source(List(1, 1, 2))
+        .groupedAdjacentBy(elem => if (elem == 2) throw ex else elem)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(TestSink[Seq[Int]]())
+        .request(10)
+        .expectNext(Seq(1, 1))
+        .expectComplete()
+    }
+
+    "restart when groupedAdjacentBy key function throws and drop current group" in {
+      val ex = new RuntimeException("key boom")
+      Source(List(1, 1, 2, 2, 3, 3))
+        .groupedAdjacentBy(elem => if (elem == 2) throw ex else elem)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .runWith(TestSink[Seq[Int]]())
+        .request(10)
+        .expectNext(Seq(3, 3))
         .expectComplete()
     }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GroupedAdjacentByWeighted.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GroupedAdjacentByWeighted.scala
@@ -18,10 +18,13 @@
 package org.apache.pekko.stream.impl.fusing
 
 import scala.collection.immutable
+import scala.util.control.NonFatal
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
+import pekko.stream.ActorAttributes.SupervisionStrategy
 import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import pekko.stream.Supervision
 import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import pekko.util.OptionVal
@@ -54,17 +57,30 @@ private[pekko] final case class GroupedAdjacentByWeighted[T, R](
       private var hasElements: Boolean = false
       private var currentKey: OptionVal[R] = OptionVal.none
       private var pendingGroup: OptionVal[immutable.Seq[T]] = OptionVal.none
+      private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
 
       override def onPush(): Unit = {
         val elem = grab(in)
-        val cost = costFn(elem)
+        val cost =
+          try costFn(elem)
+          catch {
+            case NonFatal(ex) =>
+              superviseUserFn(ex)
+              return
+          }
 
         if (cost < 0L) {
           failStage(new IllegalArgumentException(s"Negative weight [$cost] for element [$elem] is not allowed"))
           return
         }
 
-        val elemKey = f(elem)
+        val elemKey =
+          try f(elem)
+          catch {
+            case NonFatal(ex) =>
+              superviseUserFn(ex)
+              return
+          }
         require(elemKey != null, "Element key must not be null")
 
         if (shouldPushDirectly(cost)) {
@@ -76,6 +92,12 @@ private[pekko] final case class GroupedAdjacentByWeighted[T, R](
           addToCurrentGroup(elem, cost, elemKey)
           tryPullIfNeeded()
         }
+      }
+
+      private def superviseUserFn(ex: Throwable): Unit = decider(ex) match {
+        case Supervision.Stop    => failStage(ex)
+        case Supervision.Resume  => tryPullIfNeeded()
+        case Supervision.Restart => resetGroup(); tryPullIfNeeded()
       }
 
       private def shouldPushDirectly(cost: Long): Boolean = {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -1341,6 +1341,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   * On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -1340,6 +1340,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *
    * '''Backpressures when''' a chunk has been assembled and downstream backpressures
@@ -1361,6 +1363,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * The `f` function must return a non-null value , and the `costFn` must return a non-negative result for all inputs,
    * otherwise the stage will fail.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to both the key and cost functions). On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result, or exceeds the `maxWeight`.
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -3237,6 +3237,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   * On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -3236,6 +3236,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *
    * '''Backpressures when''' a chunk has been assembled and downstream backpressures
@@ -3256,6 +3258,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * The `f` function must return a non-null value , and the `costFn` must return a non-negative result for all inputs,
    * otherwise the stage will fail.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to both the key and cost functions). On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result, or exceeds the `maxWeight`.
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -742,6 +742,8 @@ final class SubFlow[In, Out, Mat](
    *
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *
    * '''Backpressures when''' a chunk has been assembled and downstream backpressures
@@ -762,6 +764,8 @@ final class SubFlow[In, Out, Mat](
    *
    * The `f` function must return a non-null value , and the `costFn` must return a non-negative result for all inputs,
    * otherwise the stage will fail.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to both the key and cost functions). On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result, or exceeds the `maxWeight`.
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -743,6 +743,7 @@ final class SubFlow[In, Out, Mat](
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   * On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -733,6 +733,7 @@ final class SubSource[Out, Mat](
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   * On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -732,6 +732,8 @@ final class SubSource[Out, Mat](
    *
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *
    * '''Backpressures when''' a chunk has been assembled and downstream backpressures
@@ -752,6 +754,8 @@ final class SubSource[Out, Mat](
    *
    * The `f` function must return a non-null value , and the `costFn` must return a non-negative result for all inputs,
    * otherwise the stage will fail.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to both the key and cost functions). On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result, or exceeds the `maxWeight`.
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1858,6 +1858,7 @@ trait FlowOps[+Out, +Mat] {
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
    * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   * On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1857,6 +1857,8 @@ trait FlowOps[+Out, +Mat] {
    *
    * The `f` function must return a non-null value for all elements, otherwise the stage will fail.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to the key function).
+   *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result
    *
    * '''Backpressures when''' a chunk has been assembled and downstream backpressures
@@ -1877,6 +1879,8 @@ trait FlowOps[+Out, +Mat] {
    *
    * The `f` function must return a non-null value , and the `costFn` must return a non-negative result for all inputs,
    * otherwise the stage will fail.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute (applied to both the key and cost functions). On `Supervision.Resume` the offending element is skipped; on `Supervision.Restart` the current group is dropped.
    *
    * '''Emits when''' the delimiter function returns a different value than the previous element's result, or exceeds the `maxWeight`.
    *


### PR DESCRIPTION
### Motivation

Per the [stream error handling docs](https://pekko.apache.org/docs/pekko/current/stream/stream-error.html#supervision-strategies), operators that apply user-provided functions should consult the configured `SupervisionStrategy`. The `groupedAdjacentBy` and `groupedAdjacentByWeighted` operators apply **two** user functions — a key function `f` and (for the weighted variant) a `costFn` — but both were called without a try-catch, so any exception failed the stream **unconditionally**, even under `Supervision.Resume`/`Restart`.

This is part of the meta-issue #3110 (add supervisor strategy support to stream operators that accept user functions). One operator (group) per PR.

### Modification

- Wrap **both** the `costFn` and the key function calls in `GroupedAdjacentByWeighted` with a `try`/`catch` (`NonFatal`) that consults the `SupervisionStrategy` decider via a shared `superviseUserFn` helper:
  - **Stop** → fail the stage (unchanged fail-fast behavior)
  - **Resume** → skip the offending element, **keep** the current group
  - **Restart** → **drop** the in-progress group (an already-completed group awaiting downstream demand is preserved)
- The negative-cost and null-key checks are intentionally left **unchanged** — they remain unconditional failures, because they are *output-contract violations* (the function returned an invalid value) rather than *user-function exceptions*. This matches the sibling `groupedWeighted`/`groupedWeightedWithin` operators.
- `decider` is a `lazy val` → zero overhead on the happy path.
- Document supervision adherence on both operators in the Scala/Java DSL scaladoc and the operator reference pages.

### Result

`groupedAdjacentBy` and `groupedAdjacentByWeighted` now adhere to the `SupervisionStrategy` attribute for both user functions.

### Tests

- `sbt "stream-tests/Test/testOnly org.apache.pekko.stream.scaladsl.FlowGroupedAdjacentByWeightedSpec"` — **14/14 passed**, including 8 new directional tests covering both functions: `costFn` throws (Stop, default Stop, Resume, Restart), key function throws (Stop, Resume, Restart, and Resume-on-last-element flushed at completion).
- `sbt "stream/mimaReportBinaryIssues"` — clean (binary compatible)

### References

Refs #3110

This is a clean-room implementation written directly for Apache Pekko.
