### PR TITLE
fix: deliver stashed timer messages for UnboundedStash and UnrestrictedStash (#3258)

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/TimerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/TimerSpec.scala
@@ -341,11 +341,67 @@ class TimersAndStashSpec extends PekkoSpec {
     }
   }
 
+  // Same scenario as ActorWithTimerAndStash but mixing in UnboundedStash, which is a sibling of
+  // Stash (both extend UnrestrictedStash), to cover the timer/stash interaction for it too (#3258).
+  class ActorWithTimerAndUnboundedStash(probe: ActorRef) extends Actor with Timers with UnboundedStash {
+    timers.startSingleTimer("key", "scheduled", 50.millis)
+    def receive: Receive = stashing
+    def notStashing: Receive = {
+      case msg => probe ! msg
+    }
+
+    def stashing: Receive = {
+      case StopStashing =>
+        context.become(notStashing)
+        unstashAll()
+      case "scheduled" =>
+        probe ! "saw-scheduled"
+        stash()
+    }
+  }
+
+  // Same scenario mixing in UnrestrictedStash directly (needs an explicitly configured
+  // deque-based mailbox, as it does not declare a RequiresMessageQueue) (#3258).
+  class ActorWithTimerAndUnrestrictedStash(probe: ActorRef) extends Actor with Timers with UnrestrictedStash {
+    timers.startSingleTimer("key", "scheduled", 50.millis)
+    def receive: Receive = stashing
+    def notStashing: Receive = {
+      case msg => probe ! msg
+    }
+
+    def stashing: Receive = {
+      case StopStashing =>
+        context.become(notStashing)
+        unstashAll()
+      case "scheduled" =>
+        probe ! "saw-scheduled"
+        stash()
+    }
+  }
+
   "Timers combined with stashing" should {
 
     "work" in {
       val probe = TestProbe()
       val actor = system.actorOf(Props(new ActorWithTimerAndStash(probe.ref)))
+      probe.expectMsg("saw-scheduled")
+      actor ! StopStashing
+      probe.expectMsg("scheduled")
+    }
+
+    "work with UnboundedStash (#3258)" in {
+      val probe = TestProbe()
+      val actor = system.actorOf(Props(new ActorWithTimerAndUnboundedStash(probe.ref)))
+      probe.expectMsg("saw-scheduled")
+      actor ! StopStashing
+      probe.expectMsg("scheduled")
+    }
+
+    "work with UnrestrictedStash (#3258)" in {
+      val probe = TestProbe()
+      val actor = system.actorOf(
+        Props(new ActorWithTimerAndUnrestrictedStash(probe.ref))
+          .withMailbox("pekko.actor.mailbox.unbounded-deque-based"))
       probe.expectMsg("saw-scheduled")
       actor ! StopStashing
       probe.expectMsg("scheduled")

--- a/actor/src/main/scala/org/apache/pekko/actor/Timers.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Timers.scala
@@ -55,8 +55,12 @@ trait Timers extends Actor {
           case OptionVal.Some(m: AutoReceivedMessage) =>
             context.asInstanceOf[ActorCell].autoReceiveMessage(Envelope(m, self, context.system))
           case OptionVal.Some(m) =>
-            if (this.isInstanceOf[Stash]) {
-              // this is important for stash interaction, as stash will look directly at currentMessage #24557
+            if (this.isInstanceOf[StashSupport]) {
+              // This is important for stash interaction, as stash reads the message directly from
+              // currentMessage (StashSupport) #24557. We match StashSupport rather than Stash so that
+              // actors mixing in UnboundedStash or UnrestrictedStash directly - which are siblings of
+              // Stash, not subtypes - also rewrite the unwrapped timer message; otherwise stash()
+              // would re-stash the TimerMsg wrapper and the message would be lost on unstash (#3258).
               actorCell.currentMessage = actorCell.currentMessage.copy(message = m)
             }
             super.aroundReceive(receive, m)


### PR DESCRIPTION
### Motivation

`Timers` rewrites `actorCell.currentMessage` to the **unwrapped** timer message
before invoking the user's `receive`, so that `stash()` (which reads
`currentMessage` directly) captures the actual message rather than the internal
`TimerMsg` wrapper.

That rewrite was guarded by `this.isInstanceOf[Stash]`. But `Stash`,
`UnboundedStash` and `UnrestrictedStash` are **siblings** — they all extend
`UnrestrictedStash` / `StashSupport`, and `UnboundedStash`/`UnrestrictedStash`
are **not** subtypes of `Stash`. So for an actor mixing in `UnboundedStash` or
`UnrestrictedStash` directly, the guard was `false`, the rewrite was skipped,
and `stash()` captured the `TimerMsg` wrapper. On `unstashAll()` the wrapper was
intercepted again and discarded (the single-shot timer was already removed, or
the generation was stale for a periodic timer), so **the message was lost**.

The same guard also excluded the Java‑API stash actors (`AbstractActorWithStash`
and friends, via `AbstractActorStashSupport`), which have the same problem.

Fixes #3258.

### Modification

- Guard the `currentMessage` rewrite with `this.isInstanceOf[StashSupport]`
  instead of `this.isInstanceOf[Stash]`. `StashSupport` is the common base of
  all stash‑capable actors (`Stash`, `UnboundedStash`, `UnrestrictedStash`, and
  the Java‑API stash classes), and it is exactly the set of actors whose
  `stash()` reads `currentMessage` — so it is the precise, correct boundary.
- Expanded the explanatory comment so the sibling relationship and the
  re‑stash/lost‑message mechanism are clear (keeping the original `#24557`
  reference).

### Result

- Timer messages stashed with `UnboundedStash` or `UnrestrictedStash` (and the
  Java‑API stash actors) are no longer lost on `unstashAll()`.
- Behavior for `Stash` is unchanged, and non‑stashing actors are unaffected
  (the guard is still `false` for them).
- The change is a method‑body change in `Timers.aroundReceive`; **no public API
  or binary‑compatibility change** (`actor / mimaReportBinaryIssues` is clean).

### Tests

- `sbt "actor-tests/testOnly org.apache.pekko.actor.TimerSpec org.apache.pekko.actor.TimersAndStashSpec"`
  → all passed.
- Added directional tests mirroring the existing `Stash` test, for
  `UnboundedStash` and `UnrestrictedStash` (the latter with an explicit
  deque‑based mailbox, since `UnrestrictedStash` does not declare
  `RequiresMessageQueue`). Both **fail before the fix** (the stashed timer
  message is lost: `expectMsg("scheduled")` times out) and pass after.
- `sbt "actor/mimaReportBinaryIssues"` → no binary issues.

### References

Fixes #3258

