### PR TITLE
refactor: apply misc Java 11-17 improvements

### DIFF
--- a/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/TestConfigExample.java
+++ b/actor-testkit-typed/src/test/java/jdocs/org/apache/pekko/actor/testkit/typed/javadsl/TestConfigExample.java
@@ -28,12 +28,20 @@ public class TestConfigExample {
     ;
 
     // #parse-string
-    ConfigFactory.parseString("pekko.loglevel = DEBUG \n" + "pekko.log-config-on-start = on \n")
+    ConfigFactory.parseString(
+        """
+        pekko.loglevel = DEBUG
+        pekko.log-config-on-start = on
+        """)
     // #parse-string
     ;
 
     // #fallback-application-conf
-    ConfigFactory.parseString("pekko.loglevel = DEBUG \n" + "pekko.log-config-on-start = on \n")
+    ConfigFactory.parseString(
+            """
+            pekko.loglevel = DEBUG
+            pekko.log-config-on-start = on
+            """)
         .withFallback(ConfigFactory.load())
     // #fallback-application-conf
     ;

--- a/cluster-sharding-typed/src/test/java/org/apache/pekko/cluster/sharding/typed/javadsl/ShardingEventSourcedEntityWithEnforcedRepliesCompileOnlyTest.java
+++ b/cluster-sharding-typed/src/test/java/org/apache/pekko/cluster/sharding/typed/javadsl/ShardingEventSourcedEntityWithEnforcedRepliesCompileOnlyTest.java
@@ -79,7 +79,7 @@ public class ShardingEventSourcedEntityWithEnforcedRepliesCompileOnlyTest {
     }
 
     private String applyEvent(String state, String evt) {
-      if (state.trim().isEmpty()) return evt;
+      if (state.isBlank()) return evt;
       else return state + "|" + evt;
     }
   }

--- a/docs/src/test/java/jdocs/actor/ImmutableMessage.java
+++ b/docs/src/test/java/jdocs/actor/ImmutableMessage.java
@@ -18,21 +18,9 @@ import java.util.Collections;
 import java.util.List;
 
 // #immutable-message
