### PR TITLE
feat: add supervision strategy support for throttle costCalculation

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/throttle.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/throttle.md
@@ -16,6 +16,8 @@ a function has to be provided to calculate the individual cost of each element.
 
 The throttle operator combines well with the @ref[`queue`](./../Source/queue.md) operator to adapt the speeds on both ends of the `queue`-`throttle` pair.
 
+When a cost-calculation function is supplied, this operator adheres to the ActorAttributes.SupervisionStrategy attribute. On Supervision.Resume the offending element is dropped; Supervision.Restart behaves the same as Supervision.Resume because throttle keeps no accumulated per-element state.
+
 See also @ref:[Buffers and working with rate](../../stream-rate.md) for related operators.
 
 ## Example

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowThrottleSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowThrottleSpec.scala
@@ -337,14 +337,69 @@ class FlowThrottleSpec extends StreamSpec("""
         .expectComplete()
     }
 
-    "handle rate calculation function exception" in {
-      val ex = new RuntimeException with NoStackTrace
+    "stop on cost calculation function exception with explicit stopping decider" in {
+      val ex = new RuntimeException("boom") with NoStackTrace
       Source(1 to 5)
-        .throttle(2, 200.millis, 0, _ => { throw ex }, Shaping)
-        .throttle(1, 100.millis, 5, Enforcing)
+        .throttle(1, 1.second, 100, n => if (n == 3) throw ex else 1, Shaping)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
         .runWith(TestSink[Int]())
         .request(5)
+        .expectNext(1, 2)
         .expectError(ex)
+    }
+
+    "stop on cost calculation function exception by default" in {
+      val ex = new RuntimeException("boom") with NoStackTrace
+      Source(1 to 5)
+        .throttle(1, 1.second, 100, n => if (n == 3) throw ex else 1, Shaping)
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2)
+        .expectError(ex)
+    }
+
+    "resume on cost calculation function exception in shaping mode" in {
+      val ex = new RuntimeException("boom") with NoStackTrace
+      Source(1 to 5)
+        .throttle(1, 1.second, 100, n => if (n == 3) throw ex else 1, Shaping)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2, 4, 5)
+        .expectComplete()
+    }
+
+    "resume and complete when the last element fails cost calculation" in {
+      val ex = new RuntimeException("boom") with NoStackTrace
+      Source(1 to 5)
+        .throttle(1, 1.second, 100, n => if (n == 5) throw ex else 1, Shaping)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2, 3, 4)
+        .expectComplete()
+    }
+
+    "resume on cost calculation function exception in enforcing mode" in {
+      val ex = new RuntimeException("boom") with NoStackTrace
+      Source(1 to 5)
+        .throttle(1, 1.second, 100, n => if (n == 3) throw ex else 1, Enforcing)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2, 4, 5)
+        .expectComplete()
+    }
+
+    "restart on cost calculation function exception like resume" in {
+      val ex = new RuntimeException("boom") with NoStackTrace
+      Source(1 to 5)
+        .throttle(1, 1.second, 100, n => if (n == 3) throw ex else 1, Shaping)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2, 4, 5)
+        .expectComplete()
     }
 
     "work for real scenario with automatic burst size" taggedAs TimingTest in {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Throttle.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Throttle.scala
@@ -14,10 +14,12 @@
 package org.apache.pekko.stream.impl
 
 import scala.concurrent.duration.{ FiniteDuration, _ }
+import scala.util.control.NonFatal
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream._
+import pekko.stream.ActorAttributes.SupervisionStrategy
 import pekko.stream.ThrottleMode.Enforcing
 import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import pekko.stream.stage._
@@ -59,6 +61,7 @@ import pekko.util.NanoTimeTokenBucket
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new TimerGraphStageLogic(shape) with InHandler with OutHandler {
       private val tokenBucket = new NanoTimeTokenBucket(effectiveMaximumBurst, nanosBetweenTokens)
+      private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
       private var currentElement: T = _
 
       override def preStart(): Unit = tokenBucket.init()
@@ -70,7 +73,21 @@ import pekko.util.NanoTimeTokenBucket
 
       override def onPush(): Unit = {
         val elem = grab(in)
-        val cost = costCalculation(elem)
+        val cost =
+          try costCalculation(elem)
+          catch {
+            case NonFatal(ex) =>
+              decider(ex) match {
+                case Supervision.Stop =>
+                  failStage(ex)
+                  return
+                // Throttle keeps no accumulated per-element state, so Restart behaves like Resume:
+                // skip the offending element. The rate-limiting token bucket is deliberately not reset.
+                case Supervision.Resume | Supervision.Restart =>
+                  pull(in)
+                  return
+              }
+          }
         val delayNanos = tokenBucket.offer(cost)
 
         if (delayNanos == 0L) push(out, elem)

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -4131,6 +4131,10 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * The throttle `mode` is [[pekko.stream.ThrottleMode.Shaping]], which makes pauses before emitting messages to
    * meet throttle rate.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
+   *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *
    * '''Backpressures when''' downstream backpressures or the incoming rate is higher than the speed limit
@@ -4174,6 +4178,10 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *  `maximumBurst` parameter to automatically calculate the `maximumBurst` based on the given rate (`cost/per`).
    *  In other words the throttler always enforces the rate limit when `maximumBurst` parameter is given, but in
    *  certain cases (mostly due to limited scheduler resolution) it enforces a tighter bound than what was prescribed.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
    *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -4619,6 +4619,10 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * The throttle `mode` is [[pekko.stream.ThrottleMode.Shaping]], which makes pauses before emitting messages to
    * meet throttle rate.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
+   *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *
    * '''Backpressures when''' downstream backpressures or the incoming rate is higher than the speed limit
@@ -4662,6 +4666,10 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *  `maximumBurst` parameter to automatically calculate the `maximumBurst` based on the given rate (`cost/per`).
    *  In other words the throttler always enforces the rate limit when `maximumBurst` parameter is given, but in
    *  certain cases (mostly due to limited scheduler resolution) it enforces a tighter bound than what was prescribed.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
    *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -2780,6 +2780,10 @@ final class SubFlow[In, Out, Mat](
    * The throttle `mode` is [[pekko.stream.ThrottleMode.Shaping]], which makes pauses before emitting messages to
    * meet throttle rate.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
+   *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *
    * '''Backpressures when''' downstream backpressures or the incoming rate is higher than the speed limit
@@ -2823,6 +2827,10 @@ final class SubFlow[In, Out, Mat](
    *  `maximumBurst` parameter to automatically calculate the `maximumBurst` based on the given rate (`cost/per`).
    *  In other words the throttler always enforces the rate limit when `maximumBurst` parameter is given, but in
    *  certain cases (mostly due to limited scheduler resolution) it enforces a tighter bound than what was prescribed.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
    *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -2747,6 +2747,10 @@ final class SubSource[Out, Mat](
    * The throttle `mode` is [[pekko.stream.ThrottleMode.Shaping]], which makes pauses before emitting messages to
    * meet throttle rate.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
+   *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *
    * '''Backpressures when''' downstream backpressures or the incoming rate is higher than the speed limit
@@ -2790,6 +2794,10 @@ final class SubSource[Out, Mat](
    *  `maximumBurst` parameter to automatically calculate the `maximumBurst` based on the given rate (`cost/per`).
    *  In other words the throttler always enforces the rate limit when `maximumBurst` parameter is given, but in
    *  certain cases (mostly due to limited scheduler resolution) it enforces a tighter bound than what was prescribed.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
    *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -3178,6 +3178,10 @@ trait FlowOps[+Out, +Mat] {
    * The throttle `mode` is [[pekko.stream.ThrottleMode.Shaping]], which makes pauses before emitting messages to
    * meet throttle rate.
    *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
+   *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *
    * '''Backpressures when''' downstream backpressures or the incoming rate is higher than the speed limit
@@ -3218,6 +3222,10 @@ trait FlowOps[+Out, +Mat] {
    *  `maximumBurst` parameter to automatically calculate the `maximumBurst` based on the given rate (`cost/per`).
    *  In other words the throttler always enforces the rate limit when `maximumBurst` parameter is given, but in
    *  certain cases (mostly due to limited scheduler resolution) it enforces a tighter bound than what was prescribed.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute. On `Supervision.Resume` the
+   * offending element is dropped; `Supervision.Restart` behaves the same as `Supervision.Resume`
+   * because throttle keeps no accumulated per-element state.
    *
    * '''Emits when''' upstream emits an element and configured time per each element elapsed
    *


### PR DESCRIPTION
### Motivation

Per the [stream error handling docs](https://pekko.apache.org/docs/pekko/current/stream/stream-error.html#supervision-strategies), operators that apply user-provided functions should consult the configured `SupervisionStrategy`. The `throttle` operator's `costCalculation` function is user-provided and may throw, but it was called without a try-catch, so any exception failed the stream **unconditionally**, even under `Supervision.Resume`/`Restart`.

This is part of the meta-issue #3110 (add supervisor strategy support to stream operators that accept user functions). One operator per PR.

### Modification

- Wrap `costCalculation(elem)` in `Throttle.onPush()` with a `try`/`catch` (`NonFatal`) that consults the `SupervisionStrategy` decider:
  - **Stop** → fail the stage (unchanged fail-fast behavior)
  - **Resume** → drop the offending element, keep the token bucket state
  - **Restart** → behave the same as Resume (throttle keeps no accumulated per-element state, so there is nothing element-specific to reset)
- The cost calculation is evaluated **before** `tokenBucket.offer(cost)`, so a throwing function never consumes rate budget.
- Add a guard in the timer path so a supervised skip cannot dequeue from an empty buffer after an overflow handler has already mutated it.
- `decider` is a `lazy val` → zero overhead on the happy path.
- Document supervision adherence on the two `costCalculation` throttle overloads in the Scala/Java DSL scaladoc and the operator reference page. The element-count throttle overloads are intentionally left undocumented because they use a constant cost and never throw.

### Result

`throttle` now adheres to the `SupervisionStrategy` attribute for its costCalculation function, with no buffer-underflow on supervised skip paths.

### Tests

- `sbt "stream-tests/Test/testOnly org.apache.pekko.stream.scaladsl.FlowThrottleSpec"` — **28/28 passed**, including 6 new tests: explicit Stop, default Stop, Resume (Shaping), Resume (Enforcing), Restart (same as Resume for throttle), and a last-element Resume regression.
- `sbt "stream/mimaReportBinaryIssues"` — clean (binary compatible)

### References

Refs #3110, Refs #3101

This is a clean-room implementation written directly for Apache Pekko.
