### PR TITLE
Fix OutboundIdleShutdownSpec harmless quarantine setup

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/artery/OutboundIdleShutdownSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/OutboundIdleShutdownSpec.scala
@@ -34,6 +34,7 @@ import org.scalatest.time.Span.convertSpanToDuration
 
 class OutboundIdleShutdownSpec extends ArteryMultiNodeSpec("""
   pekko.loglevel=INFO
+  pekko.remote.artery.propagate-harmless-quarantine-events = on
   pekko.remote.artery.advanced {
     stop-idle-outbound-after = 1 s
     connection-timeout = 2 s


### PR DESCRIPTION
### Motivation
Pekko 2.0 changed `pekko.remote.artery.propagate-harmless-quarantine-events` to default to `off`, but `OutboundIdleShutdownSpec` still expects a harmless quarantine to publish `ThisActorSystemQuarantinedEvent`. The spec therefore waits for an event that the default configuration deliberately suppresses.

### Modification
Explicitly enable harmless quarantine event propagation for `OutboundIdleShutdownSpec`.

`HarmlessQuarantineSpec` continues to use the production default and cover the suppression behavior.

### Result
The two specs again cover both directions:
- legacy propagation enabled: the remote system observes `ThisActorSystemQuarantinedEvent`
- production default disabled: harmless quarantine does not propagate the event

No production configuration or runtime behavior changes.


### References
Refs #2430