### PR TITLE
Batch elements across internal async stream boundaries

### DIFF
--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/AsyncBoundaryThroughputBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/AsyncBoundaryThroughputBenchmark.scala
@@ -52,7 +52,7 @@ class AsyncBoundaryThroughputBenchmark {
 
   implicit val system: ActorSystem = ActorSystem("AsyncBoundaryThroughputBenchmark", config)
 
-  @Param(Array("1", "3", "10"))
+  @Param(Array("0", "1", "3", "10"))
   var asyncBoundaries = 0
 
   var source: Source[Int, NotUsed] = _

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/FusingSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/FusingSpec.scala
@@ -19,14 +19,19 @@ import duration._
 
 import org.apache.pekko
 import pekko.Done
+import pekko.stream.QueueOfferResult
 import pekko.stream.impl.UnfoldResourceSource
 import pekko.stream.impl.fusing.GraphInterpreter
 import pekko.stream.scaladsl._
 import pekko.stream.stage.GraphStage
+import pekko.stream.testkit.TestPublisher
 import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.Utils.TE
+import pekko.stream.testkit.scaladsl.TestSink
 
 class FusingSpec extends StreamSpec {
+
+  val asyncBoundaryInputBuffer = Attributes.inputBuffer(16, 16)
 
   def actorRunningStage = {
     GraphInterpreter.currentInterpreter.context
@@ -45,6 +50,187 @@ class FusingSpec extends StreamSpec {
         .runWith(Sink.head)
         .futureValue
         .sorted should ===(0 to 198 by 2)
+    }
+
+    "preserve elements across repeated asynchronous boundary batches" in {
+      val elements = 1 to 5000
+
+      Source(elements)
+        .map(identity)
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .runWith(Sink.seq)
+        .futureValue should ===(elements)
+    }
+
+    "preserve elements across chained asynchronous boundary batches" in {
+      val elements = 1 to 5000
+
+      Source(elements)
+        .map(identity)
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .map(identity)
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .runWith(Sink.seq)
+        .futureValue should ===(elements)
+    }
+
+    "flush asynchronous boundary batches when async input suspends the interpreter" in {
+      val elements = 1 to 64
+      val (queue, downstream) = Source
+        .fromGraph(Source.queue[Int](elements.size))
+        .async
+        .addAttributes(ActorAttributes.syncProcessingLimit(1) and asyncBoundaryInputBuffer)
+        .toMat(TestSink[Int]())(Keep.both)
+        .run()
+
+      downstream.request(elements.size)
+      elements.foreach { elem =>
+        queue.offer(elem) should ===(QueueOfferResult.Enqueued)
+      }
+      downstream.expectNextN(elements)
+
+      queue.complete()
+      downstream.expectComplete()
+    }
+
+    "drain asynchronous boundary batches before completing" in {
+      val elements = 1 to 64
+
+      Source(elements)
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .runWith(TestSink[Int]())
+        .request(elements.size)
+        .expectNextN(elements)
+        .expectComplete()
+    }
+
+    "drain asynchronous boundary batches before failing" in {
+      val elements = 1 to 64
+      val ex = TE("boom")
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = Source
+        .fromPublisher(upstream)
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .runWith(TestSink[Int]())
+
+      downstream.request(elements.size + 1)
+
+      var sent = 0
+      while (sent < elements.size) {
+        val request = upstream.expectRequest()
+        val send = math.min(request, elements.size - sent).toInt
+        elements.slice(sent, sent + send).foreach(upstream.sendNext)
+        sent += send
+      }
+
+      upstream.sendError(ex)
+      downstream.expectNextN(elements)
+      downstream.expectError(ex)
+    }
+
+    "not emit elements after an asynchronous boundary failure" in {
+      val ex = TE("boom")
+      val probe = Source(1 to 64)
+        .concat(Source.failed(ex))
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .runWith(TestSink[Int]())
+
+      probe.request(65)
+
+      var expected = 1
+      var errorSignalled = false
+      while (!errorSignalled && expected <= 64) {
+        probe.expectNextOrError(expected, ex) match {
+          case Right(_) =>
+            expected += 1
+          case Left(_) =>
+            errorSignalled = true
+        }
+      }
+      if (!errorSignalled) probe.expectError(ex)
+    }
+
+    "propagate cancellation with asynchronous boundary elements in flight" in {
+      val upstream = TestPublisher.probe[Int]()
+      val downstream = Source
+        .fromPublisher(upstream)
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .runWith(TestSink[Int]())
+
+      downstream.request(16)
+      upstream.expectRequest() should be >= 16L
+      (1 to 16).foreach(upstream.sendNext)
+
+      downstream.expectNext(1)
+      downstream.cancel()
+
+      upstream.expectCancellation()
+    }
+
+    "not exceed downstream demand across asynchronous boundary batches" in {
+      val downstream = Source(1 to 1000)
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .runWith(TestSink[Int]())
+
+      downstream.request(1)
+      downstream.expectNext(1)
+      downstream.expectNoMessage(100.millis)
+
+      downstream.request(2)
+      downstream.expectNext(2, 3)
+      downstream.expectNoMessage(100.millis)
+
+      downstream.cancel()
+    }
+
+    "preserve resuming supervision across asynchronous boundary batches" in {
+      Source(List(1, 2, -1, 3, 4))
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .map { elem =>
+          require(elem > 0)
+          elem
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(Sink.seq)
+        .futureValue should ===(Seq(1, 2, 3, 4))
+    }
+
+    "preserve restarting supervision across asynchronous boundary batches" in {
+      Source(List(1, 3, -1, 5, 7))
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .scan(0) { (old, current) =>
+          require(current > 0)
+          old + current
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+        .runWith(Sink.seq)
+        .futureValue should ===(Seq(0, 1, 4, 0, 5, 12))
+    }
+
+    "preserve stopping supervision across asynchronous boundary batches" in {
+      val ex = TE("boom")
+      Source(List(1, 2, -1, 3, 4))
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .map {
+          case -1   => throw ex
+          case elem => elem
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
+        .runWith(TestSink[Int]())
+        .request(5)
+        .expectNext(1, 2)
+        .expectError(ex)
     }
 
     "use multiple actors when there are asynchronous boundaries in the subflows (manual)" in {

--- a/stream/src/main/mima-filters/2.0.x.backwards.excludes/pr-2916-boundary-event-allocation.excludes
+++ b/stream/src/main/mima-filters/2.0.x.backwards.excludes/pr-2916-boundary-event-allocation.excludes
@@ -28,3 +28,9 @@ ProblemFilters.exclude[Problem]("org.apache.pekko.stream.impl.fusing.ActorGraphI
 ProblemFilters.exclude[Problem]("org.apache.pekko.stream.impl.fusing.GraphInterpreterShell*Abort*")
 ProblemFilters.exclude[Problem]("org.apache.pekko.stream.impl.fusing.GraphInterpreterShell*AsyncInput*")
 ProblemFilters.exclude[Problem]("org.apache.pekko.stream.impl.fusing.GraphInterpreterShell*ResumeShell*")
+
+# Optimize internal async boundary batching
+ProblemFilters.exclude[FinalMethodProblem]("org.apache.pekko.stream.impl.fusing.ActorGraphInterpreter#BatchingActorInputBoundary.onNext")
+ProblemFilters.exclude[FinalMethodProblem]("org.apache.pekko.stream.impl.fusing.ActorGraphInterpreter#BatchingActorInputBoundary.onError")
+ProblemFilters.exclude[FinalMethodProblem]("org.apache.pekko.stream.impl.fusing.ActorGraphInterpreter#BatchingActorInputBoundary.onComplete")
+ProblemFilters.exclude[FinalMethodProblem]("org.apache.pekko.stream.impl.fusing.ActorGraphInterpreter#BatchingActorInputBoundary.onSubscribe")

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -53,6 +53,11 @@ import org.reactivestreams.Subscription
   object Resume extends DeadLetterSuppression with NoSerializationVerificationNeeded
   object Snapshot extends NoSerializationVerificationNeeded
 
+  private[stream] trait BoundarySubscriber extends Subscriber[Any] {
+    def next(elem: AnyRef): Unit
+    def batch(elements: Array[AnyRef]): Unit
+  }
+
   sealed abstract class BoundaryEvent extends DeadLetterSuppression with NoSerializationVerificationNeeded {
     def shell: GraphInterpreterShell
 
@@ -83,7 +88,7 @@ import org.reactivestreams.Subscription
     override def execute(): Unit = {
       if (GraphInterpreter.Debug)
         println(s"${boundary.shell.interpreter.Name}  onError port=${boundary.internalPortName}")
-      boundary.onError(cause)
+      boundary.receiveError(cause)
     }
 
     override def shell: GraphInterpreterShell = boundary.shell
@@ -95,7 +100,7 @@ import org.reactivestreams.Subscription
     override def execute(): Unit = {
       if (GraphInterpreter.Debug)
         println(s"${boundary.shell.interpreter.Name}  onComplete port=${boundary.internalPortName}")
-      boundary.onComplete()
+      boundary.receiveComplete()
     }
 
     override def shell: GraphInterpreterShell = boundary.shell
@@ -107,7 +112,20 @@ import org.reactivestreams.Subscription
     override def execute(): Unit = {
       if (GraphInterpreter.Debug)
         println(s"${boundary.shell.interpreter.Name} onNext $e port=${boundary.internalPortName}")
-      boundary.onNext(e)
+      boundary.receiveNext(e)
+    }
+
+    override def shell: GraphInterpreterShell = boundary.shell
+    override def logic: GraphStageLogic = boundary
+    override def cancel(): Unit = ()
+  }
+
+  final class OnNextBatch(boundary: BatchingActorInputBoundary, elements: Array[AnyRef]) extends SimpleBoundaryEvent {
+    override def execute(): Unit = {
+      if (GraphInterpreter.Debug)
+        println(
+          s"${boundary.shell.interpreter.Name} onNextBatch size=${elements.length} port=${boundary.internalPortName}")
+      boundary.receiveNextBatch(elements)
     }
 
     override def shell: GraphInterpreterShell = boundary.shell
@@ -121,7 +139,7 @@ import org.reactivestreams.Subscription
       if (GraphInterpreter.Debug)
         println(s"${boundary.shell.interpreter.Name}  onSubscribe port=${boundary.internalPortName}")
       boundary.shell.subscribeArrived()
-      boundary.onSubscribe(subscription)
+      boundary.receiveSubscribe(subscription)
     }
 
     override def shell: GraphInterpreterShell = boundary.shell
@@ -136,7 +154,8 @@ import org.reactivestreams.Subscription
       publisher: Publisher[Any],
       val internalPortName: String)
       extends UpstreamBoundaryStageLogic[Any]
-      with OutHandler {
+      with OutHandler
+      with BoundarySubscriber {
 
     if (size <= 0) throw new IllegalArgumentException("buffer size cannot be zero")
     if ((size & (size - 1)) != 0) throw new IllegalArgumentException("buffer size must be a power of two")
@@ -158,28 +177,31 @@ import org.reactivestreams.Subscription
 
     def setActor(actor: ActorRef): Unit = this.actor = actor
 
-    override def preStart(): Unit = {
-      publisher.subscribe(new Subscriber[Any] {
-        override def onError(t: Throwable): Unit = {
-          ReactiveStreamsCompliance.requireNonNullException(t)
-          actor ! new OnError(BatchingActorInputBoundary.this, t)
-        }
+    override def preStart(): Unit = publisher.subscribe(this)
 
-        override def onSubscribe(s: Subscription): Unit = {
-          ReactiveStreamsCompliance.requireNonNullSubscription(s)
-          actor ! new OnSubscribe(BatchingActorInputBoundary.this, s)
-        }
-
-        override def onComplete(): Unit = {
-          actor ! new OnComplete(BatchingActorInputBoundary.this)
-        }
-
-        override def onNext(t: Any): Unit = {
-          ReactiveStreamsCompliance.requireNonNullElement(t)
-          actor ! new OnNext(BatchingActorInputBoundary.this, t)
-        }
-      })
+    final override def onError(t: Throwable): Unit = {
+      ReactiveStreamsCompliance.requireNonNullException(t)
+      actor ! new OnError(this, t)
     }
+
+    final override def onSubscribe(s: Subscription): Unit = {
+      ReactiveStreamsCompliance.requireNonNullSubscription(s)
+      actor ! new OnSubscribe(this, s)
+    }
+
+    final override def onComplete(): Unit =
+      actor ! new OnComplete(this)
+
+    final override def onNext(t: Any): Unit = {
+      ReactiveStreamsCompliance.requireNonNullElement(t)
+      next(t.asInstanceOf[AnyRef])
+    }
+
+    final override def next(elem: AnyRef): Unit =
+      actor ! new OnNext(this, elem)
+
+    final override def batch(elements: Array[AnyRef]): Unit =
+      actor ! new OnNextBatch(this, elements)
 
     @InternalStableApi
     private def dequeue(): Any = {
@@ -214,7 +236,7 @@ import org.reactivestreams.Subscription
     }
 
     @InternalStableApi
-    def onNext(elem: Any): Unit = {
+    def receiveNext(elem: Any): Unit = {
       if (!upstreamCompleted) {
         if (inputBufferElements == size) throw new IllegalStateException("Input buffer overrun")
         inputBuffer((nextInputElementCursor + inputBufferElements) & IndexMask) = elem.asInstanceOf[AnyRef]
@@ -223,7 +245,20 @@ import org.reactivestreams.Subscription
       }
     }
 
-    def onError(e: Throwable): Unit =
+    @InternalStableApi
+    def receiveNextBatch(elements: Array[AnyRef]): Unit = {
+      var i = 0
+      while (i < elements.length) {
+        receiveNext(elements(i))
+        i += 1
+      }
+    }
+
+    @InternalStableApi
+    def onNextBatch(elements: Array[AnyRef]): Unit =
+      receiveNextBatch(elements)
+
+    def receiveError(e: Throwable): Unit =
       if (!upstreamCompleted || downstreamCanceled.isEmpty) {
         upstreamCompleted = true
         clear()
@@ -236,16 +271,16 @@ import org.reactivestreams.Subscription
       if (!(upstreamCompleted || downstreamCanceled.isDefined) && (upstream ne null)) {
         upstream.cancel()
       }
-      if (!isClosed(out)) onError(e)
+      if (!isClosed(out)) receiveError(e)
     }
 
-    def onComplete(): Unit =
+    def receiveComplete(): Unit =
       if (!upstreamCompleted) {
         upstreamCompleted = true
         if (inputBufferElements == 0) complete(out)
       }
 
-    def onSubscribe(subscription: Subscription): Unit = {
+    def receiveSubscribe(subscription: Subscription): Unit = {
       ReactiveStreamsCompliance.requireNonNullSubscription(subscription)
       if (downstreamCanceled.isDefined) {
         upstreamCompleted = true
@@ -400,6 +435,7 @@ import org.reactivestreams.Subscription
     def getActor: ActorRef = this.actor
 
     private var subscriber: Subscriber[Any] = _
+    private var boundarySubscriber: BoundarySubscriber = _
     private var downstreamDemand: Long = 0L
     // This flag is only used if complete/fail is called externally since this op turns into a Finished one inside the
     // interpreter (i.e. inside this op this flag has no effects since if it is completed the op will not be invoked)
@@ -409,15 +445,78 @@ import org.reactivestreams.Subscription
     // when upstream failed before we got the exposed publisher
     private var upstreamCompleted: Boolean = false
 
+    private var firstBatchedElement: AnyRef = _
+    private var batchedElements: Array[AnyRef] = _
+    private var batchedElementIndex = 0
+
+    private final val InitialBatchSize = 16
+    private final val MaxBatchSize = 1024
+
     private def onNext(elem: Any): Unit = {
       downstreamDemand -= 1
-      tryOnNext(subscriber, elem)
+      if (boundarySubscriber eq null) tryOnNext(subscriber, elem)
+      else enqueueBatchElement(elem)
+    }
+
+    private def enqueueBatchElement(elem: Any): Unit = {
+      ReactiveStreamsCompliance.requireNonNullElement(elem)
+      val element = elem.asInstanceOf[AnyRef]
+      if (batchedElementIndex == MaxBatchSize) flushBatch()
+      val index = batchedElementIndex
+      if (index == 0) {
+        firstBatchedElement = element
+      } else {
+        var elements = batchedElements
+        if (elements eq null) {
+          elements = new Array[AnyRef](InitialBatchSize)
+          batchedElements = elements
+        } else if (index == elements.length) {
+          val newElements = new Array[AnyRef](index << 1)
+          System.arraycopy(elements, 0, newElements, 0, index)
+          elements = newElements
+          batchedElements = elements
+        }
+        if (index == 1) elements(0) = firstBatchedElement
+        elements(index) = element
+      }
+      batchedElementIndex = index + 1
+    }
+
+    def flushBatch(): Unit = {
+      val count = batchedElementIndex
+      if (count == 0) return
+
+      val boundary = boundarySubscriber
+      if (boundary eq null) {
+        clearBatch()
+        return
+      }
+
+      if (count == 1) boundary.next(firstBatchedElement)
+      else {
+        val elements = new Array[AnyRef](count)
+        System.arraycopy(batchedElements, 0, elements, 0, count)
+        boundary.batch(elements)
+      }
+
+      clearBatch()
+    }
+
+    private def clearBatch(): Unit = {
+      val count = batchedElementIndex
+      if (count != 0) {
+        firstBatchedElement = null
+        if (batchedElements ne null)
+          java.util.Arrays.fill(batchedElements, 0, count, null)
+        batchedElementIndex = 0
+      }
     }
 
     private def complete(): Unit = {
       // No need to complete if had already been cancelled, or we closed earlier
       if (!(upstreamCompleted || downstreamCompleted)) {
         upstreamCompleted = true
+        flushBatch()
         publisher.shutdown(None)
         if (subscriber ne null) tryOnComplete(subscriber)
       }
@@ -426,10 +525,11 @@ import org.reactivestreams.Subscription
     def fail(e: Throwable): Unit = {
       // No need to fail if had already been cancelled, or we closed earlier
       if (!(downstreamCompleted || upstreamCompleted)) {
+        flushBatch()
         upstreamCompleted = true
         publisher.shutdown(Some(e))
         if ((subscriber ne null) && !e.isInstanceOf[SpecViolation]) tryOnError(subscriber, e)
-      }
+      } else clearBatch()
     }
 
     setHandler(in, this)
@@ -460,6 +560,10 @@ import org.reactivestreams.Subscription
       publisher.takePendingSubscribers().foreach { sub =>
         if (subscriber eq null) {
           subscriber = sub
+          boundarySubscriber = sub match {
+            case boundary: BoundarySubscriber => boundary
+            case _                            => null
+          }
           val subscription = new Subscription with SubscriptionWithCancelException {
             override def request(elements: Long): Unit = actor ! new RequestMore(ActorOutputBoundary.this, elements)
             override def cancel(cause: Throwable): Unit = actor ! new Cancel(ActorOutputBoundary.this, cause)
@@ -487,8 +591,10 @@ import org.reactivestreams.Subscription
     }
 
     def cancel(cause: Throwable): Unit = {
+      clearBatch()
       downstreamCompletionCause = Some(cause)
       subscriber = null
+      boundarySubscriber = null
       publisher.shutdown(Some(new ActorPublisher.NormalShutdownException))
       cancel(in, cause)
     }
@@ -503,7 +609,10 @@ import org.reactivestreams.Subscription
  * INTERNAL API
  */
 @InternalApi private[pekko] object GraphInterpreterShell {
-  import ActorGraphInterpreter.BoundaryEvent
+  import ActorGraphInterpreter.{ ActorOutputBoundary, BatchingActorInputBoundary, BoundaryEvent }
+
+  private val EmptyOutputBoundaries = new Array[ActorOutputBoundary](0)
+  private val EmptyInputBoundaries = new Array[BatchingActorInputBoundary](0)
 
   /**
    * @param promise Will be completed upon processing the event, or failed if processing the event throws
@@ -522,6 +631,7 @@ import org.reactivestreams.Subscription
       if (!shell.waitingForShutdown) {
         shell.interpreter.runAsyncInput(logic, evt, promise, handler)
         if (eventLimit == 1 && shell.interpreter.isSuspended) {
+          shell.flushOutputs()
           shell.sendResume(true)
           0
         } else shell.runBatch(eventLimit - 1)
@@ -587,8 +697,8 @@ import org.reactivestreams.Subscription
   // TODO: really needed?
   private var subscribesPending = 0
 
-  private var inputs: List[BatchingActorInputBoundary] = Nil
-  private var outputs: List[ActorOutputBoundary] = Nil
+  private var inputs: Array[BatchingActorInputBoundary] = EmptyInputBoundaries
+  private var outputs: Array[ActorOutputBoundary] = EmptyOutputBoundaries
 
   /*
    * Limits the number of events processed by the interpreter before scheduling
@@ -618,21 +728,47 @@ import org.reactivestreams.Subscription
       eventLimit: Int): Int = {
     this.self = self
     this.enqueueToShortCircuit = enqueueToShortCircuit
+    val logicCount = logics.length
     var i = 0
-    while (i < logics.length) {
-      logics(i) match {
+    var inputBoundaryCount = 0
+    var outputBoundaryCount = 0
+    while (i < logicCount) {
+      val logic = logics(i)
+      logic match {
+        case _: BatchingActorInputBoundary => inputBoundaryCount += 1
+        case _: ActorOutputBoundary        => outputBoundaryCount += 1
+        case _                             =>
+      }
+      i += 1
+    }
+
+    val initializedInputs =
+      if (inputBoundaryCount == 0) EmptyInputBoundaries else new Array[BatchingActorInputBoundary](inputBoundaryCount)
+    val initializedOutputs =
+      if (outputBoundaryCount == 0) EmptyOutputBoundaries else new Array[ActorOutputBoundary](outputBoundaryCount)
+
+    i = 0
+    var inputIndex = 0
+    var outputIndex = 0
+    while (i < logicCount) {
+      val logic = logics(i)
+      logic match {
         case in: BatchingActorInputBoundary =>
           in.setActor(self)
           subscribesPending += 1
-          inputs ::= in
+          initializedInputs(inputIndex) = in
+          inputIndex += 1
         case out: ActorOutputBoundary =>
           out.setActor(self)
           out.subscribePending()
-          outputs ::= out
+          initializedOutputs(outputIndex) = out
+          outputIndex += 1
         case _ =>
       }
       i += 1
     }
+    inputs = initializedInputs
+    outputs = initializedOutputs
 
     interpreter.init(subMat)
     runBatch(eventLimit)
@@ -666,6 +802,7 @@ import org.reactivestreams.Subscription
     try {
       val usingShellLimit = shellEventLimit < actorEventLimit
       val remainingQuota = interpreter.execute(Math.min(actorEventLimit, shellEventLimit))
+      flushOutputs()
       if (interpreter.isCompleted) {
         // Cannot stop right away if not completely subscribed
         if (canShutDown) interpreterCompleted = true
@@ -681,6 +818,16 @@ import org.reactivestreams.Subscription
       case NonFatal(e) =>
         tryAbort(e)
         actorEventLimit - 1
+    }
+  }
+
+  private def flushOutputs(): Unit = {
+    val outputBoundaries = outputs
+    val count = outputBoundaries.length
+    var i = 0
+    while (i < count) {
+      outputBoundaries(i).flushBatch()
+      i += 1
     }
   }
 
@@ -700,7 +847,13 @@ import org.reactivestreams.Subscription
     // This should handle termination while interpreter is running. If the upstream have been closed already this
     // call has no effect and therefore does the right thing: nothing.
     try {
-      inputs.foreach(_.onInternalError(reason))
+      val inputBoundaries = inputs
+      val inputsCount = inputBoundaries.length
+      var inputIndex = 0
+      while (inputIndex < inputsCount) {
+        inputBoundaries(inputIndex).onInternalError(reason)
+        inputIndex += 1
+      }
       interpreter.execute(abortLimit)
       interpreter.finish()
     } catch {
@@ -711,8 +864,20 @@ import org.reactivestreams.Subscription
       interpreterCompleted = true
       // Will only have an effect if the above call to the interpreter failed to emit a proper failure to the downstream
       // otherwise this will have no effect
-      outputs.foreach(_.fail(reason))
-      inputs.foreach(_.cancel(reason))
+      val outputBoundaries = outputs
+      val count = outputBoundaries.length
+      var i = 0
+      while (i < count) {
+        outputBoundaries(i).fail(reason)
+        i += 1
+      }
+      val inputBoundaries = inputs
+      val inputsCount = inputBoundaries.length
+      var inputIndex = 0
+      while (inputIndex < inputsCount) {
+        inputBoundaries(inputIndex).cancel(reason)
+        inputIndex += 1
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
Async stream islands currently send every element across the internal actor boundary as its own boundary event. This keeps ordering and backpressure simple, but it also creates per-element allocation and mailbox traffic.

### Modification
- Add an internal boundary subscriber marker so only Pekko-internal stream boundaries use batching.
- Accumulate elements produced by an output boundary during one interpreter run and flush them when the interpreter parks.
- Use the existing single-element event for `count == 1`, send `OnNextBatch` for `count > 1`, and keep external Reactive Streams subscribers on the existing path.
- Flush pending elements before completion and clear pending elements on cancellation or already-terminated paths.
- Store initialized input and output boundaries in exact arrays and traverse them with indexed loops for flush and abort paths.
- Keep internal boundary subscriber calls concise and use the batch write index directly on the hot path.
- Add regression coverage for async boundary ordering, async-input suspension flushing, terminal signal ordering, cancellation propagation, downstream demand boundedness, and supervision strategy behavior.
- Include a fused baseline parameter in the JMH benchmark.

### Result
Internal async boundary crossings allocate fewer boundary events and actor messages while preserving element ordering, Reactive Streams behavior, and supervision strategy behavior.

Short local JMH run on JDK 25.0.2, G1, `-wi 1 -i 3 -w 5s -r 5s -f 1 -prof gc`. The throughput confidence intervals are noisy, so treat throughput as directional; allocation is stable across the sampled iterations.

AsyncBoundaryThroughputBenchmark compared with `origin/main`:

| async boundaries | origin/main ops/s | PR ops/s | throughput delta | origin/main B/op | PR B/op | allocation delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 1,731,090.539 | 4,311,858.725 | +149.1% | 194.215 | 80.136 | -58.7% |
| 3 | 1,301,958.247 | 1,878,535.676 | +44.3% | 388.321 | 160.273 | -58.7% |
| 10 | 1,109,940.604 | 1,517,042.543 | +36.7% | 1,067.601 | 440.539 | -58.7% |

The PR also adds a fused baseline row:

| async boundaries | PR ops/s | PR B/op |
| --- | ---: | ---: |
| 0 | 68,687,515.143 | 16.028 |

MapAsyncBenchmark A/B did not show a credible regression in this short run. Non-spawn allocation stayed at about 16.16 B/op on both branches; spawn allocation was flat or slightly lower on the PR. Throughput deltas were mixed and within noisy confidence intervals.

| benchmark | parallelism | spawn | origin/main ops/s | PR ops/s | origin/main B/op | PR B/op |
| --- | ---: | :---: | ---: | ---: | ---: | ---: |
| mapAsync | 1 | false | 19,922,135.531 | 19,897,845.094 | 16.165 | 16.165 |
| mapAsync | 1 | true | 568,033.019 | 603,194.545 | 330.812 | 332.052 |
| mapAsync | 4 | false | 25,490,572.098 | 23,512,273.398 | 16.162 | 16.163 |
| mapAsync | 4 | true | 882,285.628 | 916,427.125 | 398.938 | 374.280 |
| mapAsyncUnordered | 1 | false | 20,249,997.541 | 19,834,616.264 | 16.165 | 16.165 |
| mapAsyncUnordered | 1 | true | 583,029.572 | 582,031.691 | 330.182 | 331.106 |
| mapAsyncUnordered | 4 | false | 25,156,887.351 | 26,119,709.291 | 16.163 | 16.162 |
| mapAsyncUnordered | 4 | true | 927,398.995 | 929,479.218 | 342.258 | 342.133 |

Not run:
- Full stream test suite
- `validatePullRequest`
- `+mimaReportBinaryIssues`

### References
None - internal stream boundary throughput optimization