### PR TITLE
docs: link to app-version from Deployment for rolling updates

### DIFF
--- a/docs/src/main/paradox/additional/rolling-updates.md
+++ b/docs/src/main/paradox/additional/rolling-updates.md
@@ -58,6 +58,10 @@ pekko.cluster.app-version = 1.2.3
 To understand which is old and new it compares the version numbers using normal conventions,
 see @apidoc[util.Version] for more details.
 
+When using [Kubernetes Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) with `RollingUpdate`
+strategy you should enable the @extref:[app-version from Deployment feature from Pekko Management](pekko-management-snapshot:rolling-updates.html#app-version-from-deployment)
+to automatically define the `app-version` from the Kubernetes `deployment.kubernetes.io/revision` annotation.
+
 Rebalance is also disabled during rolling updates, since shards from stopped nodes are anyway supposed to be
 started on new nodes. Messages to shards that were stopped on the old nodes will allocate corresponding shards
 on the new nodes, without waiting for rebalance actions. 

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -32,6 +32,7 @@ object Paradox {
         .url(version.value), // for links like this: @github[#1](#1) or @github[83986f9](83986f9)
       "extref.pekko.http.base_url" -> s"$pekkoBaseURL/docs/pekko-http/current/%s",
       "extref.pekko-management.base_url" -> s"$pekkoBaseURL/docs/pekko-management/current/%s",
+      "extref.pekko-management-snapshot.base_url" -> s"$pekkoBaseURL/docs/pekko-management/snapshot/%s",
       "extref.platform-guide.base_url" -> "https://developer.lightbend.com/docs/akka-platform-guide/%s",
       "extref.wikipedia.base_url" -> "https://en.wikipedia.org/wiki/%s",
       "extref.github.base_url" -> (GitHub.url(version.value) + "/%s"), // for links to our sources


### PR DESCRIPTION
### Motivation

The rolling-updates docs explained the manual `pekko.cluster.app-version` setting but did not mention that Pekko Management can derive it automatically from a Kubernetes Deployment, so users on Kubernetes bumped the version by hand unnecessarily.

### Modification

Add a paragraph to the rolling-updates page pointing to the **app-version from Deployment** feature in Pekko Management, which sets `app-version` from the Kubernetes `deployment.kubernetes.io/revision` annotation.

The upstream commit also touched `deploying.md` and added a `#kubernetes-rolling-updates` anchor to an existing link in `rolling-updates.md`, but pekko's `deploying.md` has diverged (no matching "Rolling updates" section) and pekko's corresponding `rolling-updates.md` text was rewritten without that link, so only the new app-version paragraph applies here.

### Result

Users running on Kubernetes Deployments are pointed to the automatic app-version mechanism instead of bumping it manually.

which is now Apache licensed

### Tests

Not run - docs only. `sbt "docs/paradox"` builds successfully and the `pekko-management:rolling-updates.html#app-version-from-deployment` extref resolves to a real anchor in Pekko Management.

### References

Ports [akka/akka-core@d1e577a8ba](https://github.com/akka/akka-core/commit/d1e577a8ba1bd97d8c775d09632277ef289b17e7) (akka#31942), which is now Apache licensed.
