### PR TITLE
fix code to use correct pekko.remote.classic.use-passive-connections name

### DIFF
--- a/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/RestartNodeSpec.scala
+++ b/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/RestartNodeSpec.scala
@@ -48,7 +48,7 @@ object RestartNodeMultiJvmSpec extends MultiNodeConfig {
       pekko.cluster.downing-provider-class = org.apache.pekko.cluster.testkit.AutoDowning
       pekko.cluster.testkit.auto-down-unreachable-after = 5s
       pekko.cluster.allow-weakly-up-members = off
-      #pekko.remote.use-passive-connections = off
+      #pekko.remote.classic.use-passive-connections = off
       # test is using Java serialization and not priority to rewrite
       pekko.actor.allow-java-serialization = on
       pekko.actor.warn-about-java-serializer-usage = off

--- a/remote/src/main/scala/org/apache/pekko/remote/Endpoint.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/Endpoint.scala
@@ -1197,7 +1197,7 @@ private[remote] class EndpointReader(
       if (log.isWarningEnabled)
         log.warning(
           "Discarding inbound message to [{}] in read-only association to [{}]. " +
-          "If this happens often you may consider using pekko.remote.use-passive-connections=off " +
+          "If this happens often you may consider using pekko.remote.classic.use-passive-connections=off " +
           "or use Artery TCP.",
           msgOption.map(_.recipient).getOrElse("unknown"),
           remoteAddress)


### PR DESCRIPTION
cherry pick b1148ae2565c3143e77d18e7bf8644971c97ec46 (#3207)