### PR TITLE
refactor: remove deprecated DurableStateUpdateStore.deleteObject(persistenceId) (since Akka 2.6.20)

### DIFF
--- a/docs/src/main/java/docs/persistence/state/MyJavaStateStore.java
+++ b/docs/src/main/java/docs/persistence/state/MyJavaStateStore.java
@@ -58,13 +58,6 @@ class MyJavaStateStore<A> implements DurableStateUpdateStore<A> {
     return null;
   }
 
-  /** Deprecated. Use the deleteObject overload with revision instead. */
-  @SuppressWarnings("deprecation")
-  @Override
-  public CompletionStage<Done> deleteObject(String persistenceId) {
-    return deleteObject(persistenceId, 0);
-  }
-
   /**
    * Will delete the state by setting it to the empty state and the revision number will be
    * incremented by 1.

--- a/docs/src/main/scala/docs/persistence/state/MyStateStore.scala
+++ b/docs/src/main/scala/docs/persistence/state/MyStateStore.scala
@@ -54,11 +54,6 @@ class MyStateStore[A](system: ExtendedActorSystem, config: Config, cfgPath: Stri
   override def upsertObject(persistenceId: String, revision: Long, value: A, tag: String): Future[Done] = ???
 
   /**
-   * Deprecated. Use the deleteObject overload with revision instead.
-   */
-  override def deleteObject(persistenceId: String): Future[Done] = deleteObject(persistenceId, 0)
-
-  /**
    * Will delete the state by setting it to the empty state and the revision number will be incremented by 1.
    */
   override def deleteObject(persistenceId: String, revision: Long): Future[Done] = ???

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/CapabilityFlags.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/CapabilityFlags.scala
@@ -118,11 +118,5 @@ trait DurableStateStoreCapabilityFlags extends CapabilityFlags {
    * and deserializes values via the configured Pekko serializer infrastructure.
    */
   protected def supportsSerialization: CapabilityFlag
-
-  /**
-   * When `true` enables tests which check the deprecated single-argument `deleteObject(persistenceId)`
-   * overload, which deletes regardless of the current revision.
-   */
-  protected def supportsSoftDelete: CapabilityFlag
 }
 //#durable-state-store-flags

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/japi/state/JavaDurableStateStoreSpec.scala
@@ -40,8 +40,6 @@ class JavaDurableStateStoreSpec(config: Config) extends DurableStateStoreSpec(co
 
   override protected def supportsUpsertWithRevisionCheck: CapabilityFlag = CapabilityFlag.off()
 
-  override protected def supportsSoftDelete: CapabilityFlag = CapabilityFlag.off()
-
   override def runTests(testName: Option[String], args: Args): Status =
     super.runTests(testName, args)
 

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreSpec.scala
@@ -67,8 +67,6 @@ abstract class DurableStateStoreSpec(config: Config)
 
   override protected def supportsSerialization: CapabilityFlag = CapabilityFlag.on()
 
-  override protected def supportsSoftDelete: CapabilityFlag = CapabilityFlag.off()
-
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     preparePersistenceId(pid)
@@ -197,19 +195,6 @@ abstract class DurableStateStoreSpec(config: Config)
         val result = Await.result(store.getObject(pid), timeout)
         result.value shouldBe Some(value)
         result.revision shouldBe 1L
-      }
-    }
-
-    optional(flag = supportsSoftDelete) {
-      "delete a state via the deprecated deleteObject overload" in {
-        val store = durableStateStore()
-        val value = s"state-${pid}"
-        Await.result(store.upsertObject(pid, 1L, value, "test-tag"), timeout)
-        @nowarn("cat=deprecation")
-        val deleteResult = store.deleteObject(pid)
-        Await.result(deleteResult, timeout)
-        val result = Await.result(store.getObject(pid), timeout)
-        result.value shouldBe None
       }
     }
   }

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
@@ -14,7 +14,7 @@
 package org.apache.pekko.persistence.testkit.state.javadsl
 
 import java.util.Optional
-import java.util.concurrent.{ CompletableFuture, CompletionStage }
+import java.util.concurrent.CompletionStage
 
 import scala.jdk.FutureConverters._
 import scala.jdk.OptionConverters._
@@ -46,8 +46,6 @@ class PersistenceTestKitDurableStateStore[A](stateStore: SStore[A])
 
   def upsertObject(persistenceId: String, seqNr: Long, value: A, tag: String): CompletionStage[Done] =
     stateStore.upsertObject(persistenceId, seqNr, value, tag).asJava
