### PR TITLE
fix: expand Array arguments in MarkerLoggingAdapter log templates (#3257)

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/event/MarkerLoggingSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/event/MarkerLoggingSpec.scala
@@ -44,5 +44,23 @@ class MarkerLoggingSpec extends PekkoSpec with ImplicitSender {
 
       expectMsgType[Error].cause.getMessage should be("Security Exception")
     }
+
+    "expand a non-primitive Array argument into separate template placeholders (#3257)" in {
+      system.eventStream.subscribe(self, classOf[Info])
+      system.eventStream.publish(TestEvent.Mute(EventFilter.info()))
+
+      markerLogging.info(LogMarker.Security, "{} {} {}", Array("a", "b", "c"))
+
+      expectMsgType[Info3].message should be("a b c")
+    }
+
+    "expand a primitive Array argument into separate template placeholders (#3257)" in {
+      system.eventStream.subscribe(self, classOf[Info])
+      system.eventStream.publish(TestEvent.Mute(EventFilter.info()))
+
+      markerLogging.info(LogMarker.Security, "{} {} {}", Array(1, 2, 3))
+
+      expectMsgType[Info3].message should be("1 2 3")
+    }
   }
 }

--- a/actor/src/main/scala/org/apache/pekko/event/Logging.scala
+++ b/actor/src/main/scala/org/apache/pekko/event/Logging.scala
@@ -2000,10 +2000,13 @@ class MarkerLoggingAdapter(
     }
   }
 
-  // Copy of LoggingAdapter.format1 due to binary compatibility restrictions
+  // Copy of LoggingAdapter.format1 due to binary compatibility restrictions.
+  // The array branches must spread the elements as varargs (`: _*`) so that each element is
+  // expanded into its own template placeholder; without it the whole IndexedSeq would be passed
+  // as a single argument and rendered as e.g. "ArraySeq(a, b, c)" (issue #3257).
   private def format1(t: String, arg: Any): String = arg match {
-    case a: Array[?] if !a.getClass.getComponentType.isPrimitive => format(t, a.toIndexedSeq)
-    case a: Array[?]                                             => format(t, a.toIndexedSeq.asInstanceOf[IndexedSeq[AnyRef]])
+    case a: Array[?] if !a.getClass.getComponentType.isPrimitive => format(t, a.toIndexedSeq: _*)
+    case a: Array[?]                                             => format(t, a.toIndexedSeq.asInstanceOf[IndexedSeq[AnyRef]]: _*)
     case x                                                       => format(t, x)
   }
 }


### PR DESCRIPTION
### Motivation

`MarkerLoggingAdapter.format1` passed an `Array` argument to the varargs
`format(t, arg: Any*)` **without** spreading it (`: _*`), so the whole array was
treated as a single template argument instead of being expanded into the
individual placeholders.

For example:

```scala
markerLog.info(LogMarker.Security, "{} {} {}", Array("a", "b", "c"))
```

| | base `LoggingAdapter` | `MarkerLoggingAdapter` (before) |
|---|---|---|
| Output | `a b c` | `ArraySeq(a, b, c) {} {}` |

The base `LoggingAdapter.format1` expands arrays correctly (it calls
`formatImpl(t, a.toSeq)` directly). The marker copy exists for binary
compatibility reasons (it cannot reach the base trait's `private formatImpl`),
and when it was written the varargs spread (`: _*`) was forgotten. The scaladoc
promising that an `Array` argument "will be expanded into replacement
arguments" was therefore not honored by the marker adapter.

Fixes #3257.

### Modification

Spread the array elements as varargs in both `Array` branches of
`MarkerLoggingAdapter.format1`, so each element fills its own placeholder, and
documented the reason so it is not regressed:

```scala
case a: Array[?] if !a.getClass.getComponentType.isPrimitive => format(t, a.toIndexedSeq: _*)
case a: Array[?]                                             => format(t, a.toIndexedSeq.asInstanceOf[IndexedSeq[AnyRef]]: _*)
case x                                                       => format(t, x)
```

`DiagnosticMarkerBusLoggingAdapter` inherits this method and is fixed by the
same change.

### Result

- `Array` arguments to the single-argument marker log template methods are now
  expanded into separate placeholders, matching `LoggingAdapter` and the
  documented behavior (e.g. `"a b c"` instead of `"ArraySeq(a, b, c) {} {}"`).
- `format1` is `private` and only its body changed — **no public API or
  binary-compatibility change** (`actor / mimaReportBinaryIssues` is clean).

### Tests

- `sbt "actor-tests/testOnly org.apache.pekko.event.MarkerLoggingSpec"` →
  all passed.
- Added directional tests for a non-primitive `Array[String]` and a primitive
  `Array[Int]` (the two `format1` branches). Both **fail before the fix**
  (rendering `"ArraySeq(a, b, c) {} {}"` / `"ArraySeq(1, 2, 3) {} {}"`) and pass
  after.
- `sbt "actor/mimaReportBinaryIssues"` → no binary issues.

### References

Fixes #3257

---

This is an original contribution to Apache Pekko, made under the Apache License
2.0 (i.e. the changes are now Apache licensed). No third-party or Akka-derived
code is included.
