### PR TITLE
refactor: migrate Collections.unmodifiable* to List.copyOf/Set.copyOf/Map.copyOf (Java 10+)

### DIFF
--- a/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/InteractionPatternsTest.java
+++ b/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/InteractionPatternsTest.java
@@ -186,7 +186,7 @@ public class InteractionPatternsTest {
         private final List<Command> messages;
 
         public Batch(List<Command> messages) {
-          this.messages = Collections.unmodifiableList(messages);
+          this.messages = List.copyOf(messages);
         }
 
         public List<Command> getMessages() {

--- a/cluster-sharding-typed/src/test/java/jdocs/delivery/ShardingDocExample.java
+++ b/cluster-sharding-typed/src/test/java/jdocs/delivery/ShardingDocExample.java
@@ -26,7 +26,6 @@ import org.apache.pekko.actor.typed.javadsl.Receive;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
@@ -87,7 +86,7 @@ interface ShardingDocExample {
       public final List<String> tasks;
 
       public State(List<String> tasks) {
-        this.tasks = Collections.unmodifiableList(tasks);
+        this.tasks = List.copyOf(tasks);
       }
 
       public State add(String task) {

--- a/cluster-sharding-typed/src/test/java/jdocs/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingCompileOnlySpec.java
+++ b/cluster-sharding-typed/src/test/java/jdocs/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingCompileOnlySpec.java
@@ -33,9 +33,7 @@ public class ReplicatedShardingCompileOnlySpec {
   }
 
   public static final Set<ReplicaId> ALL_REPLICAS =
-      Collections.unmodifiableSet(
-          new HashSet<>(
-              Arrays.asList(new ReplicaId("DC-A"), new ReplicaId("DC-B"), new ReplicaId("DC-C"))));
+      Set.of(new ReplicaId("DC-A"), new ReplicaId("DC-B"), new ReplicaId("DC-C"));
 
   public static ReplicatedEntityProvider<Command> provider() {
     // #bootstrap

--- a/cluster-sharding-typed/src/test/java/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingTest.java
+++ b/cluster-sharding-typed/src/test/java/org/apache/pekko/cluster/sharding/typed/ReplicatedShardingTest.java
@@ -149,10 +149,7 @@ public class ReplicatedShardingTest {
     }
 
     public static final Set<ReplicaId> ALL_REPLICAS =
-        Collections.unmodifiableSet(
-            new HashSet<>(
-                Arrays.asList(
-                    new ReplicaId("DC-A"), new ReplicaId("DC-B"), new ReplicaId("DC-C"))));
+        Set.of(new ReplicaId("DC-A"), new ReplicaId("DC-B"), new ReplicaId("DC-C"));
 
     private final ReplicatedSharding<MyReplicatedStringSet.Command> replicatedSharding;
 

--- a/docs/src/test/java/jdocs/actor/ImmutableMessage.java
+++ b/docs/src/test/java/jdocs/actor/ImmutableMessage.java
@@ -13,14 +13,12 @@
 
 package jdocs.actor;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 // #immutable-message
 public record ImmutableMessage(int sequenceNumber, List<String> values) {
   public ImmutableMessage {
-    values = Collections.unmodifiableList(new ArrayList<>(values));
+    values = List.copyOf(values);
   }
 }
 // #immutable-message

--- a/docs/src/test/java/jdocs/actor/Messages.java
+++ b/docs/src/test/java/jdocs/actor/Messages.java
@@ -13,8 +13,6 @@
 
 package jdocs.actor;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class Messages {
@@ -22,7 +20,7 @@ public class Messages {
   // #immutable-message
   static record ImmutableMessage(int sequenceNumber, List<String> values) {
     public ImmutableMessage {
-      values = Collections.unmodifiableList(new ArrayList<>(values));
+      values = List.copyOf(values);
     }
   }
 

--- a/docs/src/test/java/jdocs/stream/operators/flow/StatefulMap.java
+++ b/docs/src/test/java/jdocs/stream/operators/flow/StatefulMap.java
@@ -46,8 +46,7 @@ public class StatefulMap {
             () -> (List<String>) new LinkedList<String>(),
             (buffer, element) -> {
               if (buffer.size() > 0 && (!buffer.get(0).equals(element))) {
-                return Pair.create(
-                    new LinkedList<>(Collections.singletonList(element)), List.copyOf(buffer));
+                return Pair.create(new LinkedList<>(List.of(element)), List.copyOf(buffer));
               } else {
                 buffer.add(element);
                 return Pair.create(buffer, Collections.<String>emptyList());

--- a/docs/src/test/java/jdocs/stream/operators/flow/StatefulMap.java
+++ b/docs/src/test/java/jdocs/stream/operators/flow/StatefulMap.java
@@ -47,8 +47,7 @@ public class StatefulMap {
             (buffer, element) -> {
               if (buffer.size() > 0 && (!buffer.get(0).equals(element))) {
                 return Pair.create(
-                    new LinkedList<>(Collections.singletonList(element)),
-                    Collections.unmodifiableList(buffer));
+                    new LinkedList<>(Collections.singletonList(element)), List.copyOf(buffer));
               } else {
                 buffer.add(element);
                 return Pair.create(buffer, Collections.<String>emptyList());
@@ -96,7 +95,7 @@ public class StatefulMap {
             (list, element) -> {
               list.add(element);
               if (list.size() == 3) {
-                return Pair.create(new ArrayList<Integer>(3), Collections.unmodifiableList(list));
+                return Pair.create(new ArrayList<Integer>(3), List.copyOf(list));
               } else {
                 return Pair.create(list, Collections.<Integer>emptyList());
               }

--- a/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/MyReplicatedBehavior.java
+++ b/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/MyReplicatedBehavior.java
@@ -34,8 +34,7 @@ public class MyReplicatedBehavior
   public static final ReplicaId DCA = new ReplicaId("DCA");
   public static final ReplicaId DCB = new ReplicaId("DCB");
 
-  public static final Set<ReplicaId> ALL_REPLICAS =
-      Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DCA, DCB)));
+  public static final Set<ReplicaId> ALL_REPLICAS = Set.of(DCA, DCB);
 
   // #replicas
 

--- a/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedAuctionExampleTest.java
+++ b/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedAuctionExampleTest.java
@@ -253,8 +253,7 @@ class AuctionEntity
     AuctionState addFinishedAtReplica(String replica) {
       Set<String> s = new HashSet<>(finishedAtDc);
       s.add(replica);
-      return new AuctionState(
-          false, highestBid, highestCounterOffer, Collections.unmodifiableSet(s));
+      return new AuctionState(false, highestBid, highestCounterOffer, Set.copyOf(s));
     }
 
     public AuctionState close() {

--- a/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedMovieExample.java
+++ b/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedMovieExample.java
@@ -13,7 +13,6 @@
 
 package jdocs.org.apache.pekko.persistence.typed;
 
-import java.util.Collections;
 import java.util.Set;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
@@ -45,7 +44,7 @@ interface ReplicatedMovieExample {
       public final Set<String> movieIds;
 
       public MovieList(Set<String> movieIds) {
-        this.movieIds = Collections.unmodifiableSet(movieIds);
+        this.movieIds = Set.copyOf(movieIds);
       }
     }
 

--- a/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedShoppingCartExample.java
+++ b/persistence-typed-tests/src/test/java/jdocs/org/apache/pekko/persistence/typed/ReplicatedShoppingCartExample.java
@@ -13,7 +13,6 @@
 
 package jdocs.org.apache.pekko.persistence.typed;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -119,7 +118,7 @@ interface ReplicatedShoppingCartExample {
             int count = counter.value().intValue();
             if (count > 0) result.put(key, count);
           });
-      return Collections.unmodifiableMap(result);
+      return Map.copyOf(result);
     }
 
     @Override

--- a/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/MovieWatchList.java
+++ b/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/MovieWatchList.java
@@ -45,7 +45,7 @@ public class MovieWatchList
     public final Set<String> movieIds;
 
     public MovieList(Set<String> movieIds) {
-      this.movieIds = Collections.unmodifiableSet(movieIds);
+      this.movieIds = Set.copyOf(movieIds);
     }
 
     public MovieList add(String movieId) {

--- a/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/WebStoreCustomerFSM.java
+++ b/persistence-typed/src/test/java/jdocs/org/apache/pekko/persistence/typed/WebStoreCustomerFSM.java
@@ -15,7 +15,6 @@ package jdocs.org.apache.pekko.persistence.typed;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -33,7 +32,7 @@ public class WebStoreCustomerFSM {
     public ShoppingCart() {}
 
     public List<Item> getItems() {
-      return Collections.unmodifiableList(items);
+      return List.copyOf(items);
     }
 
     public ShoppingCart addItem(Item item) {

--- a/persistence/src/test/java/org/apache/pekko/persistence/fsm/AbstractPersistentFSMTest.java
+++ b/persistence/src/test/java/org/apache/pekko/persistence/fsm/AbstractPersistentFSMTest.java
@@ -16,7 +16,6 @@ package org.apache.pekko.persistence.fsm;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.pekko.actor.*;
 
@@ -64,7 +63,7 @@ public class AbstractPersistentFSMTest {
       public ShoppingCart() {}
 
       public List<Item> getItems() {
-        return Collections.unmodifiableList(items);
+        return List.copyOf(items);
       }
 
       public ShoppingCart addItem(Item item) {


### PR DESCRIPTION
## Summary
- Migrate `Collections.unmodifiableList(x)` → `List.copyOf(x)`
- Migrate `Collections.unmodifiableSet(new HashSet<>(Arrays.asList(...)))` → `Set.of(...)`
- Migrate `Collections.unmodifiableSet(x)` → `Set.copyOf(x)`
- Migrate `Collections.unmodifiableMap(x)` → `Map.copyOf(x)`
- Remove now-unused imports (`Collections`, `HashSet`, `Arrays` where applicable)
- 14 test files across 6 modules: `docs`, `actor-typed-tests`, `persistence-typed-tests`, `persistence-typed`, `persistence`, `cluster-sharding-typed`

## Test plan
- [x] `sbt javafmtAll` — all files formatted
- [x] All 6 affected modules compile successfully
- [ ] CI validates full test suite

Part of the Java 17 modernization effort. See also #3191 (switch expressions), #3192 (pattern matching instanceof), #3193 (misc Java 11-17).