-public class ImmutableMessage {
-  private final int sequenceNumber;
-  private final List<String> values;
-
-  public ImmutableMessage(int sequenceNumber, List<String> values) {
-    this.sequenceNumber = sequenceNumber;
-    this.values = Collections.unmodifiableList(new ArrayList<String>(values));
-  }
-
-  public int getSequenceNumber() {
-    return sequenceNumber;
-  }
-
-  public List<String> getValues() {
-    return values;
+public record ImmutableMessage(int sequenceNumber, List<String> values) {
+  public ImmutableMessage {
+    values = Collections.unmodifiableList(new ArrayList<>(values));
   }
 }
 // #immutable-message

--- a/docs/src/test/java/jdocs/actor/Messages.java
+++ b/docs/src/test/java/jdocs/actor/Messages.java
@@ -20,21 +20,9 @@ import java.util.List;
 public class Messages {
   public
   // #immutable-message
-  static class ImmutableMessage {
-    private final int sequenceNumber;
-    private final List<String> values;
-
-    public ImmutableMessage(int sequenceNumber, List<String> values) {
-      this.sequenceNumber = sequenceNumber;
-      this.values = Collections.unmodifiableList(new ArrayList<String>(values));
-    }
-
-    public int getSequenceNumber() {
-      return sequenceNumber;
-    }
-
-    public List<String> getValues() {
-      return values;
+  static record ImmutableMessage(int sequenceNumber, List<String> values) {
+    public ImmutableMessage {
+      values = Collections.unmodifiableList(new ArrayList<>(values));
     }
   }
 

--- a/docs/src/test/java/jdocs/io/japi/Message.java
+++ b/docs/src/test/java/jdocs/io/japi/Message.java
@@ -16,23 +16,7 @@ package jdocs.io.japi;
 // #message
 public class Message {
 
-  public static class Person {
-    private final String first;
-    private final String last;
-
-    public Person(String first, String last) {
-      this.first = first;
-      this.last = last;
-    }
-
-    public String getFirst() {
-      return first;
-    }
-
-    public String getLast() {
-      return last;
-    }
-  }
+  public record Person(String first, String last) {}
 
   private final Person[] persons;
   private final double[] happinessCurve;

--- a/docs/src/test/java/jdocs/stream/BidiFlowDocTest.java
+++ b/docs/src/test/java/jdocs/stream/BidiFlowDocTest.java
@@ -274,7 +274,7 @@ public class BidiFlowDocTest extends AbstractJavaTest {
             .runWith(Sink.<List<Message>>head(), system);
     assertArrayEquals(
         new Message[] {new Pong(0), new Pong(1), new Pong(2)},
-        result.toCompletableFuture().get(1, TimeUnit.SECONDS).toArray(new Message[0]));
+        result.toCompletableFuture().get(1, TimeUnit.SECONDS).toArray(Message[]::new));
     // #compose
   }
 }

--- a/docs/src/test/java/jdocs/stream/SubstreamDocTest.java
+++ b/docs/src/test/java/jdocs/stream/SubstreamDocTest.java
@@ -81,7 +81,11 @@ public class SubstreamDocTest extends AbstractJavaTest {
 
     // #wordCount
     String text =
-        "This is the first line.\n" + "The second line.\n" + "There is also the 3rd line\n";
+        """
+        This is the first line.
+        The second line.
+        There is also the 3rd line
+        """;
 
     Source.from(Arrays.asList(text.split("")))
         .map(x -> x.charAt(0))

--- a/docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupQuery.java
+++ b/docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupQuery.java
@@ -91,10 +91,11 @@ public class DeviceGroupQuery extends AbstractBehavior<DeviceGroupQuery.Command>
     ActorRef<Device.RespondTemperature> respondTemperatureAdapter =
         context.messageAdapter(Device.RespondTemperature.class, WrappedRespondTemperature::new);
 
-    for (Map.Entry<String, ActorRef<Device.Command>> entry : deviceIdToActor.entrySet()) {
-      context.watchWith(entry.getValue(), new DeviceTerminated(entry.getKey()));
-      entry.getValue().tell(new Device.ReadTemperature(0L, respondTemperatureAdapter));
-    }
+    deviceIdToActor.forEach(
+        (deviceId, actor) -> {
+          context.watchWith(actor, new DeviceTerminated(deviceId));
+          actor.tell(new Device.ReadTemperature(0L, respondTemperatureAdapter));
+        });
     stillWaiting = new HashSet<>(deviceIdToActor.keySet());
   }
 

--- a/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedShoppingCartExample.java
+++ b/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedShoppingCartExample.java
@@ -114,10 +114,11 @@ interface ReplicatedShoppingCartExample {
 
     private Map<String, Integer> filterEmptyAndNegative(Map<String, Counter> cart) {
       Map<String, Integer> result = new HashMap<>();
-      for (Map.Entry<String, Counter> entry : cart.entrySet()) {
-        int count = entry.getValue().value().intValue();
-        if (count > 0) result.put(entry.getKey(), count);
-      }
+      cart.forEach(
+          (key, counter) -> {
+            int count = counter.value().intValue();
+            if (count > 0) result.put(key, count);
+          });
       return Collections.unmodifiableMap(result);
     }
 

--- a/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/auction/AuctionEntity.java
+++ b/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/auction/AuctionEntity.java
@@ -149,15 +149,15 @@ public class AuctionEntity
     int currentBidPrice;
     int currentBidMaximum;
     if (currentBid.isPresent()) {
-      currentBidPrice = currentBid.get().getBidPrice();
-      currentBidMaximum = currentBid.get().getMaximumBid();
+      currentBidPrice = currentBid.get().bidPrice();
+      currentBidMaximum = currentBid.get().maximumBid();
     } else {
       currentBidPrice = 0;
       currentBidMaximum = 0;
     }
 
     boolean bidderIsCurrentBidder =
-        currentBid.filter(b -> b.getBidder().equals(bid.bidder)).isPresent();
+        currentBid.filter(b -> b.bidder().equals(bid.bidder)).isPresent();
 
     if (bidderIsCurrentBidder && bid.bidPrice >= currentBidPrice) {
       // Allow the current bidder to update their bid
@@ -220,12 +220,12 @@ public class AuctionEntity
                 new BidPlaced(entityUUID, new Bid(bid.bidder, now, adjustedBidPrice, bid.bidPrice)),
                 new BidPlaced(
                     entityUUID,
-                    new Bid(currentBid.get().getBidder(), now, newBidPrice, currentBidMaximum))))
+                    new Bid(currentBid.get().bidder(), now, newBidPrice, currentBidMaximum))))
         .thenReply(
             bid.replyTo,
             newState ->
                 new PlaceBidResult(
-                    PlaceBidStatus.ACCEPTED_OUTBID, newBidPrice, currentBid.get().getBidder()));
+                    PlaceBidStatus.ACCEPTED_OUTBID, newBidPrice, currentBid.get().bidder()));
   }
 
   /** Handle the situation where a bid will be accepted as the new winning bidder. */
