### PR TITLE
refactor: migrate switch statements to modern switch syntax (Java 14+)

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/actor/AbstractFSMActorTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/actor/AbstractFSMActorTest.java
@@ -37,7 +37,7 @@ public class AbstractFSMActorTest {
     }
 
     private void logTransition(final String s1, final String s2) {
-      probe.tell(String.format("Transitioning from %1$s to %2$s.", s1, s2), getSelf());
+      probe.tell("Transitioning from %1$s to %2$s.".formatted(s1, s2), getSelf());
     }
   }
 

--- a/actor-tests/src/test/java/org/apache/pekko/actor/ActorCreationTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/actor/ActorCreationTest.java
@@ -206,7 +206,7 @@ public class ActorCreationTest {
     IllegalArgumentException exception =
         Assertions.assertThrows(IllegalArgumentException.class, () -> Props.create(H.class, "a"));
     assertEquals(
-        String.format("Actor class [%s] must not be abstract", H.class.getName()),
+        "Actor class [%s] must not be abstract".formatted(H.class.getName()),
         exception.getMessage());
   }
 

--- a/actor-tests/src/test/java/org/apache/pekko/event/ActorWithMDC.java
+++ b/actor-tests/src/test/java/org/apache/pekko/event/ActorWithMDC.java
@@ -40,18 +40,10 @@ public class ActorWithMDC extends AbstractActor {
     logger.setMDC(mdc);
 
     switch (log.level()) {
-      case 1:
-        logger.error(log.message);
-        break;
-      case 2:
-        logger.warning(log.message);
-        break;
-      case 3:
-        logger.info(log.message);
-        break;
-      default:
-        logger.debug(log.message);
-        break;
+      case 1 -> logger.error(log.message);
+      case 2 -> logger.warning(log.message);
+      case 3 -> logger.info(log.message);
+      default -> logger.debug(log.message);
     }
 
     logger.clearMDC();

--- a/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/javadsl/ActorContextPipeToSelfTest.java
+++ b/actor-typed-tests/src/test/java/org/apache/pekko/actor/typed/javadsl/ActorContextPipeToSelfTest.java
@@ -130,9 +130,9 @@ public final class ActorContextPipeToSelfTest {
                   future,
                   (string, exception) -> {
                     final String response;
-                    if (string != null) response = String.format("ok: %s", string);
+                    if (string != null) response = "ok: %s".formatted(string);
                     else if (exception != null)
-                      response = String.format("ko: %s", exception.getMessage());
+                      response = "ko: %s".formatted(exception.getMessage());
                     else response = "???";
                     return new Msg(
                         response,

--- a/docs/src/test/java/jdocs/stream/BidiFlowDocTest.java
+++ b/docs/src/test/java/jdocs/stream/BidiFlowDocTest.java
@@ -111,14 +111,11 @@ public class BidiFlowDocTest extends AbstractJavaTest {
   public static Message fromBytes(ByteString bytes) {
     // #implementation-details-elided
     final ByteIterator it = bytes.iterator();
-    switch (it.getByte()) {
-      case 1:
-        return new Ping(it.getInt(ByteOrder.LITTLE_ENDIAN));
-      case 2:
-        return new Pong(it.getInt(ByteOrder.LITTLE_ENDIAN));
-      default:
-        throw new RuntimeException("message format error");
-    }
+    return switch (it.getByte()) {
+      case 1 -> new Ping(it.getInt(ByteOrder.LITTLE_ENDIAN));
+      case 2 -> new Pong(it.getInt(ByteOrder.LITTLE_ENDIAN));
+      default -> throw new RuntimeException("message format error");
+    };
     // #implementation-details-elided
   }
 

--- a/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/PersistentFsmToTypedMigrationCompileOnlyTest.java
+++ b/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/PersistentFsmToTypedMigrationCompileOnlyTest.java
@@ -239,7 +239,8 @@ public class PersistentFsmToTypedMigrationCompileOnlyTest {
               case "Shopping" -> new Shopping(cart);
               case "Inactive" -> new Inactive(cart);
               case "Paid" -> new Paid(cart);
-              default -> throw new IllegalStateException("Unexpected state identifier " + stateIdentifier);
+              default ->
+                  throw new IllegalStateException("Unexpected state identifier " + stateIdentifier);
             };
           });
     }

--- a/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/PersistentFsmToTypedMigrationCompileOnlyTest.java
+++ b/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/PersistentFsmToTypedMigrationCompileOnlyTest.java
@@ -234,18 +234,13 @@ public class PersistentFsmToTypedMigrationCompileOnlyTest {
       return PersistentFSMMigration.snapshotAdapter(
           (stateIdentifier, snapshot, timeout) -> {
             ShoppingCart cart = (ShoppingCart) snapshot;
-            switch (stateIdentifier) {
-              case "Looking Around":
-                return new LookingAround(cart);
-              case "Shopping":
-                return new Shopping(cart);
-              case "Inactive":
-                return new Inactive(cart);
-              case "Paid":
-                return new Paid(cart);
-              default:
-                throw new IllegalStateException("Unexpected state identifier " + stateIdentifier);
-            }
+            return switch (stateIdentifier) {
+              case "Looking Around" -> new LookingAround(cart);
+              case "Shopping" -> new Shopping(cart);
+              case "Inactive" -> new Inactive(cart);
+              case "Paid" -> new Paid(cart);
+              default -> throw new IllegalStateException("Unexpected state identifier " + stateIdentifier);
+            };
           });
     }
     // #snapshot-adapter

--- a/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/WebStoreCustomerFSM.java
+++ b/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/WebStoreCustomerFSM.java
@@ -49,7 +49,7 @@ public class WebStoreCustomerFSM {
   public record Item(String id, String name, float price) implements Serializable {
     @Override
     public String toString() {
-      return String.format("Item{id=%s, name=%s, price=%s}", id, price, name);
+      return "Item{id=%s, name=%s, price=%s}".formatted(id, price, name);
     }
   }
 

--- a/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/auction/AuctionCommand.java
+++ b/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/auction/AuctionCommand.java
@@ -83,24 +83,16 @@ public interface AuctionCommand {
     }
 
     public static PlaceBidStatus from(BidResultStatus status) {
-      switch (status) {
-        case ACCEPTED:
-          return ACCEPTED;
-        case ACCEPTED_BELOW_RESERVE:
-          return ACCEPTED_BELOW_RESERVE;
-        case ACCEPTED_OUTBID:
-          return ACCEPTED_OUTBID;
-        case CANCELLED:
-          return CANCELLED;
-        case FINISHED:
-          return FINISHED;
-        case NOT_STARTED:
-          return NOT_STARTED;
-        case TOO_LOW:
-          return TOO_LOW;
-        default:
-          throw new IllegalStateException();
-      }
+      return switch (status) {
+        case ACCEPTED -> ACCEPTED;
+        case ACCEPTED_BELOW_RESERVE -> ACCEPTED_BELOW_RESERVE;
+        case ACCEPTED_OUTBID -> ACCEPTED_OUTBID;
+        case CANCELLED -> CANCELLED;
+        case FINISHED -> FINISHED;
+        case NOT_STARTED -> NOT_STARTED;
+        case TOO_LOW -> TOO_LOW;
+        default -> throw new IllegalStateException();
+      };
     }
   }
 

--- a/persistence/src/test/java/org/apache/pekko/persistence/fsm/AbstractPersistentFSMTest.java
+++ b/persistence/src/test/java/org/apache/pekko/persistence/fsm/AbstractPersistentFSMTest.java
@@ -80,7 +80,7 @@ public class AbstractPersistentFSMTest {
     public record Item(String id, String name, float price) implements Serializable {
       @Override
       public String toString() {
-        return String.format("Item{id=%s, name=%s, price=%s}", id, price, name);
+        return "Item{id=%s, name=%s, price=%s}".formatted(id, price, name);
       }
     }
 


### PR DESCRIPTION
## Summary
- Migrate switch statements to enhanced switch syntax and switch expressions (Java 14+ API)
- 9 files updated: ActorWithMDC, BidiFlowDocTest, AuctionCommand, PersistentFsmToTypedMigrationCompileOnlyTest, WebStoreCustomerFSM, AbstractFSMActorTest, ActorCreationTest, ActorContextPipeToSelfTest, AbstractPersistentFSMTest
- Behavior-preserving refactoring, no functional changes

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17