### PR TITLE
fix: avoid NPE in outbound TCP stage when upstream finishes before connect (#3255)

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/TcpSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/TcpSpec.scala
@@ -519,6 +519,31 @@ class TcpSpec extends StreamSpec("""
       binding.unbind()
     }
 
+    "not throw a NullPointerException when full-close is requested and upstream finishes before the connection is established (#3255)" in {
+      val binding =
+        Tcp()
+          .bind("127.0.0.1", 0)
+          .toMat(Sink.foreach { conn =>
+            conn.flow.join(Flow[ByteString]).run()
+          })(Keep.left)
+          .run()
+          .futureValue
+
+      // `Source.empty` completes synchronously during materialization, i.e. before the outbound
+      // connection is established (the connection ActorRef is still null at that point). With
+      // half-close disabled the upstream-finished handler used to dereference that null connection
+      // (`connection ! Close`) and fail the stage with a NullPointerException. The fix defers the
+      // close until the connection is established, so the stream must complete normally here.
+      val result = Source
+        .empty[ByteString]
+        .via(Tcp().outgoingConnection(binding.localAddress, halfClose = false))
+        .runWith(Sink.ignore)
+
+      result.futureValue should ===(Done)
+
+      binding.unbind()
+    }
+
     "Echo should work even if server is in full close mode" in {
       val serverAddress = temporaryServerAddress()
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/TcpStages.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/TcpStages.scala
@@ -322,7 +322,12 @@ private[stream] object ConnectionSourceStage {
           stageActor.watch(connection)
           connection ! Register(self, keepOpenOnPeerClosed = true, useResumeWriting = false)
           if (isAvailable(bytesOut)) connection ! ResumeReading
-          if (isClosed(bytesIn)) connection ! ConfirmedClose
+          if (isClosed(bytesIn))
+            // Upstream finished before the connection was established. Honor the half-close
+            // setting: ConfirmedClose only closes the write side (half-close), while Close
+            // tears down the whole connection. Always sending ConfirmedClose here would keep
+            // the read side open even when half-close is disabled (issue #3255).
+            connection ! (if (role.halfClose) ConfirmedClose else Close)
           else pull(bytesIn)
         case other => log.warning("Unexpected message to connecting TcpStage: [{}]", other.getClass)
       }
@@ -396,23 +401,26 @@ private[stream] object ConnectionSourceStage {
     }
 
     private def closeConnectionUpstreamFinished(): Unit = {
-      if (isClosed(bytesOut) || !role.halfClose) {
+      if (connection eq null) {
+        // This is an outbound connection for which upstream finished before the connection
+        // was even established. The close is deferred until the connection is established;
+        // the `connecting` handler inspects `isClosed(bytesIn)` and closes the connection
+        // honoring the half-close setting. Dereferencing `connection` here would otherwise
+        // throw a NullPointerException when half-close is disabled (issue #3255).
+      } else if (isClosed(bytesOut) || !role.halfClose) {
         // Reading has stopped before, either because of cancel, or PeerClosed, so just Close now
         // (or half-close is turned off)
         if (writeInProgress)
           connectionClosePending = true // will continue when WriteAck is received and writeBuffer drained
         else
           connection ! Close
-      } else if (connection ne null) {
+      } else {
         // We still read, so we only close the write side
         if (writeInProgress)
           connectionClosePending = true // will continue when WriteAck is received and writeBuffer drained
         else
           connection ! ConfirmedClose
       }
-      // Otherwise, this is an outbound connection with half-close enabled for which upstream finished
-      // before the connection was even established.
-      // In that case we half-close the connection as soon as it's connected
     }
 
     private def closeConnectionDownstreamFinished(): Unit = {


### PR DESCRIPTION
### Motivation

`TcpConnectionStage.closeConnectionUpstreamFinished()` dereferences the
connection `ActorRef` without a null check on the full-close path. For an
**outbound** connection whose upstream finishes **before** the `Connected`
message arrives, `connection` is still `null` (it is only assigned when
`Connected` is received), so `connection ! Close` throws a
`NullPointerException` and fails the stage.

This is easy to hit with a source that completes eagerly: `Source.empty`
completes synchronously during materialization, i.e. before the asynchronous
`Connected` reply, so `onUpstreamFinish` runs while `connection` is `null`.
The existing null check only guarded the half-close (`ConfirmedClose`) path,
leaving the `halfClose = false` path unprotected.

Additionally, the `connecting` handler always issued `ConfirmedClose` (a
half-close) regardless of the `halfClose` setting when the upstream had
already finished before the connection was established — incorrect when
half-close is disabled, because it would keep the read side open instead of
fully tearing the connection down.

Fixes #3255.

### Modification

- Hoist a `connection eq null` guard to the top of
  `closeConnectionUpstreamFinished()` so neither close branch can dereference
  a null connection. When the connection is not yet established the close is
  **deferred** until it is — this mirrors the structure already used by the
  sibling `closeConnectionDownstreamFinished()`.
- Make the `connecting` handler honor the half-close setting when the upstream
  finished before connect: send `Close` when half-close is disabled and
  `ConfirmedClose` when it is enabled.
- Added explanatory comments at both sites so the deferral/half-close
  reasoning is clear to future readers.

### Result

- Outbound connections with `halfClose = false` no longer throw a
  `NullPointerException` when the upstream finishes before the connection is
  established.
- The early-finish close path now respects the configured half-close
  semantics (`Close` for full-close, `ConfirmedClose` for half-close).
- All touched symbols are `private[stream]` / `@InternalApi` internals, so
  there is **no public API or binary-compatibility change** (no MiMa filter
  required).

### Tests

- `sbt "stream-tests/testOnly org.apache.pekko.stream.io.TcpSpec"` → 28 passed.
- Added a directional regression test
  (`TcpSpec`: "not throw a NullPointerException when full-close is requested
  and upstream finishes before the connection is established"). It **fails
  with the exact `NullPointerException` before the fix** (verified by
  temporarily reverting the source change) and passes after.

### References

Fixes #3255

---

This is an original contribution to Apache Pekko, made under the Apache
License 2.0 (i.e. the changes are now Apache licensed). No third-party or
Akka-derived code is included.
