### PR TITLE
fix: add supervision strategy support for batch costFn

### DIFF
--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/batch.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/batch.md
@@ -23,6 +23,11 @@ to the summary type.
 Will eagerly pull elements, this behavior may result in a single pending (i.e. buffered) element which cannot be
 aggregated to the batched value.
 
+This operator adheres to the `ActorAttributes.SupervisionStrategy` attribute for exceptions thrown by the `costFn`,
+`seed`, or `aggregate` functions. On `Supervision.Stop` (the default) the stream fails. On `Supervision.Resume` the
+offending element is dropped and the accumulated batch (if any) is preserved. On `Supervision.Restart` the offending
+element is dropped, the accumulated batch is discarded, and the operator starts fresh.
+
 ## Reactive Streams semantics
 
 @@@div { .callout }

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/batchWeighted.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/batchWeighted.md
@@ -21,6 +21,11 @@ backpressure.
 Will eagerly pull elements, this behavior may result in a single pending (i.e. buffered) element which cannot be
 aggregated to the batched value.
 
+This operator adheres to the `ActorAttributes.SupervisionStrategy` attribute for exceptions thrown by the `costFn`,
+`seed`, or `aggregate` functions. On `Supervision.Stop` (the default) the stream fails. On `Supervision.Resume` the
+offending element is dropped and the accumulated batch (if any) is preserved. On `Supervision.Restart` the offending
+element is dropped, the accumulated batch is discarded, and the operator starts fresh.
+
 ## Reactive Streams semantics
 
 @@@div { .callout }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowBatchSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowBatchSpec.scala