@@ -290,7 +290,7 @@ public class AuctionEntity
     Optional<Bid> lastBid = state.lastBid();
     if (lastBid.isPresent()) {
       Bid bid = lastBid.get();
-      return new PlaceBidResult(status, bid.getBidPrice(), bid.getBidder());
+      return new PlaceBidResult(status, bid.bidPrice(), bid.bidder());
     } else {
       return new PlaceBidResult(status, 0, null);
     }

--- a/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/auction/AuctionState.java
+++ b/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/auction/AuctionState.java
@@ -50,7 +50,7 @@ public final class AuctionState {
   }
 
   public AuctionState bid(Bid bid) {
-    if (lastBid().filter(b -> b.getBidder().equals(bid.getBidder())).isPresent()) {
+    if (lastBid().filter(b -> b.bidder().equals(bid.bidder())).isPresent()) {
       // Current bidder has updated their bid
       List<Bid> newBiddingHistory = new ArrayList<>(biddingHistory);
       newBiddingHistory.remove(newBiddingHistory.size() - 1); // remove last

--- a/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/auction/Bid.java
+++ b/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/auction/Bid.java
@@ -17,39 +17,4 @@ import java.time.Instant;
 import java.util.UUID;
 
 /** A bid. */
-public final class Bid {
-  /** The bidder. */
-  private final UUID bidder;
-
-  /** The time the bid was placed. */
-  private final Instant bidTime;
-
-  /** The bid price. */
-  private final int bidPrice;
-
-  /** The maximum the bidder is willing to bid. */
-  private final int maximumBid;
-
-  public Bid(UUID bidder, Instant bidTime, int bidPrice, int maximumBid) {
-    this.bidder = bidder;
-    this.bidTime = bidTime;
-    this.bidPrice = bidPrice;
-    this.maximumBid = maximumBid;
-  }
-
-  public UUID getBidder() {
-    return bidder;
-  }
-
-  public Instant getBidTime() {
-    return bidTime;
-  }
-
-  public int getBidPrice() {
-    return bidPrice;
-  }
-
-  public int getMaximumBid() {
-    return maximumBid;
-  }
-}
+public record Bid(UUID bidder, Instant bidTime, int bidPrice, int maximumBid) {}

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/GraphDslTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/GraphDslTest.java
@@ -74,7 +74,7 @@ public class GraphDslTest extends StreamTestJupiter {
                 }));
     // #simple-graph-dsl
     final List<String> list = result.run(system).toCompletableFuture().get(3, TimeUnit.SECONDS);
-    final String[] res = list.toArray(new String[] {});
+    final String[] res = list.toArray(String[]::new);
     Arrays.sort(res, null);
     assertArrayEquals(
         new String[] {"31", "32", "33", "34", "35", "41", "42", "43", "44", "45"}, res);


### PR DESCRIPTION
## Summary
- `String.isBlank()` replacing `trim().isEmpty()`
- `Collection.toArray(IntFunction)` replacing `toArray(new X[0])`
- `Map.forEach` replacing entrySet iteration loops
- Text blocks `"""..."""` replacing multi-line string concatenation
- Records replacing simple data holder classes

## Changes

### String.isBlank() (Java 11+)
- `ShardingEventSourcedEntityWithEnforcedRepliesCompileOnlyTest.java`

### Collection.toArray(IntFunction) (Java 11+)
- `GraphDslTest.java` — `toArray(new String[] {})` → `toArray(String[]::new)`
- `BidiFlowDocTest.java` — `toArray(new Message[0])` → `toArray(Message[]::new)`

### Map.forEach (Java 8+)
- `ReplicatedShoppingCartExample.java` — entrySet loop → `cart.forEach((k, v) -> ...)`
- `DeviceGroupQuery.java` — entrySet loop → `deviceIdToActor.forEach((k, v) -> ...)`

### Text blocks (Java 15+)
- `SubstreamDocTest.java` — 3-line string concat → text block
- `TestConfigExample.java` — config string concatenations → text blocks

### Records (Java 16+)
- `ImmutableMessage.java` → `record ImmutableMessage(int sequenceNumber, List<String> values)`
- `Messages.java` inner class → record
- `Message.Person` → `record Person(String first, String last)`
- `Bid.java` → `record Bid(UUID bidder, Instant bidTime, int bidPrice, int maximumBid)`
- Updated callers in `AuctionEntity.java` and `AuctionState.java` (getter names adjusted)

## Notes
- All changes in test/doc/example code only, no production API modifications
- `javafmtAll` verified — no formatting changes needed