### PR TITLE
fix: fix compilation warnings across Scala 2.13 and 3.3 cross-builds

### DIFF
--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/AskPattern.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/AskPattern.scala
@@ -119,8 +119,8 @@ object AskPattern {
       // We do not currently use the implicit scheduler, but want to require it
       // because it might be needed when we move to a 'native' typed runtime, see #24219
       ref match {
-        case a: InternalRecipientRef[Req] => askClassic[Req, Res](a, timeout, replyTo)
-        case a                            =>
+        case a: (InternalRecipientRef[Req] @unchecked) => askClassic[Req, Res](a, timeout, replyTo)
+        case a                                         =>
           throw new IllegalStateException(
             "Only expect references to be RecipientRef, ActorRefAdapter or ActorSystemAdapter until " +
             "native system is implemented: " + a.getClass)

--- a/actor/src/main/boilerplate/org/apache/pekko/japi/function/Functions.scala.template
+++ b/actor/src/main/boilerplate/org/apache/pekko/japi/function/Functions.scala.template
@@ -19,7 +19,7 @@ import scala.annotation.nowarn
  * A Function interface. Used to create 1-arg first-class-functions is Java.
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(##1L)
 @FunctionalInterface
 trait Function1[[#-T1#], +R] extends java.io.Serializable {
@@ -34,7 +34,7 @@ trait Function1[[#-T1#], +R] extends java.io.Serializable {
  * A Procedure is like a Function, but it doesn't produce a return value.
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(##1L)
 @FunctionalInterface
 trait Procedure1[[#-T1#]] extends java.io.Serializable {

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorPath.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorPath.scala
@@ -171,7 +171,7 @@ object ActorPath {
  * references are compared the unique id of the actor is not taken into account
  * when comparing actor paths.
  */
-@nowarn("msg=@SerialVersionUID has no effect on traits")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
 

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorSelection.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorSelection.scala
@@ -307,7 +307,7 @@ private[pekko] final case class ActorSelectionMessage(
 /**
  * INTERNAL API
  */
-@nowarn("msg=@SerialVersionUID has no effect on traits")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 private[pekko] sealed trait SelectionPathElement
 

--- a/actor/src/main/scala/org/apache/pekko/actor/Deployer.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Deployer.scala
@@ -182,7 +182,7 @@ trait Scope {
   def withFallback(other: Scope): Scope
 }
 
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 abstract class LocalScope extends Scope
 
@@ -191,7 +191,7 @@ abstract class LocalScope extends Scope
  * which do not set a different scope. It is also the only scope handled by
  * the LocalActorRefProvider.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 case object LocalScope extends LocalScope {
 
@@ -206,7 +206,7 @@ case object LocalScope extends LocalScope {
 /**
  * This is the default value and as such allows overrides.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 abstract class NoScopeGiven extends Scope
 @SerialVersionUID(1L)

--- a/actor/src/main/scala/org/apache/pekko/japi/function/Function.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/function/Function.scala
@@ -22,7 +22,7 @@ import org.apache.pekko.util.ConstantFun
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Function` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Function[-T, +R] extends java.io.Serializable {
@@ -56,7 +56,7 @@ object Function {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.BiFunction` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Function2[-T1, -T2, +R] extends java.io.Serializable {
@@ -79,7 +79,7 @@ trait Function2[-T1, -T2, +R] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Consumer` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Procedure[-T] extends java.io.Serializable {
@@ -92,7 +92,7 @@ trait Procedure[-T] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Effect` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Effect extends java.io.Serializable {
@@ -106,7 +106,7 @@ trait Effect extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Predicate` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Predicate[-T] extends java.io.Serializable {
@@ -124,7 +124,7 @@ trait Predicate[-T] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.BiPredicate` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Predicate2[-T1, -T2] extends java.io.Serializable {
@@ -141,7 +141,7 @@ trait Predicate2[-T1, -T2] extends java.io.Serializable {
  * A constructor/factory, takes no parameters but creates a new value of type T every call.
  * Supports throwing `Exception` in the create method, which the `java.util.function.Supplier` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Creator[+T] extends Serializable {

--- a/actor/src/main/scala/org/apache/pekko/routing/Balancing.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/Balancing.scala
@@ -38,7 +38,7 @@ private[pekko] object BalancingRoutingLogic {
  * INTERNAL API
  * Selects the first routee, balancing will be done by the dispatcher.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 private[pekko] final class BalancingRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/actor/src/main/scala/org/apache/pekko/routing/Broadcast.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/Broadcast.scala
@@ -31,7 +31,7 @@ object BroadcastRoutingLogic {
 /**
  * Broadcasts a message to all its routees.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 final class BroadcastRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/actor/src/main/scala/org/apache/pekko/routing/Random.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/Random.scala
@@ -33,7 +33,7 @@ object RandomRoutingLogic {
 /**
  * Randomly selects one of the target routees to send a message to
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 final class RandomRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/actor/src/main/scala/org/apache/pekko/routing/RoundRobin.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/RoundRobin.scala
@@ -34,7 +34,7 @@ object RoundRobinRoutingLogic {
  * Uses round-robin to select a routee. For concurrent calls,
  * round robin is just a best effort.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 final class RoundRobinRoutingLogic extends RoutingLogic {
   val next = new AtomicLong

--- a/actor/src/main/scala/org/apache/pekko/routing/RouterConfig.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/RouterConfig.scala
@@ -47,7 +47,7 @@ import pekko.japi.Util.immutableSeq
  * someone tries sending a message to that reference before the constructor of
  * RoutedActorRef has returned, there will be a `NullPointerException`!
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 trait RouterConfig extends Serializable {
 
@@ -384,7 +384,7 @@ case object NoRouter extends NoRouter {
 /**
  * INTERNAL API
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 private[pekko] trait RouterManagementMesssage
 
@@ -393,7 +393,7 @@ private[pekko] trait RouterManagementMesssage
  * A [[Routees]] message is sent asynchronously to the "requester" containing information
  * about what routees the router is routing over.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 abstract class GetRoutees extends RouterManagementMesssage
 

--- a/actor/src/main/scala/org/apache/pekko/routing/SmallestMailbox.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/SmallestMailbox.scala
@@ -43,7 +43,7 @@ object SmallestMailboxRoutingLogic {
  *     since their mailbox size is unknown</li>
  * </ul>
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 class SmallestMailboxRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =
@@ -189,7 +189,7 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
  * @param routerDispatcher dispatcher to use for the router head actor, which handles
  *   supervision, death watch and router management messages
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 final case class SmallestMailboxPool(
     nrOfInstances: Int,

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -2849,7 +2849,7 @@ final class ByteStringBuilder extends Builder[Byte, ByteString] {
       case bs: ByteString          => addAll(bs)
       case xs: WrappedArray.ofByte =>
         if (xs.nonEmpty) putByteArrayUnsafe(xs.array.clone)
-      case seq: collection.IndexedSeq[Byte] if shouldResizeTempFor(seq.length) =>
+      case seq: (collection.IndexedSeq[Byte] @unchecked) if shouldResizeTempFor(seq.length) =>
         if (seq.nonEmpty) {
           val copied = Array.from(xs)
 
@@ -2857,7 +2857,7 @@ final class ByteStringBuilder extends Builder[Byte, ByteString] {
           _builder += ByteString.ByteString1(copied)
           _length += seq.length
         }
-      case seq: collection.IndexedSeq[Byte] =>
+      case seq: (collection.IndexedSeq[Byte] @unchecked) =>
         if (seq.nonEmpty) {
           ensureTempSize(_tempLength + seq.size)
           seq.copyToArray(_temp, _tempLength)

--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/AsyncBoundaryThroughputBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/AsyncBoundaryThroughputBenchmark.scala
@@ -92,7 +92,7 @@ class JitSafeCompletionLatchInt extends GraphStageWithMaterializedValue[SinkShap
   val in = Inlet[Int]("JitSafeCompletionLatchInt.in")
   override val shape = SinkShape(in)
 
-  @nowarn("cat=unused-params")
+  @nowarn("msg=never used")
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, CountDownLatch) = {
     val latch = new CountDownLatch(1)
     val logic = new GraphStageLogic(shape) with InHandler {

--- a/remote/src/main/scala/org/apache/pekko/remote/RemotingLifecycleEvent.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemotingLifecycleEvent.scala
@@ -20,14 +20,14 @@ import pekko.actor.{ ActorSystem, Address }
 import pekko.event.{ Logging, LoggingAdapter }
 import pekko.event.Logging.LogLevel
 
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 sealed trait RemotingLifecycleEvent extends Serializable {
   def logLevel: Logging.LogLevel
 }
 
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 sealed trait AssociationEvent extends RemotingLifecycleEvent {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/TlsGraphStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/TlsGraphStage.scala
@@ -838,8 +838,8 @@ import pekko.util.ByteString
                   }
                   continue = false
 
-                case other =>
-                  throw new IllegalArgumentException(s"Unexpected TLS input element: $other")
+                case null =>
+                  throw new IllegalArgumentException(s"Unexpected TLS input element: null")
               }
             }
 


### PR DESCRIPTION
### Motivation
Several compilation warnings were present across the codebase when building with `-Dpekko.allwarnings=true`:
- `@SerialVersionUID does nothing on a trait` (Scala 3.3.8 changed the warning text from "has no effect" to "does nothing", causing existing `@nowarn` filters to miss)
- Unchecked type tests for `IndexedSeq[Byte]` in ByteString and `InternalRecipientRef[Req]` in AskPattern (pattern match type erasure)
- Unreachable case in TlsGraphStage (sealed trait `SslTlsOutbound` exhaustively matched)
- Invalid `@nowarn` filter `cat=unused-params` in bench-jmh benchmark (not a valid Scala 3 category)

### Modification
- Update all `@nowarn` message filters for `@SerialVersionUID` to use broader regex `(has no effect|does nothing)` matching both Scala 3.3 and older warning text (17 source locations + boilerplate template)
- Add `@unchecked` annotation to type tests that can't be checked at runtime due to type erasure (ByteString `addAll`, AskPattern `ask`)
- Change unreachable `case other =>` to `case null =>` in TlsGraphStage since the sealed trait match is exhaustive
- Change invalid `@nowarn("cat=unused-params")` to `@nowarn("msg=never used")` in bench-jmh benchmark
- Update boilerplate template for generated `Functions.scala`

### Result
Clean compilation with zero Scala warnings on both Scala 2.13.18 and 3.3.8 with `-Dpekko.allwarnings=true`.

### Tests
- `sbt -Dpekko.allwarnings=true "+test:compile"` - passes with no Scala warnings

### References
None - code quality improvement