### PR TITLE
Make classic remoting handoff recovery test eventual

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/classic/RemotingSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/RemotingSpec.scala
@@ -793,8 +793,12 @@ class RemotingSpec extends PekkoSpec(RemotingSpec.cfg) with ImplicitSender with 
           case _                                  => false
         }
 
-        outboundRemoteHandle.association.write(payload("after-handoff-failure"))
-        receiverProbe.expectMsg("after-handoff-failure")
+        // The read-only handle disassociation and resuming the outbound reader are handled by different actors.
+        // Retry until the outbound reader has processed ResumeReading.
+        awaitAssert {
+          outboundRemoteHandle.association.write(payload("after-handoff-failure"))
+          receiverProbe.expectMsg(500.millis, "after-handoff-failure")
+        }
       } finally shutdown(thisSystem)
 
     }


### PR DESCRIPTION
### Motivation

The regression test added by #3205 waits for the read-only handle disassociation and then sends one verification payload through the original association. Those events are processed by different actors, so the original EndpointReader may still be in its not-reading state and discard that payload before it processes ResumeReading.

This race surfaced in CI while validating #3300, but it is independent of that PR changes.

### Modification

Wrap the final verification write and expectation in awaitAssert, with a bounded 500 ms wait per attempt. The existing default overall assertion timeout remains unchanged.

### Result

The test tolerates the expected asynchronous handoff completion while still failing if the original reader never resumes and delivers a verification message.

### Tests

- JDK 17, Scala 3.8.4 focused RemotingSpec handoff test: passed (1 test)
- JDK 17, Scala 3.8.4 full RemotingSpec: passed (22 tests)
- JDK 17, Scala 2.13.18 focused RemotingSpec handoff test: passed (1 test)
- sbt headerCreateAll +headerCheckAll: passed
- scalafmt --list --mode diff-ref=origin/main: passed
- git diff --check: passed

### References

Refs #3205