### PR TITLE
refactor: migrate .toArray() to .toArray(T[]::new) (Java 11+)

### DIFF
--- a/docs/src/test/java/jdocs/testkit/TestKitDocTest.java
+++ b/docs/src/test/java/jdocs/testkit/TestKitDocTest.java
@@ -215,7 +215,7 @@ public class TestKitDocTest extends AbstractJavaTest {
                   }
                 });
 
-        assertArrayEquals(new String[] {"42", "43"}, out.toArray());
+        assertArrayEquals(new String[] {"42", "43"}, out.toArray(String[]::new));
         expectMsgEquals("hello");
       }
     };
@@ -295,7 +295,7 @@ public class TestKitDocTest extends AbstractJavaTest {
         assertEquals("hello", any);
         assertEquals(42, i);
         assertEquals(42, j);
-        assertArrayEquals(new String[] {"hello", "world"}, all.toArray());
+        assertArrayEquals(new String[] {"hello", "world"}, all.toArray(String[]::new));
       }
     };
   }

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceTest.java
@@ -1535,7 +1535,7 @@ public class SourceTest extends StreamTestJupiter {
 
     assertArrayEquals(
         new Boolean[] {false, true, false, true, false, true, false, true, false, true},
-        future.get(1, TimeUnit.SECONDS).toArray());
+        future.get(1, TimeUnit.SECONDS).toArray(Boolean[]::new));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Migrate `List<String>.toArray()` → `.toArray(String[]::new)` in `TestKitDocTest.java` (2 occurrences)
- Migrate `List<Boolean>.toArray()` → `.toArray(Boolean[]::new)` in `SourceTest.java`

Java 11 added `Collection.toArray(IntFunction<T[]>)` which produces a type-safe array instead of `Object[]`.

## Test plan
- [x] `sbt javafmtAll` — all files formatted
- [x] Both affected modules compile successfully
- [ ] CI validates full test suite

Part of the Java 17 modernization effort. See also #3188, #3189, #3190, #3191, #3192, #3193, #3194.