### PR TITLE
Fix ambiguous scaladoc overload links in persistence-typed #353

### DIFF
--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/CommandHandler.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/CommandHandler.scala
@@ -313,7 +313,7 @@ final class CommandHandlerBuilderByState[Command, Event, S <: State, State] @Int
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandler from the appended states.
@@ -335,7 +335,7 @@ final class CommandHandlerBuilderByState[Command, Event, S <: State, State] @Int
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandler from the appended states.
@@ -360,7 +360,7 @@ final class CommandHandlerBuilderByState[Command, Event, S <: State, State] @Int
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandler from the appended states.

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/CommandHandlerWithReply.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/CommandHandlerWithReply.scala
@@ -322,7 +322,7 @@ final class CommandHandlerWithReplyBuilderByState[Command, Event, S <: State, St
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandlerWithReply from the appended states.
@@ -345,7 +345,7 @@ final class CommandHandlerWithReplyBuilderByState[Command, Event, S <: State, St
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandlerWithReply from the appended states.
@@ -371,7 +371,7 @@ final class CommandHandlerWithReplyBuilderByState[Command, Event, S <: State, St
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandlerWithReply from the appended states.

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/Effect.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/Effect.scala
@@ -43,7 +43,7 @@ import pekko.persistence.typed.internal.SideEffect
 
   /**
    * Persist all of a the given events. Each event will be applied through `applyEffect` separately but not until
-   * all events has been persisted. If `callback` is added through [[EffectBuilder.thenRun]] that will invoked
+   * all events has been persisted. If `callback` is added through `EffectBuilder.thenRun` that will invoked
    * after all the events has been persisted.
    */
   final def persist(events: java.util.List[Event]): EffectBuilder[Event, State] = PersistAll(events.asScala.toVector)

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventHandler.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventHandler.scala
@@ -274,7 +274,7 @@ final class EventHandlerBuilderByState[S <: State, State, Event](
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your event handlers.
    *
-   * Extra care should be taken when using [[onAnyEvent]] as it will match any event.
+   * Extra care should be taken when using `onAnyEvent` as it will match any event.
    * This method builds and returns the event handler since this will not let through any states to subsequent match statements.
    *
    * @return An EventHandler from the appended states.
@@ -294,7 +294,7 @@ final class EventHandlerBuilderByState[S <: State, State, Event](
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your event handlers.
    *
-   * Extra care should be taken when using [[onAnyEvent]] as it will match any event.
+   * Extra care should be taken when using `onAnyEvent` as it will match any event.
    * This method builds and returns the event handler since this will not let through any states to subsequent match statements.
    *
    * @return An EventHandler from the appended states.

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -156,7 +156,7 @@ abstract class EventSourcedBehavior[Command, Event, State] private[pekko] (
    * been persisted.
    *
    * Snapshots triggered by `snapshotWhen` will not trigger deletes of old snapshots and events if
-   * [[EventSourcedBehavior.retentionCriteria]] with [[RetentionCriteria.snapshotEvery]] is used together with
+   * [[EventSourcedBehavior.retentionCriteria]] with `RetentionCriteria.snapshotEvery` is used together with
    * `shouldSnapshot`. Such deletes are only triggered by snapshots matching the `numberOfEvents` in the
    * [[RetentionCriteria]].
    *
@@ -181,7 +181,7 @@ abstract class EventSourcedBehavior[Command, Event, State] private[pekko] (
   /**
    * Return tags to store for the given event, the tags can then be used in persistence query.
    *
-   * If [[tagsFor(Event, State)]] is overridden this method is ignored.
+   * If `tagsFor` is overridden this method is ignored.
    */
   def tagsFor(@nowarn("msg=never used") event: Event): java.util.Set[String] = Collections.emptySet()
 

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/RetentionCriteria.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/javadsl/RetentionCriteria.scala
@@ -66,7 +66,7 @@ object RetentionCriteria {
 @DoNotInherit abstract class SnapshotCountRetentionCriteria extends RetentionCriteria {
 
   /**
-   * Delete events after saving snapshot via [[RetentionCriteria.snapshotEvery]].
+   * Delete events after saving snapshot via `RetentionCriteria.snapshotEvery`.
    * Events that have sequence number less than the snapshot sequence number minus
    * `keepNSnapshots * numberOfEvents` are deleted.
    */

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala
@@ -187,7 +187,7 @@ object EventSourcedBehavior {
    * been persisted.
    *
    * Snapshots triggered by `snapshotWhen` will not trigger deletes of old snapshots and events if
-   * [[EventSourcedBehavior.withRetention]] with [[RetentionCriteria.snapshotEvery]] is used together with
+   * [[EventSourcedBehavior.withRetention]] with `RetentionCriteria.snapshotEvery` is used together with
    * `snapshotWhen`. Such deletes are only triggered by snapshots matching the `numberOfEvents` in the
    * [[RetentionCriteria]].
    */

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/RetentionCriteria.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/RetentionCriteria.scala
@@ -66,7 +66,7 @@ object RetentionCriteria {
 @DoNotInherit trait SnapshotCountRetentionCriteria extends RetentionCriteria {
 
   /**
-   * Delete events after saving snapshot via [[RetentionCriteria.snapshotEvery]].
+   * Delete events after saving snapshot via `RetentionCriteria.snapshotEvery`.
    * Events that have sequence number less than the snapshot sequence number minus
    * `keepNSnapshots * numberOfEvents` are deleted.
    */

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/CommandHandler.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/CommandHandler.scala
@@ -314,7 +314,7 @@ final class CommandHandlerBuilderByState[Command, S <: State, State] @InternalAp
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandler from the appended states.
@@ -336,7 +336,7 @@ final class CommandHandlerBuilderByState[Command, S <: State, State] @InternalAp
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandler from the appended states.
@@ -361,7 +361,7 @@ final class CommandHandlerBuilderByState[Command, S <: State, State] @InternalAp
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandler from the appended states.

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/CommandHandlerWithReply.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/CommandHandlerWithReply.scala
@@ -324,7 +324,7 @@ final class CommandHandlerWithReplyBuilderByState[Command, S <: State, State] @I
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandlerWithReply from the appended states.
@@ -346,7 +346,7 @@ final class CommandHandlerWithReplyBuilderByState[Command, S <: State, State] @I
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandlerWithReply from the appended states.
@@ -371,7 +371,7 @@ final class CommandHandlerWithReplyBuilderByState[Command, S <: State, State] @I
    * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
    * otherwise you risk to 'shadow' part of your command handlers.
    *
-   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * Extra care should be taken when using `onAnyCommand` as it will match any command.
    * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
    *
    * @return A CommandHandlerWithReply from the appended states.


### PR DESCRIPTION
  ### Motivation
  `sbt unidoc` reports 91 scaladoc warnings on `main`. The largest single cluster (19) is in `persistence-typed`: doc comments bare-link a method name that has multiple overloads (`onAnyCommand`, `onAnyEvent`,
  `RetentionCriteria.snapshotEvery`, `EffectBuilder.thenRun`), so Scaladoc can't resolve which overload is meant. Same root cause #3064 fixed for `ShardRegion`. A malformed `[[tagsFor(Event, State)]]` link in the same file is also fixed.

  ### Modification
  Replace the bare `[[method]]` links with plain backtick text in the 8 affected files (20 lines total), matching the approach used in #3064.

  ### Result
  The 19 targeted ambiguous-link warnings plus the `tagsFor` syntax warning are resolved, verified by exact warning-identity diff (not just the aggregate count). The total count moved from 91 to 74, not 71, because 3 unrelated, previously-latent warnings in `actor` and `stream` surfaced as a side effect of unidoc's cross-module link resolution ordering - confirmed via a clean rebuild that these are pre-existing and untouched by this change, not a regression it introduces.

  ### Tests
  - Not run - docs only.
  - `sbt "persistence-typed/doc"` confirms the 19 targeted warnings no longer appear.
  - `sbt -Dpekko.scaladoc.diagrams=false unidoc` (clean rebuild) confirms the exact same 20 warnings are gone; 3 unrelated warnings in `actor`/`stream` appeared independently of this change (explained above).
  - Native scalafmt not installed; ran `sbt persistence-typed/scalafmtAll` instead - made no additional changes beyond the 20 targeted lines.
  - `git diff --check`: clean.

  ### References
  Refs #353