### PR TITLE
test: cover async boundary failure draining

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/FusingSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/FusingSpec.scala
@@ -133,6 +133,22 @@ class FusingSpec extends StreamSpec {
       downstream.expectError(ex)
     }
 
+    "deliver transformed elements already produced before an asynchronous boundary failure" in {
+      val ex = TE("mapping failed after partial output")
+
+      Source(Vector("amber", "birch", "cobalt", "dune", "fault-line"))
+        .map {
+          case "fault-line" => throw ex
+          case element      => element.reverse
+        }
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .runWith(TestSink[String]())
+        .request(8)
+        .expectNext("rebma", "hcrib", "tlaboc", "enud")
+        .expectError(ex)
+    }
+
     "not emit elements after an asynchronous boundary failure" in {
       val ex = TE("boom")
       val probe = Source(1 to 64)


### PR DESCRIPTION
### Motivation
Async boundary batching should preserve elements already produced by an upstream stage before that stage fails.

### Modification
Add a focused FusingSpec regression using transformed string elements upstream of an async boundary, then assert the already emitted elements arrive before the failure.

### Result
Async boundary failure-draining behavior has a direct regression test.



### References
None - regression coverage for async boundary batching