### PR TITLE
Configure TLS resources for bind canonical tests

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/artery/BindCanonicalAddressSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/BindCanonicalAddressSpec.scala
@@ -131,5 +131,5 @@ object BindCanonicalAddressSpec {
       remote.artery.enabled = true
       remote.artery.transport = "$transport"
     }
-  """)
+  """).withFallback(ArterySpecSupport.tlsConfig)
 }


### PR DESCRIPTION
### Motivation
PR validation for #3205 exposed that `BindCanonicalAddressSpec` fails the `tls-tcp` bind canonical address cases because the spec falls back to the `reference.conf` default `keystore` and `truststore` relative paths.

### Modification
Reuse the existing `ArterySpecSupport.tlsConfig` in `BindCanonicalAddressSpec.commonConfig` so TLS transport cases resolve the test keystore and truststore resources.

### Result
The TLS bind canonical address cases no longer fail with `NoSuchFileException: keystore`.

### Tests
- JDK 17: `rtk bash -lc "export JAVA_HOME=$(/usr/libexec/java_home -v 17); export PATH=\"$JAVA_HOME/bin:$PATH\"; java -version; sbt \"remote / Test / testOnly org.apache.pekko.remote.artery.BindCanonicalAddressSpec\""` / passed (15 tests)
- `rtk scalafmt --mode diff-ref=origin/main --non-interactive` / passed
- `rtk scalafmt --list --mode diff-ref=origin/main --non-interactive` / passed
- `rtk bash -lc "git diff --check"` / passed

### References
Refs #3205
