### PR TITLE
since marker on java Deprecated annotation

### DIFF
--- a/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStateFunctionBuilder.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStateFunctionBuilder.java
@@ -25,13 +25,13 @@ import scala.PartialFunction;
 /**
  * Builder used to create a partial function for {@link org.apache.pekko.actor.FSM#whenUnhandled}.
  *
- * @deprecated use EventSourcedBehavior since Akka 2.6.0
  * @param <S> the state type
  * @param <D> the data type
  * @param <E> the domain event type
+ * @deprecated use EventSourcedBehavior since Akka 2.6.0
  */
 @SuppressWarnings("rawtypes")
-@Deprecated
+@Deprecated(since = "Akka 2.6.0")
 public class FSMStateFunctionBuilder<S, D, E> {
 
   private final PFBuilder<

--- a/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStopBuilder.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStopBuilder.java
@@ -25,11 +25,11 @@ import scala.runtime.BoxedUnit;
 /**
  * Builder used to create a partial function for {@link org.apache.pekko.actor.FSM#onTermination}.
  *
- * @deprecated use EventSourcedBehavior since Akka 2.6.0
  * @param <S> the state type
  * @param <D> the data type
+ * @deprecated use EventSourcedBehavior since Akka 2.6.0
  */
-@Deprecated
+@Deprecated(since = "Akka 2.6.0")
 public class FSMStopBuilder<S, D> {
 
   private UnitPFBuilder<org.apache.pekko.persistence.fsm.PersistentFSM.StopEvent<S, D>> builder =


### PR DESCRIPTION
use since marker on java Deprecated annotations (wasn't available in Java 8)