### PR TITLE
Close unregistered TCP channels on setup failure

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/io/TcpIntegrationSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/TcpIntegrationSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.io
 
 import java.io.IOException
 import java.net.{ InetSocketAddress, ServerSocket, Socket }
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.concurrent.duration._
 
@@ -187,10 +188,10 @@ class TcpIntegrationSpec extends PekkoSpec("""
     "reply with CommandFailed when a connect socket option fails before connect" in {
       val connectCommander = TestProbe()
       val failure = new UnsupportedOperationException("boom")
-      @volatile var socket: Socket = null
+      val socket = new AtomicReference[Socket]
       val failingOption = new Inet.SocketOption {
         override def beforeConnect(s: Socket): Unit = {
-          socket = s
+          socket.set(s)
           throw failure
         }
       }
@@ -202,8 +203,8 @@ class TcpIntegrationSpec extends PekkoSpec("""
       val commandFailed = connectCommander.expectMsgType[CommandFailed]
       commandFailed.cmd should ===(command)
       commandFailed.cause should ===(Some(failure))
-      socket should not be null
-      awaitCond(socket.isClosed)
+      socket.get should not be null
+      awaitCond(socket.get.isClosed)
     }
 
     "handle tcp connection actor death properly" in new TestSetup(shouldBindServer = false) {

--- a/actor-tests/src/test/scala/org/apache/pekko/io/TcpIntegrationSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/TcpIntegrationSpec.scala
@@ -187,8 +187,12 @@ class TcpIntegrationSpec extends PekkoSpec("""
     "reply with CommandFailed when a connect socket option fails before connect" in {
       val connectCommander = TestProbe()
       val failure = new UnsupportedOperationException("boom")
+      @volatile var socket: Socket = null
       val failingOption = new Inet.SocketOption {
-        override def beforeConnect(s: Socket): Unit = throw failure
+        override def beforeConnect(s: Socket): Unit = {
+          socket = s
+          throw failure
+        }
       }
       val endpoint = new InetSocketAddress("127.0.0.1", 1)
       val command = Connect(endpoint, options = List(failingOption))
@@ -198,6 +202,8 @@ class TcpIntegrationSpec extends PekkoSpec("""
       val commandFailed = connectCommander.expectMsgType[CommandFailed]
       commandFailed.cmd should ===(command)
       commandFailed.cause should ===(Some(failure))
+      socket should not be null
+      awaitCond(socket.isClosed)
     }
 
     "handle tcp connection actor death properly" in new TestSetup(shouldBindServer = false) {

--- a/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
@@ -410,8 +410,15 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
       (if (writePending) Set(pendingWrite.commander) else Set.empty) ++
       closedMessage.toList.flatMap(_.notificationsTo).toSet
 
-    if (channel.isOpen) // if channel is still open here, we didn't go through stopWith => unexpected actor termination
+    if (channel.isOpen) {
       prepareAbort()
+      // Without a ChannelRegistration there is no selector callback to close through.
+      if (registration.isEmpty)
+        try channel.close()
+        catch {
+          case NonFatal(e) => log.debug("Error closing SocketChannel: {}", e)
+        }
+    }
 
     def isCommandFailed: Boolean = closedMessage.exists(_.closedEvent.isInstanceOf[CommandFailed])
     def notifyInterested(): Unit =

--- a/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
@@ -416,7 +416,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
       if (registration.isEmpty)
         try channel.close()
         catch {
-          case NonFatal(e) => log.debug("Error closing SocketChannel: {}", e)
+          case NonFatal(e) => log.error(e, "Error closing SocketChannel")
         }
     }
 


### PR DESCRIPTION
### Motivation
Outgoing TCP connection setup can fail before the connection actor receives a `ChannelRegistration`. In that path, `TcpConnection.postStop` reported `CommandFailed` but left the `SocketChannel` open because there was no registration callback available to close it.

### Modification
Close still-open channels directly from `postStop` when no `ChannelRegistration` exists. Registered channels continue to use the existing `cancelAndClose` path.

Also extend the existing connect socket option failure test to verify that the socket captured before the failed `beforeConnect` call is closed after `CommandFailed`.

### Result
TCP setup failures before `ChannelRegistration` no longer leave the underlying `SocketChannel` open.

### Tests
- `sbt "actor-tests / Test / testOnly org.apache.pekko.io.TcpIntegrationSpec"`
- `sbt "actor / Compile / scalafmtCheck" "actor-tests / Test / scalafmtCheck"`
- `git diff --check`

### References
Fixes #3246