### PR TITLE
fix: suppress Java compilation warnings in actor, remote and docs modules

### DIFF
--- a/actor/src/main/java/org/apache/pekko/util/OptionalUtil.java
+++ b/actor/src/main/java/org/apache/pekko/util/OptionalUtil.java
@@ -25,6 +25,7 @@ import scala.jdk.javaapi.OptionConverters;
 public final class OptionalUtil {
   private static final scala.Option<?> noneValue = None$.MODULE$;
 
+  @SuppressWarnings("unchecked")
   public static <T> scala.Option<T> scalaNone() {
     return (scala.Option<T>) noneValue;
   }

--- a/docs/src/main/java/docs/persistence/state/MyJavaStateStore.java
+++ b/docs/src/main/java/docs/persistence/state/MyJavaStateStore.java
@@ -59,6 +59,7 @@ class MyJavaStateStore<A> implements DurableStateUpdateStore<A> {
   }
 
   /** Deprecated. Use the deleteObject overload with revision instead. */
+  @SuppressWarnings("deprecation")
   @Override
   public CompletionStage<Done> deleteObject(String persistenceId) {
     return deleteObject(persistenceId, 0);

--- a/remote/src/test/java/org/apache/pekko/remote/transport/ThrottlerTransportAdapterTest.java
+++ b/remote/src/test/java/org/apache/pekko/remote/transport/ThrottlerTransportAdapterTest.java
@@ -14,6 +14,7 @@
 package org.apache.pekko.remote.transport;
 
 // compile only; verify java interop
+@SuppressWarnings("deprecation")
 public class ThrottlerTransportAdapterTest {
 
   public void compileThrottlerTransportAdapterDirections() {


### PR DESCRIPTION
### Motivation
Several Java source files produce compilation warnings during sbt compilation:
- `OptionalUtil.scalaNone()` has an unchecked covariant cast from `scala.Option<?>` to `scala.Option<T>`
- `ThrottlerTransportAdapterTest` uses deprecated classic remoting APIs (intentionally, for Java interop verification)
- `MyJavaStateStore.deleteObject(String)` overrides a deprecated interface method from `DurableStateUpdateStore`

### Modification
- Add `@SuppressWarnings("unchecked")` to `OptionalUtil.scalaNone()`
- Add `@SuppressWarnings("deprecation")` to `ThrottlerTransportAdapterTest`
- Add `@SuppressWarnings("deprecation")` to `MyJavaStateStore.deleteObject(String)`

### Result
Java compilation no longer reports warnings for these files. All changes are suppression annotations on code where the underlying usage is intentional and correct.

### Tests
- `sbt "actor / compile"` - no warnings
- `sbt "remote / Test / compile"` - no warnings
- `sbt "docs / compile"` - no warnings

### References
None - cleanup