### PR TITLE
refactor: migrate String.format to String.formatted (Java 15+)

### DIFF
--- a/docs/src/test/java/jdocs/actor/FaultHandlingDocSample.java
+++ b/docs/src/test/java/jdocs/actor/FaultHandlingDocSample.java
@@ -109,7 +109,7 @@ public class FaultHandlingDocSample {
       }
 
       public String toString() {
-        return String.format("%s(%s)", getClass().getSimpleName(), percent);
+        return "%s(%s)".formatted(getClass().getSimpleName(), percent);
       }
     }
   }
@@ -196,7 +196,7 @@ public class FaultHandlingDocSample {
       }
 
       public String toString() {
-        return String.format("%s(%s, %s)", getClass().getSimpleName(), key, count);
+        return "%s(%s, %s)".formatted(getClass().getSimpleName(), key, count);
       }
     }
 
@@ -208,7 +208,7 @@ public class FaultHandlingDocSample {
       }
 
       public String toString() {
-        return String.format("%s(%s)", getClass().getSimpleName(), n);
+        return "%s(%s)".formatted(getClass().getSimpleName(), n);
       }
     }
 
@@ -364,7 +364,7 @@ public class FaultHandlingDocSample {
       }
 
       public String toString() {
-        return String.format("%s(%s)", getClass().getSimpleName(), storage);
+        return "%s(%s)".formatted(getClass().getSimpleName(), storage);
       }
     }
   }
@@ -430,7 +430,7 @@ public class FaultHandlingDocSample {
       }
 
       public String toString() {
-        return String.format("%s(%s)", getClass().getSimpleName(), entry);
+        return "%s(%s)".formatted(getClass().getSimpleName(), entry);
       }
     }
 
@@ -444,7 +444,7 @@ public class FaultHandlingDocSample {
       }
 
       public String toString() {
-        return String.format("%s(%s, %s)", getClass().getSimpleName(), key, value);
+        return "%s(%s, %s)".formatted(getClass().getSimpleName(), key, value);
       }
     }
 
@@ -456,7 +456,7 @@ public class FaultHandlingDocSample {
       }
 
       public String toString() {
-        return String.format("%s(%s)", getClass().getSimpleName(), key);
+        return "%s(%s)".formatted(getClass().getSimpleName(), key);
       }
     }
 

--- a/docs/src/test/java/jdocs/persistence/LambdaPersistenceDocTest.java
+++ b/docs/src/test/java/jdocs/persistence/LambdaPersistenceDocTest.java
@@ -404,12 +404,12 @@ public class LambdaPersistenceDocTest {
             getSender().tell(c, getSelf());
 
             persistAsync(
-                String.format("evt-%s-1", c),
+                "evt-%s-1".formatted(c),
                 e -> {
                   getSender().tell(e, getSelf());
                 });
             persistAsync(
-                String.format("evt-%s-2", c),
+                "evt-%s-2".formatted(c),
                 e -> {
                   getSender().tell(e, getSelf());
                 });
@@ -458,18 +458,18 @@ public class LambdaPersistenceDocTest {
 
           private void handleCommand(String c) {
             persistAsync(
-                String.format("evt-%s-1", c),
+                "evt-%s-1".formatted(c),
                 e -> {
                   getSender().tell(e, getSelf());
                 });
             persistAsync(
-                String.format("evt-%s-2", c),
+                "evt-%s-2".formatted(c),
                 e -> {
                   getSender().tell(e, getSelf());
                 });
 
             deferAsync(
-                String.format("evt-%s-3", c),
+                "evt-%s-3".formatted(c),
                 e -> {
                   getSender().tell(e, getSelf());
                 });
@@ -521,18 +521,18 @@ public class LambdaPersistenceDocTest {
 
           private void handleCommand(String c) {
             persist(
-                String.format("evt-%s-1", c),
+                "evt-%s-1".formatted(c),
                 e -> {
                   sender().tell(e, self());
                 });
             persist(
-                String.format("evt-%s-2", c),
+                "evt-%s-2".formatted(c),
                 e -> {
                   sender().tell(e, self());
                 });
 
             defer(
-                String.format("evt-%s-3", c),
+                "evt-%s-3".formatted(c),
                 e -> {
                   sender().tell(e, self());
                 });
@@ -576,17 +576,17 @@ public class LambdaPersistenceDocTest {
                     String.class,
                     msg -> {
                       persist(
-                          String.format("%s-outer-1", msg),
+                          "%s-outer-1".formatted(msg),
                           event -> {
                             getSender().tell(event, getSelf());
-                            persist(String.format("%s-inner-1", event), replyToSender);
+                            persist("%s-inner-1".formatted(event), replyToSender);
                           });
 
                       persist(
-                          String.format("%s-outer-2", msg),
+                          "%s-outer-2".formatted(msg),
                           event -> {
                             getSender().tell(event, getSelf());
-                            persist(String.format("%s-inner-2", event), replyToSender);
+                            persist("%s-inner-2".formatted(event), replyToSender);
                           });
                     })
                 .build();
@@ -637,17 +637,17 @@ public class LambdaPersistenceDocTest {
                     String.class,
                     msg -> {
                       persistAsync(
-                          String.format("%s-outer-1", msg),
+                          "%s-outer-1".formatted(msg),
                           event -> {
                             getSender().tell(event, getSelf());
-                            persistAsync(String.format("%s-inner-1", event), replyToSender);
+                            persistAsync("%s-inner-1".formatted(event), replyToSender);
                           });
 
                       persistAsync(
-                          String.format("%s-outer-2", msg),
+                          "%s-outer-2".formatted(msg),
                           event -> {
                             getSender().tell(event, getSelf());
-                            persistAsync(String.format("%s-inner-1", event), replyToSender);
+                            persistAsync("%s-inner-1".formatted(event), replyToSender);
                           });
                     })
                 .build();

--- a/docs/src/test/java/jdocs/stream/FlowErrorDocTest.java
+++ b/docs/src/test/java/jdocs/stream/FlowErrorDocTest.java
@@ -156,7 +156,7 @@ public class FlowErrorDocTest extends AbstractJavaTest {
             n -> {
               // assuming `4` and `5` are unexpected values that could throw exception
               if (Arrays.asList(4, 5).contains(n))
-                throw new RuntimeException(String.format("Boom! Bad value found: %s", n));
+                throw new RuntimeException("Boom! Bad value found: %s".formatted(n));
               else return n.toString();
             })
         .recover(

--- a/docs/src/test/java/jdocs/stream/QuickStartDocTest.java
+++ b/docs/src/test/java/jdocs/stream/QuickStartDocTest.java
@@ -69,7 +69,7 @@ public class QuickStartDocTest extends AbstractJavaTest {
 
     // #add-streams
     factorials
-        .zipWith(Source.range(0, 99), (num, idx) -> String.format("%d! = %s", idx, num))
+        .zipWith(Source.range(0, 99), (num, idx) -> "%d! = %s".formatted(idx, num))
         .throttle(1, Duration.ofSeconds(1))
         // #add-streams
         .take(2)


### PR DESCRIPTION
## Summary
- Migrate `String.format("literal", args)` to `"literal".formatted(args)` (Java 15+ API)
- 4 files updated: test and documentation example files
- Behavior-preserving refactoring, no functional changes

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17