### PR TITLE
test: make mapWithResource abrupt cleanup tests deterministic

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapWithResourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapWithResourceSpec.scala
@@ -416,7 +416,7 @@ class FlowMapWithResourceSpec extends StreamSpec(UnboundedMailboxConfig) {
       val promise = Promise[Done]()
       val created = Promise[Done]()
       val matVal = Source
-        .single(1)
+        .maybe[Int]
         .mapWithResource(() => {
           created.trySuccess(Done)
           newBufferedReader()
@@ -429,6 +429,7 @@ class FlowMapWithResourceSpec extends StreamSpec(UnboundedMailboxConfig) {
         .mapConcat(identity)
         .runWith(Sink.never)(mat)
       Await.result(created.future, 3.seconds.dilated) shouldBe Done
+      promise.isCompleted shouldBe false
       mat.shutdown()
       matVal.failed.futureValue shouldBe an[AbruptTerminationException]
       Await.result(promise.future, 3.seconds.dilated) shouldBe Done
@@ -531,10 +532,11 @@ class FlowMapWithResourceSpec extends StreamSpec(UnboundedMailboxConfig) {
         }
       }
       val matVal = Source
-        .single(1)
+        .maybe[Int]
         .mapWithResource(create, (_: AutoCloseable, count) => count)
         .runWith(Sink.never)(mat)
       Await.result(created.future, 3.seconds.dilated) shouldBe Done
+      closedCounter.get shouldBe 0
       mat.shutdown()
       matVal.failed.futureValue shouldBe an[AbruptTerminationException]
       Await.result(promise.future, 3.seconds.dilated) shouldBe Done


### PR DESCRIPTION
### Motivation

The abrupt materializer termination tests used Source.single. Since mapWithResource runs on the blocking I/O dispatcher, its async boundary can let Source.single complete and close the resource before materializer shutdown. The test can therefore observe normal upstream completion instead of the abrupt termination path.

### Modification

Use Source.maybe in both abrupt termination variants so the upstream remains open. After resource creation, assert that cleanup has not run before shutting down the materializer.

### Result

The tests now isolate abrupt termination from normal upstream completion and retain directional assertions that cleanup runs after shutdown, including exactly-once closure for AutoCloseable resources.

### Verification

- FlowMapWithResourceSpec passed on Scala 2.13 and Scala 3.
- validatePullRequest passed with 3,392 tests and no failures or errors.
- Header and code-style checks passed.

### References

Fixes #3310