### PR TITLE
fix(remote): restore eager SSLContext init for classic remoting fail-fast

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/SSLEngineProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/SSLEngineProvider.scala
@@ -79,7 +79,7 @@ class ConfigSSLEngineProvider(protected val log: MarkerLoggingAdapter, private v
       "TLS/SSL hostname verification is disabled. " +
       "Set pekko.remote.classic.netty.ssl.security.hostname-verification=on to enable.")
 
-  private lazy val sslContext: SSLContext = {
+  private val sslContext: SSLContext = {
     try {
       val rng = createSecureRandom()
       val ctx = SSLContext.getInstance(SSLProtocol)


### PR DESCRIPTION
### Motivation
PR #3164 accidentally changed `ConfigSSLEngineProvider.sslContext` from eager `val` back to `lazy val` (it was based on a branch predating #3165). This regressed the fail-fast behavior added by #3165: keystore and truststore errors are now only discovered on the first connection attempt instead of at provider construction, and the regression test `ConfigSSLEngineProviderSpec` started failing on CI with "Expected exception RemoteTransportException to be thrown, but no exception was thrown".

### Modification
Change `private lazy val sslContext` back to `private val sslContext` in classic remoting's `ConfigSSLEngineProvider` so SSL initialization runs during construction and surfaces misconfiguration immediately.

### Result
`ConfigSSLEngineProvider` once again throws `RemoteTransportException` at construction time when the keystore cannot be loaded, matching the behavior asserted by `ConfigSSLEngineProviderSpec` and the intent of PR #3165.

### Tests
- `sbt "remote / Test / testOnly org.apache.pekko.remote.ConfigSSLEngineProviderSpec org.apache.pekko.remote.Ticket1978ConfigSpec"`

### References
Regression from #3164 over #3165