### PR TITLE
refactor: remove deprecated RepointableActorRef.isTerminated (since Akka 2.2)

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/actor/RepointableActorRef.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/RepointableActorRef.scala
@@ -151,14 +151,13 @@ private[pekko] class RepointableActorRef(
 
   def restart(cause: Throwable): Unit = underlying.restart(cause)
 
+  override private[pekko] def isTerminated: Boolean = underlying.isTerminated
+
   def isStarted: Boolean = underlying match {
     case _: UnstartedCell => false
     case null             => throw new IllegalStateException("isStarted called before initialized")
     case _                => true
   }
-
-  @deprecated("Use context.watch(actor) and receive Terminated(actor)", "Akka 2.2") def isTerminated: Boolean =
-    underlying.isTerminated
 
   def provider: ActorRefProvider = system.provider
 

--- a/actor/src/main/scala/org/apache/pekko/routing/RoutedActorRef.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/RoutedActorRef.scala
@@ -34,7 +34,7 @@ import pekko.dispatch.MessageDispatcher
  * A RoutedActorRef is an ActorRef that has a set of connected ActorRef and it uses a Router to
  * send a message to one (or more) of these actors.
  */
-@nowarn("msg=deprecated")
+@nowarn("msg=BalancingDispatcher.*deprecated")
 private[pekko] class RoutedActorRef(
     _system: ActorSystemImpl,
     _routerProps: Props,

--- a/actor/src/main/scala/org/apache/pekko/routing/SmallestMailbox.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/SmallestMailbox.scala
@@ -92,8 +92,6 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
     }
   }
 
-  // TODO should we rewrite this not to use isTerminated?
-  @nowarn("msg=deprecated")
   protected def isTerminated(a: Routee): Boolean = a match {
     case ActorRefRoutee(ref) => ref.isTerminated
     case _                   => false


### PR DESCRIPTION
### Motivation
The public `isTerminated` method on `RepointableActorRef` was deprecated since Akka 2.2 in favor of using `context.watch(actor)` and receiving `Terminated(actor)`.

### Modification
Remove the deprecated public `isTerminated` method. The `private[pekko]` version from the `ActorRef` trait remains available for internal use.

### Result
Cleaner public API. Internal callers are unaffected as they use the `private[pekko]` `ActorRef.isTerminated`.

### Tests
- `git diff --check origin/main...HEAD` - passed
- `scalafmt --list --mode diff-ref=origin/main` - passed
- `sbt "actor / Compile / compile" "actor / mimaReportBinaryIssues"` - passed
- `sbt "actor-tests / Test / testOnly org.apache.pekko.routing.SmallestMailboxSpec org.apache.pekko.routing.ConfiguredLocalRoutingSpec org.apache.pekko.actor.ActorConfigurationVerificationSpec org.apache.pekko.actor.ActorSystemSpec"` - passed, 40 tests

### References
None - deprecated API cleanup