### PR TITLE
refactor: replace .collect(Collectors.toList()) with .toList()

### DIFF
--- a/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/AggregatorTest.java
+++ b/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/AggregatorTest.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.pekko.actor.testkit.typed.annotations.JUnitJupiterTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.JUnitJupiterTestKitBuilder;
@@ -159,7 +158,7 @@ public class AggregatorTest {
                       }
                     })
                 .sorted((a, b) -> a.price().compareTo(b.price()))
-                .collect(Collectors.toList());
+                .toList();
 
         return new AggregatedQuotes(quotes);
       }

--- a/docs/src/test/java/jdocs/stream/RateTransformationDocTest.java
+++ b/docs/src/test/java/jdocs/stream/RateTransformationDocTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 import jdocs.AbstractJavaTest;
@@ -71,7 +70,7 @@ public class RateTransformationDocTest extends AbstractJavaTest {
                 elem -> Collections.singletonList(elem),
                 (acc, elem) -> {
                   return Stream.concat(acc.stream(), Collections.singletonList(elem).stream())
-                      .collect(Collectors.toList());
+                      .toList();
                 })
             .map(
                 s -> {
@@ -103,7 +102,7 @@ public class RateTransformationDocTest extends AbstractJavaTest {
                 (acc, elem) -> {
                   if (r.nextDouble() < p) {
                     return Stream.concat(acc.stream(), Collections.singletonList(elem).stream())
-                        .collect(Collectors.toList());
+                        .toList();
                   }
                   return acc;
                 })

--- a/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMultiGroupByTest.java
+++ b/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMultiGroupByTest.java
@@ -13,7 +13,6 @@
 
 package jdocs.stream.javadsl.cookbook;
 
-import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -111,7 +110,7 @@ public class RecipeMultiGroupByTest extends RecipeTest {
                   // the message belongs to
                   return topicsForMessage.stream()
                       .map(topic -> new Pair<Message, Topic>(msg, topic))
-                      .collect(toList());
+                      .toList();
                 });
 
         SubSource<Pair<Message, Topic>, NotUsed> multiGroups =
@@ -138,7 +137,7 @@ public class RecipeMultiGroupByTest extends RecipeTest {
                       Topic topic = pair.get(0).second();
                       return topic.name
                           + mkString(
-                              pair.stream().map(p -> p.first().msg).collect(toList()),
+                              pair.stream().map(p -> p.first().msg).toList(),
                               "[",
                               ", ",
                               "]");

--- a/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMultiGroupByTest.java
+++ b/docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMultiGroupByTest.java
@@ -137,10 +137,7 @@ public class RecipeMultiGroupByTest extends RecipeTest {
                       Topic topic = pair.get(0).second();
                       return topic.name
                           + mkString(
-                              pair.stream().map(p -> p.first().msg).toList(),
-                              "[",
-                              ", ",
-                              "]");
+                              pair.stream().map(p -> p.first().msg).toList(), "[", ", ", "]");
                     })
                 .grouped(10)
                 .runWith(Sink.head(), system);

--- a/stream-tests/src/test/java/org/apache/pekko/stream/io/SinkAsJavaSourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/io/SinkAsJavaSourceTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.pekko.stream.StreamTestJupiter;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -43,6 +42,6 @@ public class SinkAsJavaSourceTest extends StreamTestJupiter {
     final List<Integer> list = Arrays.asList(1, 2, 3);
     final Sink<Integer, Stream<Integer>> streamSink = StreamConverters.asJavaStream();
     java.util.stream.Stream<Integer> javaStream = Source.from(list).runWith(streamSink, system);
-    assertEquals(list, javaStream.collect(Collectors.toList()));
+    assertEquals(list, javaStream.toList());
   }
 }

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/FlowTest.java
@@ -501,7 +501,7 @@ public class FlowTest extends StreamTestJupiter {
     final List<List<String>> result =
         future.toCompletableFuture().get(1, TimeUnit.SECONDS).stream()
             .sorted(Comparator.comparingInt(list -> list.get(0).charAt(0)))
-            .collect(Collectors.toList());
+            .toList();
 
     assertEquals(
         Arrays.asList(

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -266,7 +266,7 @@ public class SourceTest extends StreamTestJupiter {
     final List<List<String>> result =
         future.toCompletableFuture().get(1, TimeUnit.SECONDS).stream()
             .sorted(Comparator.comparingInt(list -> list.get(0).charAt(0)))
-            .collect(Collectors.toList());
+            .toList();
 
     assertEquals(
         Arrays.asList(


### PR DESCRIPTION
### Motivation
Java 16+ `Stream.toList()` provides a concise way to collect stream elements into an unmodifiable list, replacing the verbose `.collect(Collectors.toList())` pattern.

### Modification
Replace `.collect(Collectors.toList())` with `.toList()` across 8 files.
Remove unused `Collectors` imports.
Correctly skips Pekko Streams `Sink.collect(Collectors.toList())` patterns which are not JDK Stream API calls.

### Result
Cleaner stream collection code using Java 17 API.

### Tests
Not run - compile-only test file changes

### References
None - Java 17 API modernization