### PR TITLE
Use StandardCharsets.UTF_8 for UTF-8 encoding

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/RelativeActorPathSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/RelativeActorPathSpec.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.actor
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 import scala.collection.immutable
 
@@ -32,7 +33,7 @@ class RelativeActorPathSpec extends AnyWordSpec with Matchers {
       elements("foo/bar/baz") should ===(List("foo", "bar", "baz"))
     }
     "match url encoded name" in {
-      val name = URLEncoder.encode("pekko://ClusterSystem@127.0.0.1:7355", "UTF-8")
+      val name = URLEncoder.encode("pekko://ClusterSystem@127.0.0.1:7355", StandardCharsets.UTF_8)
       elements(name) should ===(List(name))
     }
     "match path with uid fragment" in {

--- a/actor-tests/src/test/scala/org/apache/pekko/routing/BalancingSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/routing/BalancingSpec.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.routing
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.{ Await, Future, Promise }
@@ -171,7 +172,7 @@ class BalancingSpec extends PekkoSpec("""
     }
 
     "work with encoded actor names" in {
-      val encName = URLEncoder.encode("abcå6#$€xyz", "utf-8")
+      val encName = URLEncoder.encode("abcå6#$€xyz", StandardCharsets.UTF_8)
       // % is a valid config key character (e.g. %C3%A5)
       system.actorOf(Props[Parent](), encName) ! 1001
       expectMsgType[Int]

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -1204,7 +1204,7 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
       bsCompact.indexOf('a'.toByte, 2, 5) should ===(-1) // before fromIndex, not in [2,5)
 
       // ByteString1 with startIndex > 0: length=26, search range [0,5) has searchLength=5 < 8
-      val arrayLong = ("xyz" + "abcdefghijklmnopqrstuvwxyz").getBytes("UTF-8")
+      val arrayLong = ("xyz" + "abcdefghijklmnopqrstuvwxyz").getBytes(StandardCharsets.UTF_8)
       val bs1 = ByteString1(arrayLong, 3, 26)
       bs1.indexOf('a'.toByte, 0, 5) should ===(0) // found within range
       bs1.indexOf('e'.toByte, 0, 5) should ===(4) // found at last position in range

--- a/persistence/src/test/scala/org/apache/pekko/persistence/serialization/SnapshotSerializerSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/serialization/SnapshotSerializerSpec.scala
@@ -18,6 +18,7 @@
 package org.apache.pekko.persistence.serialization
 
 import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
 import java.util.Base64
 
 import annotation.nowarn
@@ -93,7 +94,7 @@ class SnapshotSerializerSpec extends PekkoSpec {
       serializerId shouldEqual snapshotSerializer.identifier
       // header bytes[8..4+headerLength) = manifest as UTF-8 string
       val manifestBytes = bytes.slice(8, 4 + headerLength)
-      val manifest = new String(manifestBytes, "UTF-8")
+      val manifest = new String(manifestBytes, StandardCharsets.UTF_8)
       manifest shouldEqual Serializers.manifestFor(snapshotSerializer, fsmSnapshot)
     }
     "serialize and deserialize a simple string snapshot" in {

--- a/project/PekkoBuild.scala
+++ b/project/PekkoBuild.scala
@@ -22,6 +22,7 @@ import sbtwelcome.WelcomePlugin.autoImport._
 
 import java.io.FileInputStream
 import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
 import java.util.Properties
 
 object PekkoBuild {
@@ -322,7 +323,7 @@ object PekkoBuild {
     val file = new File(fileName)
     if (file.exists()) {
       println("Loading system properties from file `" + fileName + "`")
-      val in = new InputStreamReader(new FileInputStream(file), "UTF-8")
+      val in = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)
       val props = new Properties
       props.load(in)
       in.close()

--- a/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
+++ b/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
@@ -164,7 +164,7 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
   def serializeToJsonString(obj: AnyRef, sys: ActorSystem = system): String = {
     val blob = serializeToBinary(obj, sys)
-    new String(blob, "utf-8")
+    new String(blob, StandardCharsets.UTF_8)
   }
 
   def deserializeFromJsonString(
@@ -172,7 +172,7 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       serializerId: Int,
       manifest: String,
       sys: ActorSystem = system): AnyRef = {
-    val blob = json.getBytes("utf-8")
+    val blob = json.getBytes(StandardCharsets.UTF_8)
     deserializeFromBinary(blob, serializerId, manifest, sys)
   }
 


### PR DESCRIPTION
Summary: Replace UTF-8 charset string arguments with StandardCharsets.UTF_8 in tests and build property loading. Verification: ran formatting, targeted compile, git diff --check, and residual charset literal searches.