### PR TITLE
docs: fix import order in state store plugin examples

### DIFF
--- a/docs/src/main/scala/docs/persistence/state/MyStateStore.scala
+++ b/docs/src/main/scala/docs/persistence/state/MyStateStore.scala
@@ -13,14 +13,14 @@
 
 package docs.persistence.state
 
+import com.typesafe.config.Config
+
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.ExtendedActorSystem
 import pekko.persistence.state.{ DurableStateStoreProvider, DurableStateStoreRegistry }
 import pekko.persistence.state.javadsl.{ DurableStateStore => JDurableStateStore }
 import pekko.persistence.state.scaladsl.{ DurableStateStore, DurableStateUpdateStore, GetObjectResult }
-
-import com.typesafe.config.Config
 
 import scala.concurrent.Future
 

--- a/docs/src/test/scala/docs/persistence/state/PersistenceStatePluginDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/state/PersistenceStatePluginDocSpec.scala
@@ -13,6 +13,9 @@
 
 package docs.persistence.state
 
+import com.typesafe.config._
+import docs.persistence
+
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.{ ActorSystem, ExtendedActorSystem }
@@ -23,9 +26,6 @@ import pekko.persistence.state.scaladsl.GetObjectResult
 import pekko.persistence.Persistence
 import pekko.persistence.state.DurableStateStoreRegistry
 import pekko.testkit.TestKit
-
-import com.typesafe.config._
-import docs.persistence
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.Future


### PR DESCRIPTION
### Motivation
In PR #3274, @pjfanning noted that `com.typesafe.config.Config` was placed after pekko imports, breaking the visual grouping of pekko imports in the state store plugin example files.

### Modification
Moved `com.typesafe.config` imports before `org.apache.pekko` in `MyStateStore.scala` and `PersistenceStatePluginDocSpec.scala` so that all pekko imports are grouped together, consistent with the convention in other persistence doc files.

### Result
Import order follows the established convention: `scala.*` → `com.*` → `org.apache.pekko`/`pekko.*` → `org.*`

### Tests
- `sbt docs/compile` → success
- `sbt "docs/Test/testOnly docs.persistence.state.PersistenceStatePluginDocSpec"` → 2/2 passed

### References
Refs #3274