-
-  def deleteObject(persistenceId: String): CompletionStage[Done] = CompletableFuture.completedFuture(Done)
 
   def deleteObject(persistenceId: String, revision: Long): CompletionStage[Done] =
     stateStore.deleteObject(persistenceId, revision).asJava

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
@@ -80,8 +80,6 @@ class PersistenceTestKitDurableStateStore[A](val system: ExtendedActorSystem)
       Future.successful(Done)
     }
 
-  override def deleteObject(persistenceId: String): Future[Done] = Future.successful(Done)
-
   override def deleteObject(persistenceId: String, revision: Long): Future[Done] = this.synchronized {
     store.get(persistenceId) match {
       case Some(record) =>

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehaviorStashOverflowSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehaviorStashOverflowSpec.scala
@@ -60,8 +60,6 @@ object DurableStateBehaviorStashOverflowSpec {
 
     def completeUpsertFuture(): Unit = promise.success(Done)
 
-    override def deleteObject(persistenceId: String): Future[Done] = Future.successful(Done)
-
     override def deleteObject(persistenceId: String, revision: Long): Future[Done] = Future.successful(Done)
   }
 

--- a/persistence/src/main/mima-filters/1.1.x.backwards.excludes/remove-deprecated-deleteObject.excludes
+++ b/persistence/src/main/mima-filters/1.1.x.backwards.excludes/remove-deprecated-deleteObject.excludes
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Remove deprecated deleteObject(persistenceId) overload (deprecated since Akka 2.6.20)
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.persistence.state.javadsl.DurableStateUpdateStore.deleteObject")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.persistence.state.scaladsl.DurableStateUpdateStore.deleteObject")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.state.javadsl.DurableStateUpdateStore.deleteObject")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.state.scaladsl.DurableStateUpdateStore.deleteObject")

--- a/persistence/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-deleteObject.excludes
+++ b/persistence/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-deleteObject.excludes
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Remove deprecated deleteObject(persistenceId) overload (deprecated since Akka 2.6.20)
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.persistence.state.javadsl.DurableStateUpdateStore.deleteObject")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.persistence.state.scaladsl.DurableStateUpdateStore.deleteObject")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.state.javadsl.DurableStateUpdateStore.deleteObject")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.persistence.state.scaladsl.DurableStateUpdateStore.deleteObject")

--- a/persistence/src/main/scala/org/apache/pekko/persistence/state/javadsl/DurableStateUpdateStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/state/javadsl/DurableStateUpdateStore.scala
@@ -37,16 +37,6 @@ trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
   def upsertObject(persistenceId: String, revision: Long, value: A, tag: String): CompletionStage[Done]
 
   /**
-   * Delete the object with the given `persistenceId`. This deprecated
-   * function ignores whether the object is deleted or not.
-   *
-   * @param persistenceId the persistenceId of the object to delete
-   * @return a CompletionStage that completes when the object has been deleted
-   */
-  @deprecated(message = "Use the deleteObject overload with revision instead.", since = "Akka 2.6.20")
-  def deleteObject(persistenceId: String): CompletionStage[Done]
-
-  /**
    * Delete the object with the given `persistenceId` and `revision`.
    *
    * <p>

--- a/persistence/src/main/scala/org/apache/pekko/persistence/state/scaladsl/DurableStateUpdateStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/state/scaladsl/DurableStateUpdateStore.scala
@@ -37,16 +37,6 @@ trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
   def upsertObject(persistenceId: String, revision: Long, value: A, tag: String): Future[Done]
 
   /**
-   * Delete the object with the given `persistenceId`. This deprecated
-   * function ignores whether the object is deleted or not.
-   *
-   * @param persistenceId the persistenceId of the object to delete
-   * @return a Future that completes when the object has been deleted
-   */
-  @deprecated(message = "Use the deleteObject overload with revision instead.", since = "Akka 2.6.20")
-  def deleteObject(persistenceId: String): Future[Done]
-
-  /**
    * Delete the object with the given `persistenceId` and `revision`.
    *
    * <p>


### PR DESCRIPTION
### Motivation
The single-argument `deleteObject(persistenceId)` was deprecated since Akka 2.6.20 in favor of the overload that takes a `revision` parameter for optimistic locking.

### Modification
Remove the deprecated abstract method from both scaladsl and javadsl `DurableStateUpdateStore` traits. Remove the corresponding TCK test for the deprecated overload.

### Result
Only the revision-aware `deleteObject(persistenceId, revision)` remains in the trait.

Note: Implementation projects (pekko-persistence-r2dbc, pekko-persistence-jdbc, pekko-persistence-cassandra, pekko-persistence-dynamodb) will need follow-up PRs to remove their overrides of this deleted method.

### Tests
Not run - trait method removal with TCK test cleanup

### References
None - deprecated API cleanup