### PR TITLE
docs: document preMaterialize error-propagation caveat

### DIFF
--- a/docs/src/main/paradox/stream/operators/Sink/preMaterialize.md
+++ b/docs/src/main/paradox/stream/operators/Sink/preMaterialize.md
@@ -13,3 +13,6 @@ Materializes this Sink, immediately returning (1) its materialized value, and (2
 
 Materializes this Sink, immediately returning (1) its materialized value, and (2) a new Sink that can be consume elements 'into' the pre-materialized one. Useful for when you need a materialized value of a Sink when handing it out to someone to materialize it for you.
 
+Note that `preMaterialize` is implemented through a reactive streams `Subscriber` which means that a buffer is introduced
+and that errors are not propagated upstream but are turned into cancellations without error details.
+

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/preMaterialize.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/preMaterialize.md
@@ -14,3 +14,7 @@ Materializes this Graph, immediately returning (1) its materialized value, and (
 
 Materializes this Graph, immediately returning (1) its materialized value, and (2) a new pre-materialized Graph.
 
+Note that `preMaterialize` is implemented through a reactive streams `Publisher` for a `Source` or a `Publisher`
+and `Subscriber` pair for a `Flow` which means that a buffer is introduced and that errors are not propagated upstream
+but are turned into cancellations without error details.
+

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -389,6 +389,10 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
 
   /**
    * Materializes this [[Flow]], immediately returning (1) its materialized value, and (2) a newly materialized [[Flow]].
+   *
+   * Note that `preMaterialize` is implemented through a reactive streams `Publisher` and `Subscriber` pair which means
+   * that a buffer is introduced and that errors are not propagated upstream but are turned into cancellations without
+   * error details.
    */
   def preMaterialize(
       systemProvider: ClassicActorSystemProvider): pekko.japi.Pair[Mat @uncheckedVariance, Flow[In, Out, NotUsed]] = {
@@ -398,6 +402,10 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
   /**
    * Materializes this [[Flow]], immediately returning (1) its materialized value, and (2) a newly materialized [[Flow]].
    * The returned flow is partial materialized and do not support multiple times materialization.
+   *
+   * Note that `preMaterialize` is implemented through a reactive streams `Publisher` and `Subscriber` pair which means
+   * that a buffer is introduced and that errors are not propagated upstream but are turned into cancellations without
+   * error details.
    */
   def preMaterialize(materializer: Materializer): pekko.japi.Pair[Mat @uncheckedVariance, Flow[In, Out, NotUsed]] = {
     val (mat, flow) = delegate.preMaterialize()(materializer)

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
@@ -631,6 +631,9 @@ final class Sink[In, Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkSh
    * Useful for when you need a materialized value of a Sink when handing it out to someone to materialize it for you.
    *
    * Note that the `ActorSystem` can be used as the `systemProvider` parameter.
+   *
+   * Note that `preMaterialize` is implemented through a reactive streams `Subscriber` which means that a buffer is
+   * introduced and that errors are not propagated upstream but are turned into cancellations without error details.
    */
   def preMaterialize(systemProvider: ClassicActorSystemProvider)
       : japi.Pair[Mat @uncheckedVariance, Sink[In @uncheckedVariance, NotUsed]] = {
@@ -645,6 +648,9 @@ final class Sink[In, Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkSh
    * Useful for when you need a materialized value of a Sink when handing it out to someone to materialize it for you.
    *
    * Prefer the method taking an ActorSystem unless you have special requirements.
+   *
+   * Note that `preMaterialize` is implemented through a reactive streams `Subscriber` which means that a buffer is
+   * introduced and that errors are not propagated upstream but are turned into cancellations without error details.
    */
   def preMaterialize(
       materializer: Materializer): japi.Pair[Mat @uncheckedVariance, Sink[In @uncheckedVariance, NotUsed]] = {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -890,6 +890,9 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * that can be used to consume elements from the newly materialized Source.
    *
    * Note that the `ActorSystem` can be used as the `systemProvider` parameter.
+   *
+   * Note that `preMaterialize` is implemented through a reactive streams `Publisher` which means that a buffer is
+   * introduced and that errors are not propagated upstream but are turned into cancellations without error details.
    */
   def preMaterialize(systemProvider: ClassicActorSystemProvider)
       : Pair[Mat @uncheckedVariance, Source[Out @uncheckedVariance, NotUsed]] = {
@@ -902,6 +905,9 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * that can be used to consume elements from the newly materialized Source.
    *
    * Prefer the method taking an `ActorSystem` unless you have special requirements.
+   *
+   * Note that `preMaterialize` is implemented through a reactive streams `Publisher` which means that a buffer is
+   * introduced and that errors are not propagated upstream but are turned into cancellations without error details.
    */
   def preMaterialize(
       materializer: Materializer): Pair[Mat @uncheckedVariance, Source[Out @uncheckedVariance, NotUsed]] = {

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -173,6 +173,10 @@ final class Flow[-In, +Out, +Mat](
   /**
    * Materializes this [[Flow]], immediately returning (1) its materialized value, and (2) a newly materialized [[Flow]].
    * The returned flow is partial materialized and do not support multiple times materialization.
+   *
+   * Note that `preMaterialize` is implemented through a reactive streams `Publisher` and `Subscriber` pair which means
+   * that a buffer is introduced and that errors are not propagated upstream but are turned into cancellations without
+   * error details.
    */
   def preMaterialize()(implicit materializer: Materializer): (Mat, ReprMat[Out, NotUsed]) = {
     val ((sub, mat), pub) =

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
@@ -73,6 +73,9 @@ final class Sink[-In, +Mat](override val traversalBuilder: LinearTraversalBuilde
    * that can be consume elements 'into' the pre-materialized one.
    *
    * Useful for when you need a materialized value of a Sink when handing it out to someone to materialize it for you.
+   *
+   * Note that `preMaterialize` is implemented through a reactive streams `Subscriber` which means that a buffer is
+   * introduced and that errors are not propagated upstream but are turned into cancellations without error details.
    */
   def preMaterialize()(implicit materializer: Materializer): (Mat, Sink[In, NotUsed]) = {
     val (sub, mat) = Source.asSubscriber.toMat(this)(Keep.both).run()

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
@@ -111,6 +111,9 @@ final class Source[+Out, +Mat](
   /**
    * Materializes this Source, immediately returning (1) its materialized value, and (2) a new Source
    * that can be used to consume elements from the newly materialized Source.
+   *
+   * Note that `preMaterialize` is implemented through a reactive streams `Publisher` which means that a buffer is
+   * introduced and that errors are not propagated upstream but are turned into cancellations without error details.
    */
   def preMaterialize()(implicit materializer: Materializer): (Mat, ReprMat[Out, NotUsed]) = {
     val (mat, pub) = toMat(Sink.asPublisher(fanout = true))(Keep.both).run()


### PR DESCRIPTION
### Motivation

`preMaterialize` crosses a reactive-streams `Publisher`/`Subscriber` boundary, which introduces a buffer and turns upstream failures into cancellations without error details. This surprising behaviour was previously undocumented, so users reasonably expected error propagation through a pre-materialized `Source`/`Sink`/`Flow`.

### Modification

Add the caveat to the scaladoc of every `preMaterialize` overload on `Source`/`Sink`/`Flow` in both the Scala and Java DSLs, and to the `Sink` and `Source-or-Flow` paradox operator pages:

- Scala DSL: `Source`, `Sink`, `Flow`
- Java DSL: `Source` (×2), `Sink` (×2), `Flow` (×2)
- Paradox: `Sink/preMaterialize.md`, `Source-or-Flow/preMaterialize.md`

The wording follows the DSL primitive used by each operator: `Source` → `Publisher`, `Sink` → `Subscriber`, `Flow` → `Publisher` and `Subscriber` pair. For consistency the caveat is also added to the Java DSL `materializer` overloads of `Sink`/`Source`, which had no direct upstream counterpart (Akka documented only the `ActorSystem` overloads there); both overloads delegate to the same `scaladsl.preMaterialize()`, so the caveat applies equally.

### Result

Users are clearly warned that `preMaterialize` buffers elements and does not propagate upstream errors, avoiding surprises when a pre-materialized graph fails.

which is now Apache licensed

### Tests

Not run - docs only (scaladoc + paradox). The change is mechanically comment-only and was validated with native `scalafmt` (3.11.1).

### References

Ports [akka/akka-core@b7e625fb](https://github.com/akka/akka-core/commit/b7e625fb1274323afb9e8c5f0c2f4c9560cc4da1) (akka#31982), which is now Apache licensed.
