### PR TITLE
refactor: replace deprecated extends App with explicit main method

### DIFF
--- a/docs/src/test/scala/docs/actor/ActorDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/ActorDocSpec.scala
@@ -278,15 +278,17 @@ class Swapper extends Actor {
   }
 }
 
-object SwapperApp extends App {
-  val system = ActorSystem("SwapperSystem")
-  val swap = system.actorOf(Props[Swapper](), name = "swapper")
-  swap ! Swap // logs Hi
-  swap ! Swap // logs Ho
-  swap ! Swap // logs Hi
-  swap ! Swap // logs Ho
-  swap ! Swap // logs Hi
-  swap ! Swap // logs Ho
+object SwapperApp {
+  def main(args: Array[String]): Unit = {
+    val system = ActorSystem("SwapperSystem")
+    val swap = system.actorOf(Props[Swapper](), name = "swapper")
+    swap ! Swap // logs Hi
+    swap ! Swap // logs Ho
+    swap ! Swap // logs Hi
+    swap ! Swap // logs Ho
+    swap ! Swap // logs Hi
+    swap ! Swap // logs Ho
+  }
 }
 //#swapper
 

--- a/docs/src/test/scala/docs/actor/FaultHandlingDocSample.scala
+++ b/docs/src/test/scala/docs/actor/FaultHandlingDocSample.scala
@@ -28,24 +28,26 @@ import com.typesafe.config.ConfigFactory
 /**
  * Runs the sample
  */
-object FaultHandlingDocSample extends App {
-  import Worker._
+object FaultHandlingDocSample {
+  def main(args: Array[String]): Unit = {
+    import Worker._
 
-  val config = ConfigFactory.parseString("""
-    pekko.loglevel = "DEBUG"
-    pekko.actor.debug {
-      receive = on
-      lifecycle = on
-    }
-    """)
+    val config = ConfigFactory.parseString("""
+      pekko.loglevel = "DEBUG"
+      pekko.actor.debug {
+        receive = on
+        lifecycle = on
+      }
+      """)
 
-  val system = ActorSystem("FaultToleranceSample", config)
-  val worker = system.actorOf(Props[Worker](), name = "worker")
-  val listener = system.actorOf(Props[Listener](), name = "listener")
-  // start the work and listen on progress
-  // note that the listener is used as sender of the tell,
-  // i.e. it will receive replies from the worker
-  worker.tell(Start, sender = listener)
+    val system = ActorSystem("FaultToleranceSample", config)
+    val worker = system.actorOf(Props[Worker](), name = "worker")
+    val listener = system.actorOf(Props[Listener](), name = "listener")
+    // start the work and listen on progress
+    // note that the listener is used as sender of the tell,
+    // i.e. it will receive replies from the worker
+    worker.tell(Start, sender = listener)
+  }
 }
 
 /**

--- a/docs/src/test/scala/docs/io/EchoServer.scala
+++ b/docs/src/test/scala/docs/io/EchoServer.scala
@@ -24,17 +24,19 @@ import pekko.util.ByteString
 
 import scala.io.StdIn
 
-object EchoServer extends App {
+object EchoServer {
+  def main(args: Array[String]): Unit = {
 
-  val config = ConfigFactory.parseString("pekko.loglevel = DEBUG")
-  implicit val system: ActorSystem = ActorSystem("EchoServer", config)
+    val config = ConfigFactory.parseString("pekko.loglevel = DEBUG")
+    implicit val system: ActorSystem = ActorSystem("EchoServer", config)
 
-  system.actorOf(Props(classOf[EchoManager], classOf[EchoHandler]), "echo")
-  system.actorOf(Props(classOf[EchoManager], classOf[SimpleEchoHandler]), "simple")
+    system.actorOf(Props(classOf[EchoManager], classOf[EchoHandler]), "echo")
+    system.actorOf(Props(classOf[EchoManager], classOf[SimpleEchoHandler]), "simple")
 
-  println("Press enter to exit...")
-  StdIn.readLine()
-  system.terminate()
+    println("Press enter to exit...")
+    StdIn.readLine()
+    system.terminate()
+  }
 }
 
 class EchoManager(handlerClass: Class[?]) extends Actor with ActorLogging {

--- a/docs/src/test/scala/docs/persistence/PersistentActorExample.scala
+++ b/docs/src/test/scala/docs/persistence/PersistentActorExample.scala
@@ -58,17 +58,19 @@ class ExamplePersistentActor extends PersistentActor {
 }
 //#persistent-actor-example
 
-object PersistentActorExample extends App {
+object PersistentActorExample {
+  def main(args: Array[String]): Unit = {
 
-  val system = ActorSystem("example")
-  val persistentActor = system.actorOf(Props[ExamplePersistentActor](), "persistentActor-4-scala")
+    val system = ActorSystem("example")
+    val persistentActor = system.actorOf(Props[ExamplePersistentActor](), "persistentActor-4-scala")
 
-  persistentActor ! Cmd("foo")
-  persistentActor ! Cmd("baz")
-  persistentActor ! Cmd("bar")
-  persistentActor ! Cmd("buzz")
-  persistentActor ! "print"
+    persistentActor ! Cmd("foo")
+    persistentActor ! Cmd("baz")
+    persistentActor ! Cmd("bar")
+    persistentActor ! Cmd("buzz")
+    persistentActor ! "print"
 
-  Thread.sleep(10000)
-  system.terminate()
+    Thread.sleep(10000)
+    system.terminate()
+  }
 }

--- a/docs/src/test/scala/docs/stream/QuickStartDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/QuickStartDocSpec.scala
@@ -33,9 +33,11 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.concurrent._
 
 //#main-app
-object Main extends App {
-  implicit val system: ActorSystem = ActorSystem("QuickStart")
-  // Code here
+object Main {
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem("QuickStart")
+    // Code here
+  }
 }
 //#main-app
 

--- a/docs/src/test/scala/docs/stream/operators/source/Restart.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/Restart.scala
@@ -26,67 +26,69 @@ import scala.util.control.NoStackTrace
 import org.apache.pekko.stream.scaladsl.Source
 // #imports
 
-object Restart extends App {
-  implicit val system: ActorSystem = ActorSystem()
+object Restart {
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem()
 
-  onRestartWitFailureKillSwitch()
+    onRestartWitFailureKillSwitch()
 
-  case class CantConnectToDatabase(msg: String) extends RuntimeException(msg) with NoStackTrace
+    case class CantConnectToDatabase(msg: String) extends RuntimeException(msg) with NoStackTrace
 
-  def onRestartWithBackoffInnerFailure(): Unit = {
-    // #restart-failure-inner-failure
-    // could throw if for example it used a database connection to get rows
-    val flakySource: Source[() => Int, NotUsed] =
-      Source(List(() => 1, () => 2, () => 3, () => throw CantConnectToDatabase("darn")))
-    val forever =
-      RestartSource.onFailuresWithBackoff(
-        RestartSettings(minBackoff = 1.second, maxBackoff = 10.seconds, randomFactor = 0.1))(() => flakySource)
-    forever.runWith(Sink.foreach(nr => system.log.info("{}", nr())))
-    // logs
-    // [INFO] [12/10/2019 13:51:58.300] [default-pekko.test.stream-dispatcher-7] [pekko.actor.ActorSystemImpl(default)] 1
-    // [INFO] [12/10/2019 13:51:58.301] [default-pekko.test.stream-dispatcher-7] [pekko.actor.ActorSystemImpl(default)] 2
-    // [INFO] [12/10/2019 13:51:58.302] [default-pekko.test.stream-dispatcher-7] [pekko.actor.ActorSystemImpl(default)] 3
-    // [WARN] [12/10/2019 13:51:58.310] [default-pekko.test.stream-dispatcher-7] [RestartWithBackoffSource(pekko://default)] Restarting graph due to failure. stack_trace:  (docs.stream.operators.source.Restart$CantConnectToDatabase: darn)
-    // --> 1 second gap
-    // [INFO] [12/10/2019 13:51:59.379] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 1
-    // [INFO] [12/10/2019 13:51:59.382] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 2
-    // [INFO] [12/10/2019 13:51:59.383] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 3
-    // [WARN] [12/10/2019 13:51:59.386] [default-pekko.test.stream-dispatcher-8] [RestartWithBackoffSource(pekko://default)] Restarting graph due to failure. stack_trace:  (docs.stream.operators.source.Restart$CantConnectToDatabase: darn)
-    // --> 2 second gap
-    // [INFO] [12/10/2019 13:52:01.594] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 1
-    // [INFO] [12/10/2019 13:52:01.595] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 2
-    // [INFO] [12/10/2019 13:52:01.595] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 3
-    // [WARN] [12/10/2019 13:52:01.596] [default-pekko.test.stream-dispatcher-8] [RestartWithBackoffSource(pekko://default)] Restarting graph due to failure. stack_trace:  (docs.stream.operators.source.Restart$CantConnectToDatabase: darn)
-    // #restart-failure-inner-failure
+    def onRestartWithBackoffInnerFailure(): Unit = {
+      // #restart-failure-inner-failure
+      // could throw if for example it used a database connection to get rows
+      val flakySource: Source[() => Int, NotUsed] =
+        Source(List(() => 1, () => 2, () => 3, () => throw CantConnectToDatabase("darn")))
+      val forever =
+        RestartSource.onFailuresWithBackoff(
+          RestartSettings(minBackoff = 1.second, maxBackoff = 10.seconds, randomFactor = 0.1))(() => flakySource)
+      forever.runWith(Sink.foreach(nr => system.log.info("{}", nr())))
+      // logs
+      // [INFO] [12/10/2019 13:51:58.300] [default-pekko.test.stream-dispatcher-7] [pekko.actor.ActorSystemImpl(default)] 1
+      // [INFO] [12/10/2019 13:51:58.301] [default-pekko.test.stream-dispatcher-7] [pekko.actor.ActorSystemImpl(default)] 2
+      // [INFO] [12/10/2019 13:51:58.302] [default-pekko.test.stream-dispatcher-7] [pekko.actor.ActorSystemImpl(default)] 3
+      // [WARN] [12/10/2019 13:51:58.310] [default-pekko.test.stream-dispatcher-7] [RestartWithBackoffSource(pekko://default)] Restarting graph due to failure. stack_trace:  (docs.stream.operators.source.Restart$CantConnectToDatabase: darn)
+      // --> 1 second gap
+      // [INFO] [12/10/2019 13:51:59.379] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 1
+      // [INFO] [12/10/2019 13:51:59.382] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 2
+      // [INFO] [12/10/2019 13:51:59.383] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 3
+      // [WARN] [12/10/2019 13:51:59.386] [default-pekko.test.stream-dispatcher-8] [RestartWithBackoffSource(pekko://default)] Restarting graph due to failure. stack_trace:  (docs.stream.operators.source.Restart$CantConnectToDatabase: darn)
+      // --> 2 second gap
+      // [INFO] [12/10/2019 13:52:01.594] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 1
+      // [INFO] [12/10/2019 13:52:01.595] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 2
+      // [INFO] [12/10/2019 13:52:01.595] [default-pekko.test.stream-dispatcher-8] [pekko.actor.ActorSystemImpl(default)] 3
+      // [WARN] [12/10/2019 13:52:01.596] [default-pekko.test.stream-dispatcher-8] [RestartWithBackoffSource(pekko://default)] Restarting graph due to failure. stack_trace:  (docs.stream.operators.source.Restart$CantConnectToDatabase: darn)
+      // #restart-failure-inner-failure
 
-  }
+    }
 
-  def onRestartWithBackoffInnerComplete(): Unit = {
+    def onRestartWithBackoffInnerComplete(): Unit = {
 
-    // #restart-failure-inner-complete
-    val finiteSource = Source.tick(1.second, 1.second, "tick").take(3)
-    val forever = RestartSource.onFailuresWithBackoff(RestartSettings(1.second, 10.seconds, 0.1))(() => finiteSource)
-    forever.runWith(Sink.foreach(println))
-    // prints
-    // tick
-    // tick
-    // tick
-    // #restart-failure-inner-complete
-  }
+      // #restart-failure-inner-complete
+      val finiteSource = Source.tick(1.second, 1.second, "tick").take(3)
+      val forever = RestartSource.onFailuresWithBackoff(RestartSettings(1.second, 10.seconds, 0.1))(() => finiteSource)
+      forever.runWith(Sink.foreach(println))
+      // prints
+      // tick
+      // tick
+      // tick
+      // #restart-failure-inner-complete
+    }
 
-  def onRestartWitFailureKillSwitch(): Unit = {
-    // #restart-failure-inner-complete-kill-switch
-    val flakySource: Source[() => Int, NotUsed] =
-      Source(List(() => 1, () => 2, () => 3, () => throw CantConnectToDatabase("darn")))
-    val stopRestarting: UniqueKillSwitch =
-      RestartSource
-        .onFailuresWithBackoff(RestartSettings(1.second, 10.seconds, 0.1))(() => flakySource)
-        .viaMat(KillSwitches.single)(Keep.right)
-        .toMat(Sink.foreach(nr => println(s"Nr ${nr()}")))(Keep.left)
-        .run()
-    // ... from some where else
-    // stop the source from restarting
-    stopRestarting.shutdown()
-    // #restart-failure-inner-complete-kill-switch
+    def onRestartWitFailureKillSwitch(): Unit = {
+      // #restart-failure-inner-complete-kill-switch
+      val flakySource: Source[() => Int, NotUsed] =
+        Source(List(() => 1, () => 2, () => 3, () => throw CantConnectToDatabase("darn")))
+      val stopRestarting: UniqueKillSwitch =
+        RestartSource
+          .onFailuresWithBackoff(RestartSettings(1.second, 10.seconds, 0.1))(() => flakySource)
+          .viaMat(KillSwitches.single)(Keep.right)
+          .toMat(Sink.foreach(nr => println(s"Nr ${nr()}")))(Keep.left)
+          .run()
+      // ... from some where else
+      // stop the source from restarting
+      stopRestarting.shutdown()
+      // #restart-failure-inner-complete-kill-switch
+    }
   }
 }

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/ExtrapolateAndExpand.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/ExtrapolateAndExpand.scala
@@ -32,10 +32,12 @@ import scala.util.Random
 
 /**
  */
-object ExtrapolateAndExpandMain extends App {
-  implicit val sys: ActorSystem = ActorSystem("25fps-stream")
-  videoAt25Fps.map(_.pixels.utf8String).map(frame => s"$nowInSeconds - $frame").to(Sink.foreach(println)).run()
+object ExtrapolateAndExpandMain {
+  def main(args: Array[String]): Unit = {
+    implicit val sys: ActorSystem = ActorSystem("25fps-stream")
+    videoAt25Fps.map(_.pixels.utf8String).map(frame => s"$nowInSeconds - $frame").to(Sink.foreach(println)).run()
 
+  }
 }
 object ExtrapolateAndExpand {
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Fold.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Fold.scala
@@ -19,25 +19,27 @@ import pekko.actor.ActorSystem
 import pekko.stream.scaladsl.Source
 
 //#imports
-object Fold extends App {
+object Fold {
+  def main(args: Array[String]): Unit = {
 
-  // #histogram
-  case class Histogram(low: Long = 0, high: Long = 0) {
-    def add(i: Int): Histogram = if (i < 100) copy(low = low + 1) else copy(high = high + 1)
+    // #histogram
+    case class Histogram(low: Long = 0, high: Long = 0) {
+      def add(i: Int): Histogram = if (i < 100) copy(low = low + 1) else copy(high = high + 1)
+    }
+    // #histogram
+
+    implicit val sys: ActorSystem = ActorSystem()
+
+    // #fold
+    Source(1 to 150).fold(Histogram())((acc, n) => acc.add(n)).runForeach(println)
+
+    // Prints: Histogram(99,51)
+    // #fold
+
+    // #foldWhile
+    Source(1 to 100)
+      .foldWhile(0)(elem => elem < 100)(_ + _)
+      .runForeach(println)
+    // #foldWhile
   }
-  // #histogram
-
-  implicit val sys: ActorSystem = ActorSystem()
-
-  // #fold
-  Source(1 to 150).fold(Histogram())((acc, n) => acc.add(n)).runForeach(println)
-
-  // Prints: Histogram(99,51)
-  // #fold
-
-  // #foldWhile
-  Source(1 to 100)
-    .foldWhile(0)(elem => elem < 100)(_ + _)
-    .runForeach(println)
-  // #foldWhile
 }

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/FoldAsync.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/FoldAsync.scala
@@ -21,19 +21,21 @@ import pekko.stream.scaladsl.Source
 import scala.concurrent.{ ExecutionContext, Future }
 //#imports
 
-object FoldAsync extends App {
+object FoldAsync {
+  def main(args: Array[String]): Unit = {
 
-  implicit val system: ActorSystem = ActorSystem()
-  implicit val ec: ExecutionContext = system.dispatcher
+    implicit val system: ActorSystem = ActorSystem()
+    implicit val ec: ExecutionContext = system.dispatcher
 
-  // #foldAsync
-  case class Histogram(low: Long = 0, high: Long = 0) {
-    def add(i: Int): Future[Histogram] =
-      if (i < 100) Future { copy(low = low + 1) } else Future { copy(high = high + 1) }
+    // #foldAsync
+    case class Histogram(low: Long = 0, high: Long = 0) {
+      def add(i: Int): Future[Histogram] =
+        if (i < 100) Future { copy(low = low + 1) } else Future { copy(high = high + 1) }
+    }
+
+    Source(1 to 150).foldAsync(Histogram())((acc, n) => acc.add(n)).runForeach(println)
+
+    // Prints: Histogram(99,51)
+    // #foldAsync
   }
-
-  Source(1 to 150).foldAsync(Histogram())((acc, n) => acc.add(n)).runForeach(println)
-
-  // Prints: Histogram(99,51)
-  // #foldAsync
 }

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/FoldWhile.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/FoldWhile.scala
@@ -23,15 +23,17 @@ import pekko.actor.ActorSystem
 import pekko.stream.scaladsl.Source
 
 //#imports
-object FoldWhile extends App {
+object FoldWhile {
+  def main(args: Array[String]): Unit = {
 
-  implicit val sys: ActorSystem = ActorSystem()
+    implicit val sys: ActorSystem = ActorSystem()
 
-  // #foldWhile
-  Source(1 to 10)
-    .foldWhile(0)(_ < 10)(_ + _)
-    .runForeach(println)
-  // Expect prints:
-  // 10
-  // #foldWhile
+    // #foldWhile
+    Source(1 to 10)
+      .foldWhile(0)(_ < 10)(_ + _)
+      .runForeach(println)
+    // Expect prints:
+    // 10
+    // #foldWhile
+  }
 }

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Intersperse.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Intersperse.scala
@@ -16,16 +16,18 @@ package docs.stream.operators.sourceorflow
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.scaladsl.Source
 
-object Intersperse extends App {
-  import org.apache.pekko.actor.ActorSystem
+object Intersperse {
+  def main(args: Array[String]): Unit = {
+    import org.apache.pekko.actor.ActorSystem
 
-  implicit val system: ActorSystem = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
-  // #intersperse
-  Source(1 to 4).map(_.toString).intersperse("[", ", ", "]").runWith(Sink.foreach(print))
-  // prints
-  // [1, 2, 3, 4]
-  // #intersperse
+    // #intersperse
+    Source(1 to 4).map(_.toString).intersperse("[", ", ", "]").runWith(Sink.foreach(print))
+    // prints
+    // [1, 2, 3, 4]
+    // #intersperse
 
-  system.terminate()
+    system.terminate()
+  }
 }

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/MapAsyncs.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/MapAsyncs.scala
@@ -76,50 +76,56 @@ object CommonMapAsync {
 
 }
 
-object MapAsyncStrictOrder extends App {
-  import CommonMapAsync._
-  // #mapasync-strict-order
-
-  events
-    .mapAsync(1) { in =>
-      eventHandler(in)
-    }
-    .map { in =>
-      println(s"`mapAsync` emitted event number: $in")
-    }
+object MapAsyncStrictOrder {
+  def main(args: Array[String]): Unit = {
+    import CommonMapAsync._
     // #mapasync-strict-order
-    .runWith(Sink.ignore)
 
+    events
+      .mapAsync(1) { in =>
+        eventHandler(in)
+      }
+      .map { in =>
+        println(s"`mapAsync` emitted event number: $in")
+      }
+      // #mapasync-strict-order
+      .runWith(Sink.ignore)
+
+  }
 }
 
-object MapAsync extends App {
-  import CommonMapAsync._
-  // #mapasync-concurrent
-
-  events
-    .mapAsync(3) { in =>
-      eventHandler(in)
-    }
-    .map { in =>
-      println(s"`mapAsync` emitted event number: $in")
-    }
+object MapAsync {
+  def main(args: Array[String]): Unit = {
+    import CommonMapAsync._
     // #mapasync-concurrent
-    .runWith(Sink.ignore)
 
+    events
+      .mapAsync(3) { in =>
+        eventHandler(in)
+      }
+      .map { in =>
+        println(s"`mapAsync` emitted event number: $in")
+      }
+      // #mapasync-concurrent
+      .runWith(Sink.ignore)
+
+  }
 }
 
-object MapAsyncUnordered extends App {
-  import CommonMapAsync._
-  // #mapasyncunordered
-
-  events
-    .mapAsyncUnordered(3) { in =>
-      eventHandler(in)
-    }
-    .map { in =>
-      println(s"`mapAsyncUnordered` emitted event number: $in")
-    }
+object MapAsyncUnordered {
+  def main(args: Array[String]): Unit = {
+    import CommonMapAsync._
     // #mapasyncunordered
-    .runWith(Sink.ignore)
 
+    events
+      .mapAsyncUnordered(3) { in =>
+        eventHandler(in)
+      }
+      .map { in =>
+        println(s"`mapAsyncUnordered` emitted event number: $in")
+      }
+      // #mapasyncunordered
+      .runWith(Sink.ignore)
+
+  }
 }

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/MapError.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/MapError.scala
@@ -20,25 +20,27 @@ import scala.concurrent.ExecutionContext
 import scala.util.control.NoStackTrace
 import scala.util.{ Failure, Success }
 
-object MapError extends App {
+object MapError {
+  def main(args: Array[String]): Unit = {
 
-  implicit val system: ActorSystem = ActorSystem()
-  implicit val ec: ExecutionContext = system.dispatcher
+    implicit val system: ActorSystem = ActorSystem()
+    implicit val ec: ExecutionContext = system.dispatcher
 
-  // #map-error
-  Source(-1 to 1)
-    .map(1 / _)
-    .mapError {
-      case _: ArithmeticException =>
-        new UnsupportedOperationException("Divide by Zero Operation is not supported.") with NoStackTrace
-    }
-    .runWith(Sink.seq)
-    .onComplete {
-      case Success(value) => println(value.mkString)
-      case Failure(ex)    => println(ex.getMessage)
-    }
+    // #map-error
+    Source(-1 to 1)
+      .map(1 / _)
+      .mapError {
+        case _: ArithmeticException =>
+          new UnsupportedOperationException("Divide by Zero Operation is not supported.") with NoStackTrace
+      }
+      .runWith(Sink.seq)
+      .onComplete {
+        case Success(value) => println(value.mkString)
+        case Failure(ex)    => println(ex.getMessage)
+      }
 
-  // prints "Divide by Zero Operation is not supported."
-  // #map-error
+    // prints "Divide by Zero Operation is not supported."
+    // #map-error
 
+  }
 }

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/MergeLatest.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/MergeLatest.scala
@@ -15,27 +15,29 @@ package docs.stream.operators.sourceorflow
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.Source
 
-object MergeLatest extends App {
-  implicit val system: ActorSystem = ActorSystem()
+object MergeLatest {
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem()
 
-  // #mergeLatest
-  val prices = Source(List(100, 101, 99, 103))
-  val quantity = Source(List(1, 3, 4, 2))
+    // #mergeLatest
+    val prices = Source(List(100, 101, 99, 103))
+    val quantity = Source(List(1, 3, 4, 2))
 
-  prices
-    .mergeLatest(quantity)
-    .map {
-      case price :: quantity :: Nil => price * quantity
-    }
-    .runForeach(println)
+    prices
+      .mergeLatest(quantity)
+      .map {
+        case price :: quantity :: Nil => price * quantity
+      }
+      .runForeach(println)
 
-  // prints something like:
-  // 100
-  // 101
-  // 303
-  // 297
-  // 396
-  // 412
-  // 206
-  // #mergeLatest
+    // prints something like:
+    // 100
+    // 101
+    // 303
+    // 297
+    // 396
+    // 412
+    // 206
+    // #mergeLatest
+  }
 }

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Throttle.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Throttle.scala
@@ -23,33 +23,35 @@ import scala.concurrent.duration._
 
 /**
  */
-object Throttle extends App {
+object Throttle {
+  def main(args: Array[String]): Unit = {
 
-  implicit val sys: ActorSystem = ActorSystem("25fps-stream")
+    implicit val sys: ActorSystem = ActorSystem("25fps-stream")
 
-  val frameSource: Source[Int, NotUsed] =
-    Source.fromIterator(() => Iterator.from(0))
+    val frameSource: Source[Int, NotUsed] =
+      Source.fromIterator(() => Iterator.from(0))
 
-  // #throttle
-  val framesPerSecond = 24
+    // #throttle
+    val framesPerSecond = 24
 
-  // val frameSource: Source[Frame,_]
-  val videoThrottling = frameSource.throttle(framesPerSecond, 1.second)
-  // serialize `Frame` and send over the network.
-  // #throttle
+    // val frameSource: Source[Frame,_]
+    val videoThrottling = frameSource.throttle(framesPerSecond, 1.second)
+    // serialize `Frame` and send over the network.
+    // #throttle
 
-  // #throttle-with-burst
-  // val frameSource: Source[Frame,_]
-  val videoThrottlingWithBurst = frameSource.throttle(
-    framesPerSecond,
-    1.second,
-    framesPerSecond * 30, // maximumBurst
-    ThrottleMode.Shaping)
-  // serialize `Frame` and send over the network.
-  // #throttle-with-burst
+    // #throttle-with-burst
+    // val frameSource: Source[Frame,_]
+    val videoThrottlingWithBurst = frameSource.throttle(
+      framesPerSecond,
+      1.second,
+      framesPerSecond * 30, // maximumBurst
+      ThrottleMode.Shaping)
+    // serialize `Frame` and send over the network.
+    // #throttle-with-burst
 
-  videoThrottling.take(1000).to(Sink.foreach(println)).run()
-  videoThrottlingWithBurst.take(1000).to(Sink.foreach(println)).run()
+    videoThrottling.take(1000).to(Sink.foreach(println)).run()
+    videoThrottlingWithBurst.take(1000).to(Sink.foreach(println)).run()
+  }
 }
 
 object ThrottleCommon {

--- a/docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala
+++ b/docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala
@@ -162,9 +162,11 @@ class Main(context: ActorContext[String]) extends AbstractBehavior[String](conte
     }
 }
 
-object ActorHierarchyExperiments extends App {
-  val testSystem = ActorSystem(Main(), "testSystem")
-  testSystem ! "start"
+object ActorHierarchyExperiments {
+  def main(args: Array[String]): Unit = {
+    val testSystem = ActorSystem(Main(), "testSystem")
+    testSystem ! "start"
+  }
 }
 //#print-refs
 


### PR DESCRIPTION
### Motivation
`extends App` is deprecated in Scala 3. Replace with explicit `def main(args: Array[String]): Unit` method for forward compatibility.

### Modification
Replace `object X extends App { ... }` with `object X { def main(args: Array[String]): Unit = { ... } }` in doc example and test files.

### Result
No more usage of deprecated `scala.App` trait. Code is compatible with Scala 3.

### Tests
Not run - docs only

### References
None - Scala 3 compatibility