### PR TITLE
fix(remote): eager SSLContext init for artery ConfigSSLEngineProvider fail-fast

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ConfigSSLEngineProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ConfigSSLEngineProvider.scala
@@ -66,7 +66,7 @@ class ConfigSSLEngineProvider(protected val config: Config, protected val log: M
   val SSLRequireMutualAuthentication: Boolean = sslEngineConfig.SSLRequireMutualAuthentication
   val HostnameVerification: Boolean = sslEngineConfig.HostnameVerification
 
-  private lazy val sslContext: SSLContext = {
+  private val sslContext: SSLContext = {
     // log hostname verification warning once
     if (HostnameVerification)
       log.debug("TLS/SSL hostname verification is enabled.")

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/ArteryConfigSSLEngineProviderSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/ArteryConfigSSLEngineProviderSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package org.apache.pekko.remote.artery.tcp
+
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
+
+import com.typesafe.config.ConfigFactory
+
+class ArteryConfigSSLEngineProviderSpec
+    extends PekkoSpec(
+      ConfigFactory.parseString("""
+    pekko {
+      actor.provider = remote
+      remote.artery.ssl.config-ssl-engine {
+        key-store = "/nonexistent/keystore.jks"
+        key-store-password = "changeme"
+        key-password = "changeme"
+        trust-store = "/nonexistent/truststore.jks"
+        trust-store-password = "changeme"
+        protocol = "TLSv1.3"
+        enabled-algorithms = [TLS_AES_128_GCM_SHA256]
+        random-number-generator = ""
+        require-mutual-authentication = off
+      }
+    }
+  """)) {
+
+  "Artery ConfigSSLEngineProvider" must {
+    "fail fast when keystore cannot be loaded" in {
+      intercept[SslTransportException] {
+        new ConfigSSLEngineProvider(system)
+      }.getMessage should include("could not be established")
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

Artery's `ConfigSSLEngineProvider` has used `lazy val sslContext` since its introduction. As a result, keystore and truststore misconfiguration is only discovered on the first connection attempt rather than at provider construction. Classic remoting's `ConfigSSLEngineProvider` was given the same eager-init fail-fast behavior in #3165; artery should match so that SSL misconfiguration surfaces at `ActorSystem` startup with a clear error.

### Modification

- Change `private lazy val sslContext` to `private val sslContext` in `org.apache.pekko.remote.artery.tcp.ConfigSSLEngineProvider` so that `SslTransportException` is raised during construction when the keystore or truststore cannot be loaded.
- Add a directional regression test `ArteryConfigSSLEngineProviderSpec` that constructs the provider against a config pointing at nonexistent keystore/truststore paths and asserts `SslTransportException` with the "could not be established" message.

### Result

Artery SSL misconfiguration now fails fast at `ActorSystem` startup with a clear error, instead of silently succeeding construction and failing later on the first connection attempt.

### Tests

- `sbt "remote / Test / testOnly org.apache.pekko.remote.artery.tcp.ArteryConfigSSLEngineProviderSpec"`
  - Tests: succeeded 1, failed 0
- Companion classic-side regression test `ConfigSSLEngineProviderSpec` (added in #3165) still passes.

### References

None - companion to the classic remoting fail-fast fix (#3165).