### PR TITLE
fix: replace broken scalafmt-native-action with coursier/setup-action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -34,7 +34,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@a9c8e1032a02004c425d53ef8ce420fe2179eba7 # v5
+      - name: Setup Coursier
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
-          arguments: '--list --mode diff-ref=origin/main'
+          apps: scalafmt
+
+      - name: Check project is formatted
+        run: scalafmt --list --mode diff-ref=origin/main


### PR DESCRIPTION
### Motivation

The "Code is formatted" CI job fails because `jrouly/scalafmt-native-action@v5` has a hardcoded install script URL pointing to scalafmt v3.7.17:

```
curl -sL https://raw.githubusercontent.com/scalameta/scalafmt/refs/tags/v3.7.17/bin/install-scalafmt-native.sh | bash -sv -- 3.11.1
```

This script cannot download scalafmt-native 3.11.1 (the version specified in `.scalafmt.conf`), causing the action to fail before it even checks formatting.

### Modification

Replace `jrouly/scalafmt-native-action` with `coursier/setup-action` (already used in `link-validator.yml`) to install scalafmt via Coursier, then run `scalafmt` directly:

```yaml
- name: Setup Coursier
  uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
  with:
    apps: scalafmt

- name: Check project is formatted
  run: scalafmt --list --mode diff-ref=origin/main
```

The scalafmt version is read from `.scalafmt.conf` automatically.

### Result

The scalafmt CI check installs scalafmt reliably via Coursier and is no longer dependent on a third-party action with stale install script URLs.

### Tests

Not run - CI workflow change only

### References

None - CI infrastructure fix