### PR TITLE
fix: fix javadoc warnings in actor module Java sources

### DIFF
--- a/actor/src/main/java/org/apache/pekko/io/UnsynchronizedByteArrayInputStream.java
+++ b/actor/src/main/java/org/apache/pekko/io/UnsynchronizedByteArrayInputStream.java
@@ -92,7 +92,7 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
    * @param data the buffer
    * @param offset the offset into the buffer
    * @param length the length of the buffer
-   * @throws IllegalArgumentException if the offset or length less than zero
+   * @throws java.lang.IllegalArgumentException if the offset or length less than zero
    */
   public UnsynchronizedByteArrayInputStream(final byte[] data, final int offset, final int length) {
     requireNonNegative(offset, "offset");

--- a/actor/src/main/java/org/apache/pekko/japi/pf/AbstractMatch.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/AbstractMatch.java
@@ -16,7 +16,7 @@ package org.apache.pekko.japi.pf;
 import scala.PartialFunction;
 
 /**
- * Version of {@link scala.PartialFunction} that can be built during runtime from Java.
+ * Version of {@code scala.PartialFunction} that can be built during runtime from Java.
  *
  * @param <I> the input type, that this PartialFunction will be applied to
  * @param <R> the return type, that the results of the application will have
@@ -32,7 +32,7 @@ class AbstractMatch<I, R> {
   }
 
   /**
-   * Turn this {@link Match} into a {@link scala.PartialFunction}.
+   * Turn this {@link Match} into a {@code scala.PartialFunction}.
    *
    * @return a partial function representation ot his {@link Match}
    */

--- a/actor/src/main/java/org/apache/pekko/japi/pf/AbstractPFBuilder.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/AbstractPFBuilder.java
@@ -16,7 +16,7 @@ package org.apache.pekko.japi.pf;
 import scala.PartialFunction;
 
 /**
- * A builder for {@link scala.PartialFunction}.
+ * A builder for {@code scala.PartialFunction}.
  *
  * @param <F> the input type, that this PartialFunction will be applied to
  * @param <T> the return type, that the results of the application will have
@@ -31,7 +31,7 @@ abstract class AbstractPFBuilder<F, T> {
   }
 
   /**
-   * Build a {@link scala.PartialFunction} from this builder. After this call the builder will be
+   * Build a {@code scala.PartialFunction} from this builder. After this call the builder will be
    * reset.
    *
    * @return a PartialFunction for this builder.

--- a/actor/src/main/java/org/apache/pekko/japi/pf/FSMStateFunctionBuilder.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/FSMStateFunctionBuilder.java
@@ -263,7 +263,7 @@ public class FSMStateFunctionBuilder<S, D> {
   }
 
   /**
-   * Build a {@link scala.PartialFunction} from this builder. After this call the builder will be
+   * Build a {@code scala.PartialFunction} from this builder. After this call the builder will be
    * reset.
    *
    * @return a PartialFunction for this builder.

--- a/actor/src/main/java/org/apache/pekko/japi/pf/FSMStopBuilder.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/FSMStopBuilder.java
@@ -122,7 +122,7 @@ public class FSMStopBuilder<S, D> {
   }
 
   /**
-   * Build a {@link scala.PartialFunction} from this builder. After this call the builder will be
+   * Build a {@code scala.PartialFunction} from this builder. After this call the builder will be
    * reset.
    *
    * @return a PartialFunction for this builder.

--- a/actor/src/main/java/org/apache/pekko/japi/pf/FSMTransitionHandlerBuilder.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/FSMTransitionHandlerBuilder.java
@@ -91,7 +91,7 @@ public class FSMTransitionHandlerBuilder<S> {
   }
 
   /**
-   * Build a {@link scala.PartialFunction} from this builder. After this call the builder will be
+   * Build a {@code scala.PartialFunction} from this builder. After this call the builder will be
    * reset.
    *
    * @return a PartialFunction for this builder.

--- a/actor/src/main/java/org/apache/pekko/japi/pf/Match.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/Match.java
@@ -19,7 +19,7 @@ import scala.MatchError;
 import scala.PartialFunction;
 
 /**
- * Version of {@link scala.PartialFunction} that can be built during runtime from Java.
+ * Version of {@code scala.PartialFunction} that can be built during runtime from Java.
  *
  * @param <I> the input type, that this PartialFunction will be applied to
  * @param <R> the return type, that the results of the application will have

--- a/actor/src/main/java/org/apache/pekko/japi/pf/PFBuilder.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/PFBuilder.java
@@ -17,7 +17,7 @@ import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.japi.function.Predicate;
 
 /**
- * A builder for {@link scala.PartialFunction}.
+ * A builder for {@code scala.PartialFunction}.
  *
  * @param <I> the input type, that this PartialFunction will be applied to
  * @param <R> the return type, that the results of the application will have

--- a/actor/src/main/java/org/apache/pekko/japi/pf/ReceiveBuilder.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/ReceiveBuilder.java
@@ -57,7 +57,7 @@ public class ReceiveBuilder {
   }
 
   /**
-   * Build a {@link scala.PartialFunction} from this builder. After this call the builder will be
+   * Build a {@code scala.PartialFunction} from this builder. After this call the builder will be
    * reset.
    *
    * @return a PartialFunction for this builder.

--- a/actor/src/main/java/org/apache/pekko/japi/pf/UnitMatch.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/UnitMatch.java
@@ -20,8 +20,8 @@ import scala.PartialFunction;
 import scala.runtime.BoxedUnit;
 
 /**
- * Version of {@link scala.PartialFunction} that can be built during runtime from Java. This is a
- * specialized version of {@link UnitMatch} to map java void methods to {@link
+ * Version of {@code scala.PartialFunction} that can be built during runtime from Java. This is a
+ * specialized version of {@link UnitMatch} to map java void methods to {@code
  * scala.runtime.BoxedUnit}.
  *
  * @param <I> the input type, that this PartialFunction will be applied to

--- a/actor/src/main/java/org/apache/pekko/japi/pf/UnitPFBuilder.java
+++ b/actor/src/main/java/org/apache/pekko/japi/pf/UnitPFBuilder.java
@@ -18,8 +18,8 @@ import org.apache.pekko.japi.function.Procedure;
 import scala.runtime.BoxedUnit;
 
 /**
- * A builder for {@link scala.PartialFunction}. This is a specialized version of {@link PFBuilder}
- * to map java void methods to {@link scala.runtime.BoxedUnit}.
+ * A builder for {@code scala.PartialFunction}. This is a specialized version of {@link PFBuilder}
+ * to map java void methods to {@code scala.runtime.BoxedUnit}.
  *
  * @param <I> the input type, that this PartialFunction to be applied to
  */

--- a/actor/src/main/java/org/apache/pekko/util/OptionalUtil.java
+++ b/actor/src/main/java/org/apache/pekko/util/OptionalUtil.java
@@ -25,6 +25,7 @@ import scala.jdk.javaapi.OptionConverters;
 public final class OptionalUtil {
   private static final scala.Option<?> noneValue = None$.MODULE$;
 
+  @SuppressWarnings("unchecked")
   public static <T> scala.Option<T> scalaNone() {
     return (scala.Option<T>) noneValue;
   }

--- a/docs/src/main/java/docs/persistence/state/MyJavaStateStore.java
+++ b/docs/src/main/java/docs/persistence/state/MyJavaStateStore.java
@@ -59,6 +59,7 @@ class MyJavaStateStore<A> implements DurableStateUpdateStore<A> {
   }
 
   /** Deprecated. Use the deleteObject overload with revision instead. */
+  @SuppressWarnings("deprecation")
   @Override
   public CompletionStage<Done> deleteObject(String persistenceId) {
     return deleteObject(persistenceId, 0);

--- a/persistence-query/src/main/java/org/apache/pekko/persistence/query/javadsl/package-info.java
+++ b/persistence-query/src/main/java/org/apache/pekko/persistence/query/javadsl/package-info.java
@@ -18,8 +18,8 @@
 /**
  * Java API for Pekko Persistence Query.
  *
- * <p>This package contains the Java DSL for Pekko Persistence Query. For the Scala DSL see
- * [[org.apache.pekko.persistence.query.scaladsl]].
+ * <p>This package contains the Java DSL for Pekko Persistence Query. For the Scala DSL see {@code
+ * org.apache.pekko.persistence.query.scaladsl}.
  */
 @org.jspecify.annotations.NullMarked
 package org.apache.pekko.persistence.query.javadsl;

--- a/persistence-testkit/src/main/java/org/apache/pekko/persistence/testkit/javadsl/package-info.java
+++ b/persistence-testkit/src/main/java/org/apache/pekko/persistence/testkit/javadsl/package-info.java
@@ -18,8 +18,8 @@
 /**
  * Java API for Pekko Persistence TestKit.
  *
- * <p>This package contains the Java DSL for Pekko Persistence TestKit. For the Scala DSL see
- * [[org.apache.pekko.persistence.testkit.scaladsl]].
+ * <p>This package contains the Java DSL for Pekko Persistence TestKit. For the Scala DSL see {@code
+ * org.apache.pekko.persistence.testkit.scaladsl}.
  */
 @org.jspecify.annotations.NullMarked
 package org.apache.pekko.persistence.testkit.javadsl;

--- a/persistence-typed/src/main/java/org/apache/pekko/persistence/typed/javadsl/package-info.java
+++ b/persistence-typed/src/main/java/org/apache/pekko/persistence/typed/javadsl/package-info.java
@@ -18,8 +18,8 @@
 /**
  * Java API for Pekko Persistence Typed.
  *
- * <p>This package contains the Java DSL for Pekko Persistence Typed. For the Scala DSL see
- * [[org.apache.pekko.persistence.typed.scaladsl]].
+ * <p>This package contains the Java DSL for Pekko Persistence Typed. For the Scala DSL see {@code
+ * org.apache.pekko.persistence.typed.scaladsl}.
  */
 @org.jspecify.annotations.NullMarked
 package org.apache.pekko.persistence.typed.javadsl;

--- a/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStateFunctionBuilder.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStateFunctionBuilder.java
@@ -287,7 +287,7 @@ public class FSMStateFunctionBuilder<S, D, E> {
   }
 
   /**
-   * Build a {@link scala.PartialFunction} from this builder. After this call the builder will be
+   * Build a {@code scala.PartialFunction} from this builder. After this call the builder will be
    * reset.
    *
    * @return a PartialFunction for this builder.

--- a/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStopBuilder.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/fsm/japi/pf/FSMStopBuilder.java
@@ -133,7 +133,7 @@ public class FSMStopBuilder<S, D> {
   }
 
   /**
-   * Build a {@link scala.PartialFunction} from this builder. After this call the builder will be
+   * Build a {@code scala.PartialFunction} from this builder. After this call the builder will be
    * reset.
    *
    * @return a PartialFunction for this builder.

--- a/persistence/src/main/java/org/apache/pekko/persistence/journal/japi/AsyncRecoveryPlugin.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/journal/japi/AsyncRecoveryPlugin.java
@@ -51,8 +51,8 @@ interface AsyncRecoveryPlugin {
    * Java API, Plugin API: asynchronously reads the highest stored sequence number for the given
    * `persistenceId`. The persistent actor will use the highest sequence number after recovery as
    * the starting point when persisting new events. This sequence number is also used as
-   * `toSequenceNr` in subsequent call to [[#asyncReplayMessages]] unless the user has specified a
-   * lower `toSequenceNr`.
+   * `toSequenceNr` in subsequent call to {@code #asyncReplayMessages} unless the user has specified
+   * a lower `toSequenceNr`.
    *
    * @param persistenceId id of the persistent actor.
    * @param fromSequenceNr hint where to start searching for the highest sequence number.

--- a/persistence/src/main/java/org/apache/pekko/persistence/journal/japi/package-info.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/journal/japi/package-info.java
@@ -18,8 +18,8 @@
 /**
  * Java API for Pekko Persistence Journal.
  *
- * <p>This package contains the Java DSL for Pekko Persistence Journal. For the Scala DSL see
- * [[org.apache.pekko.persistence.journal]].
+ * <p>This package contains the Java DSL for Pekko Persistence Journal. For the Scala DSL see {@code
+ * org.apache.pekko.persistence.journal}.
  */
 @org.jspecify.annotations.NullMarked
 package org.apache.pekko.persistence.journal.japi;

--- a/persistence/src/main/java/org/apache/pekko/persistence/snapshot/japi/package-info.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/snapshot/japi/package-info.java
@@ -19,7 +19,7 @@
  * Java API for Pekko Persistence Snapshot Store.
  *
  * <p>This package contains the Java DSL for Pekko Persistence Snapshot Store. For the Scala DSL see
- * [[org.apache.pekko.persistence.snapshot]].
+ * {@code org.apache.pekko.persistence.snapshot}.
  */
 @org.jspecify.annotations.NullMarked
 package org.apache.pekko.persistence.snapshot.japi;

--- a/persistence/src/main/java/org/apache/pekko/persistence/state/javadsl/package-info.java
+++ b/persistence/src/main/java/org/apache/pekko/persistence/state/javadsl/package-info.java
@@ -19,7 +19,7 @@
  * Java API for Pekko Persistence Durable State.
  *
  * <p>This package contains the Java DSL for Pekko Persistence Durable State. For the Scala DSL see
- * [[org.apache.pekko.persistence.state.scaladsl]].
+ * {@code org.apache.pekko.persistence.state.scaladsl}.
  */
 @org.jspecify.annotations.NullMarked
 package org.apache.pekko.persistence.state.javadsl;

--- a/remote/src/test/java/org/apache/pekko/remote/transport/ThrottlerTransportAdapterTest.java
+++ b/remote/src/test/java/org/apache/pekko/remote/transport/ThrottlerTransportAdapterTest.java
@@ -14,6 +14,7 @@
 package org.apache.pekko.remote.transport;
 
 // compile only; verify java interop
+@SuppressWarnings("deprecation")
 public class ThrottlerTransportAdapterTest {
 
   public void compileThrottlerTransportAdapterDirections() {

--- a/stream-testkit/src/main/java/org/apache/pekko/stream/testkit/javadsl/package-info.java
+++ b/stream-testkit/src/main/java/org/apache/pekko/stream/testkit/javadsl/package-info.java
@@ -18,8 +18,8 @@
 /**
  * Java API for Pekko Streams TestKit.
  *
- * <p>This package contains the Java DSL for Pekko Streams TestKit. For the Scala DSL see
- * [[org.apache.pekko.stream.testkit.scaladsl]].
+ * <p>This package contains the Java DSL for Pekko Streams TestKit. For the Scala DSL see {@code
+ * org.apache.pekko.stream.testkit.scaladsl}.
  */
 @org.jspecify.annotations.NullMarked
 package org.apache.pekko.stream.testkit.javadsl;

--- a/stream-typed/src/main/java/org/apache/pekko/stream/typed/javadsl/package-info.java
+++ b/stream-typed/src/main/java/org/apache/pekko/stream/typed/javadsl/package-info.java
@@ -18,8 +18,8 @@
 /**
  * Java API for Pekko Streams Typed.
  *
- * <p>This package contains the Java DSL for Pekko Streams Typed. For the Scala DSL see
- * [[org.apache.pekko.stream.typed.scaladsl]].
+ * <p>This package contains the Java DSL for Pekko Streams Typed. For the Scala DSL see {@code
+ * org.apache.pekko.stream.typed.scaladsl}.
  */
 @org.jspecify.annotations.NullMarked
 package org.apache.pekko.stream.typed.javadsl;

--- a/stream/src/main/java/org/apache/pekko/stream/javadsl/FramingTruncation.java
+++ b/stream/src/main/java/org/apache/pekko/stream/javadsl/FramingTruncation.java
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.stream.javadsl;
 
-/** Determines mode in which [[Framing]] operates. */
+/** Determines mode in which {@code Framing} operates. */
 public enum FramingTruncation {
   ALLOW,
   DISALLOW

--- a/stream/src/main/java/org/apache/pekko/stream/javadsl/JavaFlowSupport.java
+++ b/stream/src/main/java/org/apache/pekko/stream/javadsl/JavaFlowSupport.java
@@ -32,7 +32,8 @@ public final class JavaFlowSupport {
   }
 
   /**
-   * {@link org.apache.pekko.stream.javadsl.Flow]] factories operating with {@code java.util.concurrent.Flow.*} interfaces.
+   * {@link org.apache.pekko.stream.javadsl.Flow} factories operating with {@code
+   * java.util.concurrent.Flow.*} interfaces.
    */
   public static final class Source {
     private Source() {
@@ -75,7 +76,8 @@ public final class JavaFlowSupport {
   }
 
   /**
-   * {@link org.apache.pekko.stream.javadsl.Flow]] factories operating with {@code java.util.concurrent.Flow.*} interfaces.
+   * {@link org.apache.pekko.stream.javadsl.Flow} factories operating with {@code
+   * java.util.concurrent.Flow.*} interfaces.
    */
   public static final class Flow {
     private Flow() {
@@ -89,7 +91,8 @@ public final class JavaFlowSupport {
     }
 
     /**
-     * Creates a Flow from a {@link java.util.concurrent.Flow.Processor>> and returns a materialized value.
+     * Creates a Flow from a {@link java.util.concurrent.Flow.Processor} and returns a materialized
+     * value.
      */
     public static <I, O, M> org.apache.pekko.stream.javadsl.Flow<I, O, M> fromProcessorMat(
         org.apache.pekko.japi.function.Creator<

--- a/stream/src/main/java/org/apache/pekko/stream/javadsl/package-info.java
+++ b/stream/src/main/java/org/apache/pekko/stream/javadsl/package-info.java
@@ -18,8 +18,8 @@
 /**
  * Java API for Pekko Streams.
  *
- * <p>This package contains the Java DSL for Pekko Streams. For the Scala DSL see
- * [[org.apache.pekko.stream.scaladsl]].
+ * <p>This package contains the Java DSL for Pekko Streams. For the Scala DSL see {@code
+ * org.apache.pekko.stream.scaladsl}.
  */
 @org.jspecify.annotations.NullMarked
 package org.apache.pekko.stream.javadsl;


### PR DESCRIPTION
## Motivation

Running `sbt doc` produces javadoc warnings in Java source files of the actor module:
- Multi-line `{@link}` tags cause "Could not find any member to link" warnings
- `{@link}` references to Scala classes fail since they are not visible to javadoc
- Unqualified `@throws` references cannot be resolved

## Modification

- `ReceiveBuilder.java`: Move multi-line `{@link}` to single line to avoid empty link target
- `UnitMatch.java`: Replace `{@link scala.PartialFunction}` and `{@link scala.runtime.BoxedUnit}` with `{@code}` since Scala classes are not resolvable by javadoc
- `UnsynchronizedByteArrayInputStream.java`: Use fully qualified `java.lang.IllegalArgumentException` in `@throws` tag

## Result

Javadoc warnings in these files are eliminated, improving documentation quality.

## Tests

Manually verified via `sbt doc`

## References

Follow-up to #3254