@@ -348,5 +348,52 @@ class FlowBatchSpec extends StreamSpec("""
       subscriber.expectComplete()
     }
 
+    "resume when seed throws in onPush and supervision is Resume" in {
+      // seed is only called in onPush when agg == null (i.e. no active batch).
+      // Under Resume the failing element must be dropped and the next element
+      // should start a fresh batch.
+      val future = Source(1 to 5)
+        .batchWeighted(
+          max = Long.MaxValue,
+          costFn = (i: Int) => i.toLong,
+          seed = (i: Int) => if (i == 1) throw new RuntimeException("boom") else i)(aggregate = _ + _)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runFold(0)(_ + _)
+      Await.result(future, 3.seconds) should be(2 + 3 + 4 + 5)
+    }
+
+    "resume when aggregate throws in onPush and supervision is Resume" in {
+      // aggregate is only called in onPush when downstream backpressures and a batch
+      // is accumulating. Use a manual subscriber to force batching. Under Resume
+      // the failing element must be dropped while the accumulated batch is preserved.
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.manualProbe[Int]()
+
+      Source
+        .fromPublisher(publisher)
+        .batchWeighted(
+          max = 10,
+          costFn = (_: Int) => 1L,
+          seed = (i: Int) => i)(aggregate =
+          (acc, i) => if (i == 3) throw new RuntimeException("boom") else acc + i)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .to(Sink.fromSubscriber(subscriber))
+        .run()
+      val sub = subscriber.expectSubscription()
+
+      // Send elements without requesting; they accumulate in a single batch.
+      publisher.sendNext(1) // seed -> agg=1
+      publisher.sendNext(2) // aggregate(1,2) -> agg=3
+      publisher.sendNext(3) // aggregate(3,3) throws -> Resume, agg stays 3, element 3 dropped
+      publisher.sendNext(4) // aggregate(3,4) -> agg=7
+      publisher.sendNext(5) // aggregate(7,5) -> agg=12
+      publisher.sendComplete()
+
+      subscriber.expectNoMessage(300.millis)
+      sub.request(1)
+      subscriber.expectNext(1 + 2 + 4 + 5)
+      subscriber.expectComplete()
+    }
+
   }
 }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowBatchSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowBatchSpec.scala
@@ -19,7 +19,9 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.pekko
+import pekko.stream.ActorAttributes
 import pekko.stream.OverflowStrategy
+import pekko.stream.Supervision
 import pekko.stream.testkit._
 
 class FlowBatchSpec extends StreamSpec("""
@@ -118,6 +120,232 @@ class FlowBatchSpec extends StreamSpec("""
         .buffer(50, OverflowStrategy.backpressure)
         .runFold(0)(_ + _)
       Await.result(future, 3.seconds) should be((1 to 50).sum)
+    }
+
+    "fail stream when costFn throws and supervision is Stop" in {
+      val ex = new RuntimeException("boom")
+      val result = Source(1 to 5)
+        .batchWeighted(
+          max = 10,
+          costFn = (i: Int) => if (i == 3) throw ex else i.toLong,
+          seed = (i: Int) => i)(aggregate = _ + _)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
+        .runWith(Sink.ignore)
+      result.failed.futureValue shouldBe ex
+    }
+
+    "fail stream when costFn throws and supervision defaults to Stop" in {
+      // No supervision attribute is set, so the mandatory SupervisionStrategy attribute
+      // resolves to the default stopping decider. This guards the default code path.
+      val ex = new RuntimeException("boom")
+      val result = Source(1 to 5)
+        .batchWeighted(
+          max = 10,
+          costFn = (i: Int) => if (i == 3) throw ex else i.toLong,
+          seed = (i: Int) => i)(aggregate = _ + _)
+        .runWith(Sink.ignore)
+      result.failed.futureValue shouldBe ex
+    }
+
+    "resume when costFn throws and supervision is Resume" in {
+      val future = Source(1 to 5)
+        .batchWeighted(
+          max = Long.MaxValue,
+          costFn = (i: Int) => if (i == 3) throw new RuntimeException("boom") else i.toLong,
+          seed = (i: Int) => i)(aggregate = _ + _)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runFold(0)(_ + _)
+      Await.result(future, 3.seconds) should be(12) // 1 + 2 + 4 + 5, 3 is skipped
+    }
+
+    // The next two tests are a directional pair: with downstream silent the whole stream
+    // aggregates into a single batch, so the emitted value reveals whether the partial
+    // batch accumulated before the failing element was kept (Resume) or discarded (Restart).
+    "keep the accumulated batch when costFn throws and supervision is Resume" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.manualProbe[Int]()
+
+      Source
+        .fromPublisher(publisher)
+        .batchWeighted(
+          max = Long.MaxValue,
+          costFn = (i: Int) => if (i == 3) throw new RuntimeException("boom") else 1L,
+          seed = (i: Int) => i)(aggregate = _ + _)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .to(Sink.fromSubscriber(subscriber))
+        .run()
+      val sub = subscriber.expectSubscription()
+
+      for (i <- 1 to 5) publisher.sendNext(i)
+      publisher.sendComplete()
+      subscriber.expectNoMessage(300.millis)
+      sub.request(1)
+      // 1 + 2 accumulated, element 3 skipped but the partial batch is preserved, then 4 + 5 added
+      subscriber.expectNext(1 + 2 + 4 + 5)
+      subscriber.expectComplete()
+    }
+
+    "reset the accumulated batch when costFn throws and supervision is Restart" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.manualProbe[Int]()
+
+      Source
+        .fromPublisher(publisher)
+        .batchWeighted(
+          max = Long.MaxValue,
+          costFn = (i: Int) => if (i == 3) throw new RuntimeException("boom") else 1L,
+          seed = (i: Int) => i)(aggregate = _ + _)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .to(Sink.fromSubscriber(subscriber))
+        .run()
+      val sub = subscriber.expectSubscription()
+
+      for (i <- 1 to 5) publisher.sendNext(i)
+      publisher.sendComplete()
+      subscriber.expectNoMessage(300.millis)
+      sub.request(1)
+      // 1 + 2 accumulated, then discarded on Restart, element 3 skipped, only 4 + 5 remain
+      subscriber.expectNext(4 + 5)
+      subscriber.expectComplete()
+    }
+
+    "restart and continue when pending element costFn throws during flush" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.manualProbe[Int]()
+      var callsForThree = 0
+
+      Source
+        .fromPublisher(publisher)
+        .batchWeighted(
+          max = 3,
+          costFn = (i: Int) => {
+            if (i == 3) {
+              callsForThree += 1
+              if (callsForThree == 2) throw new RuntimeException("boom")
+            }
+            i.toLong
+          },
+          seed = (i: Int) => i)(aggregate = _ + _)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .to(Sink.fromSubscriber(subscriber))
+        .run()
+      val sub = subscriber.expectSubscription()
+
+      // 3 is evaluated once in onPush (becomes pending because left < cost) and again in flush.
+      publisher.sendNext(1)
+      publisher.sendNext(2)
+      publisher.sendNext(3)
+      subscriber.expectNoMessage(300.millis)
+
+      sub.request(1)
+      subscriber.expectNext(3)
+
+      // After restart in flush(), the stage must still pull and continue processing new elements.
+      publisher.sendNext(4)
+      publisher.sendComplete()
+      sub.request(1)
+      subscriber.expectNext(4)
+      subscriber.expectComplete()
+
+      callsForThree shouldBe 2
+    }
+
+    "resume and continue when pending element costFn throws during flush" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.manualProbe[Int]()
+      var callsForThree = 0
+
+      Source
+        .fromPublisher(publisher)
+        .batchWeighted(
+          max = 2,
+          costFn = (i: Int) => {
+            if (i == 3) {
+              callsForThree += 1
+              if (callsForThree == 2) throw new RuntimeException("boom")
+            }
+            1L
+          },
+          seed = (i: Int) => i)(aggregate = _ + _)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .to(Sink.fromSubscriber(subscriber))
+        .run()
+      val sub = subscriber.expectSubscription()
+
+      // 3 is evaluated once in onPush (becomes pending) and again in flush.
+      publisher.sendNext(1)
+      publisher.sendNext(2)
+      publisher.sendNext(3)
+      subscriber.expectNoMessage(300.millis)
+
+      sub.request(1)
+      subscriber.expectNext(3)
+
+      // On Resume, pending should be dropped without leaking the previously emitted batch into new state.
+      publisher.sendNext(4)
+      publisher.sendComplete()
+      sub.request(1)
+      subscriber.expectNext(4)
+      subscriber.expectComplete()
+
+      callsForThree shouldBe 2
+    }
+
+    "stop with the original exception when pending element costFn throws during flush" in {
+      val ex = new RuntimeException("boom")
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.manualProbe[Int]()
+      var callsForThree = 0
+
+      Source
+        .fromPublisher(publisher)
+        .batchWeighted(
+          max = 2,
+          costFn = (i: Int) => {
+            if (i == 3) {
+              callsForThree += 1
+              if (callsForThree == 2) throw ex
+            }
+            1L
+          },
+          seed = (i: Int) => i)(aggregate = _ + _)
+        .to(Sink.fromSubscriber(subscriber))
+        .run()
+      val sub = subscriber.expectSubscription()
+
+      publisher.sendNext(1)
+      publisher.sendNext(2)
+      publisher.sendNext(3)
+      subscriber.expectNoMessage(300.millis)
+
+      sub.request(1)
+      subscriber.expectNext(3)
+      subscriber.expectError(ex)
+
+      callsForThree shouldBe 2
+    }
+
+    "complete when pending seed throws at end of stream and supervision is Restart" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.manualProbe[Int]()
+
+      Source
+        .fromPublisher(publisher)
+        .batchWeighted(
+          max = 1,
+          costFn = (_: Int) => 1L,
+          seed = (i: Int) => if (i == 2) throw new RuntimeException("boom") else i)(aggregate = _ + _)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .to(Sink.fromSubscriber(subscriber))
+        .run()
+      val sub = subscriber.expectSubscription()
+
+      publisher.sendNext(1)
+      publisher.sendNext(2)
+      publisher.sendComplete()
+      sub.request(1)
+      subscriber.expectNext(1)
+      subscriber.expectComplete()
     }
 
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -1081,11 +1081,13 @@ private[stream] object Collect {
         if (agg != null) {
           push(out, agg)
           left = max
+          agg = null.asInstanceOf[Out]
         }
         if (pending != null) {
           try {
+            val cost = costFn(pending)
             agg = seed(pending)
-            left -= costFn(pending)
+            left -= cost
             pending = null.asInstanceOf[In]
           } catch {
             case NonFatal(ex) =>
@@ -1105,7 +1107,23 @@ private[stream] object Collect {
 
       def onPush(): Unit = {
         val elem = grab(in)
-        val cost = costFn(elem)
+        val cost =
+          try costFn(elem)
+          catch {
+            case NonFatal(ex) =>
+              decider(ex) match {
+                case Supervision.Stop =>
+                  failStage(ex)
+                  return
+                case Supervision.Resume =>
+                  pull(in)
+                  return
+                case Supervision.Restart =>
+                  restartState()
+                  pull(in)
+                  return
+              }
+          }
         contextPropagation.suspendContext()
 
         if (agg == null) {
@@ -1139,7 +1157,7 @@ private[stream] object Collect {
         }
 
         if (isAvailable(out)) flush()
-        if (pending == null) pull(in)
+        if (pending == null && !isClosed(in)) pull(in)
       }
 
       override def onUpstreamFinish(): Unit = {
@@ -1153,6 +1171,7 @@ private[stream] object Collect {
         } else if (isClosed(in)) {
           contextPropagation.resumeContext()
           push(out, agg)
+          agg = null.asInstanceOf[Out]
           if (pending == null) completeStage()
           else {
             try {
@@ -1160,19 +1179,21 @@ private[stream] object Collect {
             } catch {
               case NonFatal(ex) =>
                 decider(ex) match {
-                  case Supervision.Stop    => failStage(ex)
+                  case Supervision.Stop =>
+                    failStage(ex)
+                    return
                   case Supervision.Resume  =>
                   case Supervision.Restart =>
                     restartState()
-                    if (!hasBeenPulled(in)) pull(in)
                 }
             }
             pending = null.asInstanceOf[In]
+            if (agg == null) completeStage()
           }
         } else {
           contextPropagation.resumeContext()
           flush()
-          if (!hasBeenPulled(in)) pull(in)
+          if (!isClosed(in) && !hasBeenPulled(in)) pull(in)
         }
 
       }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -1092,7 +1092,9 @@ private[stream] object Collect {
           } catch {
             case NonFatal(ex) =>
               decider(ex) match {
-                case Supervision.Stop    => failStage(ex)
+                case Supervision.Stop =>
+                  failStage(ex)
+                  return
                 case Supervision.Restart => restartState()
                 case Supervision.Resume  =>
                   pending = null.asInstanceOf[In]
@@ -1133,7 +1135,9 @@ private[stream] object Collect {
           } catch {
             case NonFatal(ex) =>
               decider(ex) match {
-                case Supervision.Stop    => failStage(ex)
+                case Supervision.Stop =>
+                  failStage(ex)
+                  return
                 case Supervision.Restart =>
                   restartState()
                 case Supervision.Resume =>
@@ -1148,7 +1152,9 @@ private[stream] object Collect {
           } catch {
             case NonFatal(ex) =>
               decider(ex) match {
-                case Supervision.Stop    => failStage(ex)
+                case Supervision.Stop =>
+                  failStage(ex)
+                  return
                 case Supervision.Restart =>
                   restartState()
                 case Supervision.Resume =>


### PR DESCRIPTION
### Motivation

Issue #3110 tracks stream operators that should honor `SupervisionStrategy` for user functions.

`batchWeighted` already supervised `seed` and `aggregate`, but `costFn` in `Batch.onPush()` still ran outside that boundary, so `costFn` exceptions failed the stream unconditionally.

While adding `costFn` supervision, additional coupled exceptional-path issues were found around pending-element handling in `flush()`/EOS handling (state leakage and invalid pull-after-fail behavior). Those are fixed in the same PR to keep supervision behavior consistent and safe.

### Modification

- Added supervision handling around `costFn(elem)` in `Batch.onPush()`:
  - `Stop` → fail stage
  - `Resume` → drop offending element and continue
  - `Restart` → reset batch state and continue
- Hardened pending exceptional paths in `Batch`:
  - clear `agg` immediately after push before processing `pending`
  - evaluate `costFn(pending)` before `seed(pending)` in `flush()`
  - guard follow-up pulls with `!isClosed(in)`
  - complete stage at EOS when pending is dropped by `Resume`/`Restart` after seed failure
- Expanded directional tests in `FlowBatchSpec`:
  - explicit `Stop` and default `Stop`
  - Resume vs Restart semantics
  - pending/flush second `costFn` evaluation failures under Resume/Restart/Stop
  - EOS pending-seed failure under Restart

### Result

`batch` / `batchWeighted` now consistently apply supervision to `costFn`, `seed`, and `aggregate`, and maintain correct state/pull behavior on exceptional pending paths.

which is now Apache licensed

### Tests

- `sbt "stream-tests/Test/testOnly org.apache.pekko.stream.scaladsl.FlowBatchSpec"` (14/14 passed)
- `sbt "stream/mimaReportBinaryIssues"` (clean)

### References

Refs #3110
