### PR TITLE
Fix ambiguous scaladoc overload links in persistence module family #353

### DIFF
--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/ReadJournalProvider.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/ReadJournalProvider.scala
@@ -29,13 +29,13 @@ trait ReadJournalProvider {
 
   /**
    * The `ReadJournal` implementation for the Scala API.
-   * This corresponds to the instance that is returned by [[PersistenceQuery#readJournalFor]].
+   * This corresponds to the instance that is returned by `PersistenceQuery#readJournalFor`.
    */
   def scaladslReadJournal(): scaladsl.ReadJournal
 
   /**
    * The `ReadJournal` implementation for the Java API.
-   * This corresponds to the instance that is returned by [[PersistenceQuery#getReadJournalFor]].
+   * This corresponds to the instance that is returned by `PersistenceQuery#getReadJournalFor`.
    */
   def javadslReadJournal(): javadsl.ReadJournal
 }

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/javadsl/LeveldbReadJournal.scala
@@ -172,7 +172,7 @@ object LeveldbReadJournal {
 
   /**
    * The default identifier for [[LeveldbReadJournal]] to be used with
-   * [[pekko.persistence.query.PersistenceQuery#getReadJournalFor]].
+   * `PersistenceQuery#getReadJournalFor`.
    *
    * The value is `"pekko.persistence.query.journal.leveldb"` and corresponds
    * to the absolute path to the read journal configuration entry.

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/journal/leveldb/scaladsl/LeveldbReadJournal.scala
@@ -283,7 +283,7 @@ object LeveldbReadJournal {
 
   /**
    * The default identifier for [[LeveldbReadJournal]] to be used with
-   * [[pekko.persistence.query.PersistenceQuery#readJournalFor]].
+   * `PersistenceQuery#readJournalFor`.
    *
    * The value is `"pekko.persistence.query.journal.leveldb"` and corresponds
    * to the absolute path to the read journal configuration entry.

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
@@ -26,7 +26,7 @@ import com.typesafe.config.Config
 /**
  * JAVA API
  *
- * This spec aims to verify custom pekko-persistence [[pekko.persistence.state.DurableStateStore]]
+ * This spec aims to verify custom pekko-persistence `DurableStateStore`
  * implementations.
  * Plugin authors are highly encouraged to include it in their plugin's test suites.
  *

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
@@ -41,7 +41,7 @@ object DurableStateStoreSpec {
 }
 
 /**
- * This spec aims to verify custom pekko-persistence [[DurableStateStore]] implementations.
+ * This spec aims to verify custom pekko-persistence `DurableStateStore` implementations.
  * Plugin authors are highly encouraged to include it in their plugin's test suites.
  *
  * In case your durable state store plugin needs some kind of setup or teardown, override the `beforeAll`

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/TestOps.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/TestOps.scala
@@ -117,7 +117,7 @@ private[testkit] trait PolicyOpsTestKit[P] {
   }
 
   /**
-   * Returns default policy if it was changed by [[PolicyOpsTestKit.this.withPolicy()]].
+   * Returns default policy if it was changed by `withPolicy`.
    */
   def resetPolicy(): Unit = storage.resetPolicy()
 
@@ -272,7 +272,7 @@ private[testkit] trait ClearOps {
    *
    * NOTE! Also clears sequence numbers in storage!
    *
-   * @see [[ClearPreservingSeqNums.clearAllPreservingSeqNumbers()]]
+   * @see `ClearPreservingSeqNums.clearAllPreservingSeqNumbers`
    */
   def clearAll(): Unit = {
     storage.clearAll()
@@ -284,7 +284,7 @@ private[testkit] trait ClearOps {
    *
    * NOTE! Also clears sequence number in the storage!
    *
-   * @see [[ClearPreservingSeqNums.clearByIdPreservingSeqNumbers()]]
+   * @see `ClearPreservingSeqNums.clearByIdPreservingSeqNumbers`
    */
   def clearByPersistenceId(persistenceId: String): Unit = {
     storage.removeKey(persistenceId)
@@ -299,7 +299,7 @@ private[testkit] trait ClearPreservingSeqNums {
   /**
    * Clear all data in the storage preserving sequence numbers.
    *
-   * @see [[ClearOps.clearAll()]]
+   * @see `ClearOps.clearAll`
    */
   def clearAllPreservingSeqNumbers(): Unit = {
     storage.clearAllPreservingSeqNumbers()
@@ -309,7 +309,7 @@ private[testkit] trait ClearPreservingSeqNums {
   /**
    * Clear all data in the storage for particular persistence id preserving sequence numbers.
    *
-   * @see [[ClearOps.clearByPersistenceId()]]
+   * @see `ClearOps.clearByPersistenceId`
    */
   def clearByIdPreservingSeqNumbers(persistenceId: String): Unit = {
     storage.removePreservingSeqNumber(persistenceId)

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/delivery/EventSourcedProducerQueue.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/delivery/EventSourcedProducerQueue.scala
@@ -40,7 +40,7 @@ import com.typesafe.config.Config
  * event before sending the message to the destination and one event for the confirmation
  * that the message has been delivered and processed.
  *
- * The [[DurableProducerQueue.LoadState]] request is used at startup to retrieve the unconfirmed messages.
+ * The `DurableProducerQueue.LoadState` request is used at startup to retrieve the unconfirmed messages.
  */
 @ApiMayChange
 object EventSourcedProducerQueue {

--- a/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala
@@ -92,7 +92,7 @@ object AtLeastOnceDelivery {
 /**
  * Scala API: Mix-in this trait with your `PersistentActor` to send messages with at-least-once
  * delivery semantics to destinations. It takes care of re-sending messages when they
- * have not been confirmed within a configurable timeout. Use the [[AtLeastOnceDeliveryLike#deliver]] method to
+ * have not been confirmed within a configurable timeout. Use the `AtLeastOnceDeliveryLike#deliver` method to
  * send a message to a destination. Call the [[AtLeastOnceDeliveryLike#confirmDelivery]] method when the destination
  * has replied with a confirmation message.
  *
@@ -227,7 +227,7 @@ trait AtLeastOnceDeliveryLike extends Eventsourced {
 
   /**
    * Maximum number of unconfirmed messages that this actor is allowed to hold in memory.
-   * If this number is exceed [[#deliver]] will not accept more messages and it will throw
+   * If this number is exceed `deliver` will not accept more messages and it will throw
    * [[AtLeastOnceDelivery.MaxUnconfirmedMessagesExceededException]].
    *
    * The default value can be configured with the
@@ -303,7 +303,7 @@ trait AtLeastOnceDeliveryLike extends Eventsourced {
   /**
    * Call this method when a message has been confirmed by the destination,
    * or to abort re-sending.
-   * @see [[#deliver]]
+   * @see `deliver`
    * @return `true` the first time the `deliveryId` is confirmed, i.e. `false` for duplicate confirm
    */
   def confirmDelivery(deliveryId: Long): Boolean = {

--- a/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
@@ -522,7 +522,7 @@ private[persistence] trait Eventsourced
    * If the delete is successful a [[pekko.persistence.DeleteMessagesSuccess]] will be sent to the actor.
    * If the delete fails a [[pekko.persistence.DeleteMessagesFailure]] will be sent to the actor.
    *
-   * The given `toSequenceNr` must be less than or equal to [[Eventsourced#lastSequenceNr]], otherwise
+   * The given `toSequenceNr` must be less than or equal to `lastSequenceNr`, otherwise
    * [[pekko.persistence.DeleteMessagesFailure]] is sent to the actor without performing the delete. All persistent
    * messages may be deleted without specifying the actual sequence number by using `Long.MaxValue`
    * as the `toSequenceNr`.
@@ -544,7 +544,7 @@ private[persistence] trait Eventsourced
    * An [[Eventsourced]] actor can request cleanup by deleting either a range of, or all persistent events.
    * For example, on successful snapshot completion, delete messages within a configurable `snapshotAfter`
    * range that are less than or equal to the given [[SnapshotMetadata.sequenceNr]]
-   * (provided the [[SnapshotMetadata.sequenceNr]] is <= to [[Eventsourced#lastSequenceNr]]).
+   * (provided the [[SnapshotMetadata.sequenceNr]] is <= to `lastSequenceNr`).
    *
    * Or delete all by using `Long.MaxValue` as the `toSequenceNr`
    * {{{ m.copy(sequenceNr = Long.MaxValue) }}}

--- a/persistence/src/main/scala/org/apache/pekko/persistence/JournalProtocol.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/JournalProtocol.scala
@@ -156,11 +156,11 @@ private[persistence] object JournalProtocol {
 }
 
 /**
- * Reply message to a successful [[JournalProtocol.DeleteMessagesTo]] request.
+ * Reply message to a successful `DeleteMessagesTo` request.
  */
 final case class DeleteMessagesSuccess(toSequenceNr: Long) extends JournalProtocol.Response
 
 /**
- * Reply message to a failed [[JournalProtocol.DeleteMessagesTo]] request.
+ * Reply message to a failed `DeleteMessagesTo` request.
  */
 final case class DeleteMessagesFailure(cause: Throwable, toSequenceNr: Long) extends JournalProtocol.Response

--- a/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSMBase.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSMBase.scala
@@ -153,8 +153,8 @@ trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging 
     register(stateName, stateFunction, Option(stateTimeout))
 
   /**
-   * Set initial state. Call this method from the constructor before the [[#initialize]] method.
-   * If different state is needed after a restart this method, followed by [[#initialize]], can
+   * Set initial state. Call this method from the constructor before the `initialize` method.
+   * If different state is needed after a restart this method, followed by `initialize`, can
    * be used in the actor life cycle hooks [[pekko.actor.Actor#preStart]] and [[pekko.actor.Actor#postRestart]].
    *
    * @param stateName initial state designator
@@ -821,8 +821,8 @@ abstract class AbstractPersistentFSMBase[S, D, E] extends PersistentFSMBase[S, D
     when(stateName, stateTimeout)(stateFunctionBuilder.build())
 
   /**
-   * Set initial state. Call this method from the constructor before the [[#initialize]] method.
-   * If different state is needed after a restart this method, followed by [[#initialize]], can
+   * Set initial state. Call this method from the constructor before the `initialize` method.
+   * If different state is needed after a restart this method, followed by `initialize`, can
    * be used in the actor life cycle hooks [[pekko.actor.Actor#preStart]] and [[pekko.actor.Actor#postRestart]].
    *
    * @param stateName initial state designator
@@ -832,8 +832,8 @@ abstract class AbstractPersistentFSMBase[S, D, E] extends PersistentFSMBase[S, D
     startWith(stateName, stateData, null: FiniteDuration)
 
   /**
-   * Set initial state. Call this method from the constructor before the [[#initialize]] method.
-   * If different state is needed after a restart this method, followed by [[#initialize]], can
+   * Set initial state. Call this method from the constructor before the `initialize` method.
+   * If different state is needed after a restart this method, followed by `initialize`, can
    * be used in the actor life cycle hooks [[pekko.actor.Actor#preStart]] and [[pekko.actor.Actor#postRestart]].
    *
    * @param stateName initial state designator

--- a/persistence/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreProvider.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreProvider.scala
@@ -25,13 +25,13 @@ trait DurableStateStoreProvider {
 
   /**
    * The `DurableStateStore` implementation for the Scala API.
-   * This corresponds to the instance that is returned by [[org.apache.pekko.persistence.state.DurableStateStoreRegistry.durableStateStoreFor DurableStateStoreRegistry#durableStateStoreFor]].
+   * This corresponds to the instance that is returned by `DurableStateStoreRegistry#durableStateStoreFor`.
    */
   def scaladslDurableStateStore(): scaladsl.DurableStateStore[Any]
 
   /**
    * The `DurableStateStore` implementation for the Java API.
-   * This corresponds to the instance that is returned by [[org.apache.pekko.persistence.state.DurableStateStoreRegistry.getDurableStateStoreFor DurableStateStoreRegistry#getDurableStateStoreFor]].
+   * This corresponds to the instance that is returned by `DurableStateStoreRegistry#getDurableStateStoreFor`.
    */
   def javadslDurableStateStore(): javadsl.DurableStateStore[AnyRef]
 }


### PR DESCRIPTION
  ### Motivation
  Continuing from #3281. `sbt unidoc` reported 74 warnings after that merge. The next-largest clusters were bare
  `[[method]]` links to overloaded or private members — same bug class as #3281 — spread across the persistence
  module family (`persistence`, `persistence-query`, `persistence-tck`, `persistence-testkit`,
  `persistence-typed`).

  ### Modification
  Replace the bare `[[method]]` links with plain backtick text in 12 files (27 lines total):
  `deliver`/`initialize`/`DeleteMessagesTo`/`lastSequenceNr` in `persistence`,
  `readJournalFor`/`getReadJournalFor` in `persistence-query`, `DurableStateStore` in `persistence-tck`, five
  parenthesized links in `persistence-testkit`'s `TestOps.scala`, and one leftover in `persistence-typed`.

  ### Result
  23 targeted warnings resolved, verified by exact warning-identity diff. Total count moved from 74 to 61, not
  51, because fixing these revealed 10 previously-latent warnings elsewhere (all in the `stream` module, none
  touched by this change) — the same unidoc cross-module ordering effect noted in #3281. Those `stream` warnings
  are left for a separate PR since initial investigation showed fixing them cascades into revealing many more
  in `stream`/`stream-typed`, making it a much larger, separate effort.

  ### Tests
  - Not run - docs only.
  - `sbt "persistence/doc"` (and equivalent per-module checks) confirm the 23 targeted warnings no longer
  appear.
  - `sbt -Dpekko.scaladoc.diagrams=false unidoc` (clean rebuild, run twice) confirms the count is stable at 61
  and the warning set is reproducible.
  - Native scalafmt not installed; ran `sbt scalafmtAll` per touched module instead - made no additional changes
  beyond the 27 targeted lines.
  - `git diff --check`: clean.

  ### References
  Refs #353