### PR TITLE
refactor: use pattern matching instanceof (Java 16+)

### DIFF
--- a/cluster-typed/src/test/java/jdocs/org/apache/pekko/cluster/typed/PingSerializerExampleTest.java
+++ b/cluster-typed/src/test/java/jdocs/org/apache/pekko/cluster/typed/PingSerializerExampleTest.java
@@ -66,9 +66,9 @@ public class PingSerializerExampleTest {
 
     @Override
     public byte[] toBinary(Object obj) {
-      if (obj instanceof Ping)
+      if (obj instanceof Ping ping)
         return actorRefResolver
-            .toSerializationFormat(((Ping) obj).replyTo)
+            .toSerializationFormat(ping.replyTo)
             .getBytes(StandardCharsets.UTF_8);
       else if (obj instanceof Pong) return new byte[0];
       else

--- a/docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -153,9 +153,9 @@ public class ActorDocTest extends AbstractJavaTest {
 
     @Override
     public void onReceive(Object msg) throws Exception {
-      if (msg instanceof Msg1) receiveMsg1((Msg1) msg);
-      else if (msg instanceof Msg2) receiveMsg2((Msg2) msg);
-      else if (msg instanceof Msg3) receiveMsg3((Msg3) msg);
+      if (msg instanceof Msg1 msg1) receiveMsg1(msg1);
+      else if (msg instanceof Msg2 msg2) receiveMsg2(msg2);
+      else if (msg instanceof Msg3 msg3) receiveMsg3(msg3);
       else unhandled(msg);
     }
 


### PR DESCRIPTION
## Summary
- Migrate remaining old-style `instanceof` checks with explicit casts to Java 16+ pattern matching instanceof
- 2 files updated: PingSerializerExampleTest (1 cast pattern), ActorDocTest (3 cast patterns)
- Most of the codebase already uses pattern matching instanceof; remaining instanceof checks are pure boolean tests (no cast needed)

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17