### PR TITLE
Abort TLS transport on session verification failure

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/TlsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/TlsSpec.scala
@@ -21,12 +21,12 @@ import javax.net.ssl._
 
 import scala.collection.immutable
 import scala.concurrent.Await
-import scala.concurrent.Future
+import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
-import scala.util.{ Random, Success }
+import scala.util.{ Failure, Random, Success }
 
 import org.apache.pekko
-import pekko.NotUsed
+import pekko.{ Done, NotUsed }
 import pekko.pattern.{ after => later }
 import pekko.stream._
 import pekko.stream.TLSProtocol._
@@ -501,6 +501,30 @@ abstract class AbstractTlsSpec(useLegacyActor: Boolean)
 
         val clientErrText = Await.result(clientErr, 1.second).getMessage
         clientErrText should include("unable to find valid certification path to requested target")
+      }
+
+      "abort the transport when session verification fails" in {
+        val verificationFailure = new SSLException("session verification failed")
+        val rejectingClientTls = tlsBidi(
+          () => createSSLEngine(sslContext, Client),
+          verifySession = _ => Failure(verificationFailure),
+          closing = IgnoreBoth)
+        val clientToServerDone = Promise[Done]()
+        val clientToServer = Flow[ByteString].watchTermination { (_, done) =>
+          done.onComplete(clientToServerDone.tryComplete)
+          NotUsed
+        }
+        val transport = BidiFlow.fromFlows(clientToServer, Flow[ByteString])
+        val serverApplication: Flow[SslTlsInbound, SslTlsOutbound, NotUsed] =
+          Flow.fromSinkAndSource(Sink.ignore, Source.maybe[SslTlsOutbound])
+
+        Source
+          .maybe[SslTlsOutbound]
+          .via(rejectingClientTls.atop(transport).atop(serverTls(IgnoreBoth).reversed).join(serverApplication))
+          .runWith(Sink.ignore)
+
+        val failure = intercept[SSLException](Await.result(clientToServerDone.future, 3.seconds.dilated))
+        (failure should be).theSameInstanceAs(verificationFailure)
       }
 
       "reliably cancel subscriptions when TransportIn fails early" in {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/TlsGraphStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/TlsGraphStage.scala
@@ -380,26 +380,29 @@ import pekko.util.ByteString
         val result = wrapIntoTransportBuffer()
         lastHandshakeStatus = result.getHandshakeStatus
 
-        if (lastHandshakeStatus == FINISHED) handshakeFinished()
-        runDelegatedTasks()
+        if (lastHandshakeStatus == FINISHED && !handshakeFinished()) {
+          // stop processing after failed session verification
+        } else {
+          runDelegatedTasks()
 
-        result.getStatus match {
-          case OK =>
-            if (transportOutBuffer.position() == 0 && lastHandshakeStatus == NEED_WRAP)
-              throw new IllegalStateException("SSLEngine trying to loop NEED_WRAP without producing output")
+          result.getStatus match {
+            case OK =>
+              if (transportOutBuffer.position() == 0 && lastHandshakeStatus == NEED_WRAP)
+                throw new IllegalStateException("SSLEngine trying to loop NEED_WRAP without producing output")
 
-            flushToTransportIfNeeded(result)
+              flushToTransportIfNeeded(result)
 
-          case CLOSED =>
-            flushToTransport()
-            if (engine.isInboundDone) nextPhase(CompletedPhase)
-            else nextPhase(AwaitingClosePhase)
+            case CLOSED =>
+              flushToTransport()
+              if (engine.isInboundDone) nextPhase(CompletedPhase)
+              else nextPhase(AwaitingClosePhase)
 
-          case BUFFER_OVERFLOW =>
-            growTransportOutBuffer()
+            case BUFFER_OVERFLOW =>
+              growTransportOutBuffer()
 
-          case status =>
-            failTls(new IllegalStateException(s"unexpected status $status in doWrap()"))
+            case status =>
+              failTls(new IllegalStateException(s"unexpected status $status in doWrap()"))
+          }
         }
       }
 
@@ -450,8 +453,8 @@ import pekko.util.ByteString
 
               case FINISHED =>
                 flushToUser()
-                handshakeFinished()
-                transportInput.putBackUnreadBuffer(transportInBuffer)
+                if (handshakeFinished())
+                  transportInput.putBackUnreadBuffer(transportInBuffer)
 
               case NEED_UNWRAP
                   if transportInBuffer.hasRemaining &&
@@ -484,16 +487,18 @@ import pekko.util.ByteString
         if (TlsEngineHelpers.runDelegatedTasks(engine) > 0 || lastHandshakeStatus == NEED_TASK)
           lastHandshakeStatus = engine.getHandshakeStatus
 
-      private def handshakeFinished(): Unit = {
+      private def handshakeFinished(): Boolean = {
         val session = engine.getSession
         verifySession(session) match {
           case Success(()) =>
             currentSession = session
             stateBits |= PlainDataAllowedFlag
             flushToUser()
+            true
 
           case Failure(ex) =>
-            throw ex
+            failTls(ex)
+            false
         }
       }
 


### PR DESCRIPTION
### Motivation
A failed post-handshake session verifier was handled as if the `SSLEngine` itself had failed. When the verifier returned an `SSLException`, the GraphStage TLS implementation caught it in the engine failure path and called `closeOutbound()`. Because the handshake had already succeeded and there was no pending fatal alert, this generated `close_notify` and completed the transport gracefully instead of aborting it.

Engine-originated handshake failures are intentionally left unchanged: those paths must continue wrapping and flushing pending fatal alerts such as `certificate_unknown`.

### Modification
- Handle a failed `verifySession` result as an explicit TLS stage failure.
- Stop wrap/unwrap handshake processing immediately after the verifier rejects the session.
- Use structured `if`/`else` control flow rather than a non-local return.
- Add a directional regression test that observes the cipher-side transport termination and checks that the original verifier exception fails it.
- Run the shared test for both the GraphStage and legacy actor implementations, covering TLS 1.2 and TLS 1.3.

### Result
Post-handshake session verification failures now abort the transport with the original exception. The GraphStage behavior matches the legacy TLS actor, while engine-originated TLS failures continue to flush their fatal alerts.

### Tests
- `stream-tests / Test / testOnly org.apache.pekko.stream.io.TlsGraphStageSpec` — 113 passed
- `stream-tests / Test / testOnly org.apache.pekko.stream.io.TlsSpec` — 113 passed
- `stream-tests / Test / testOnly org.apache.pekko.stream.io.TlsGraphStageDeferredCloseSpec` — 3 passed
- `stream-tests / Test / testOnly org.apache.pekko.stream.io.TlsGraphStageIsolatedSpec` — 7 passed
- `+mimaReportBinaryIssues` — passed for Scala 2.13 and Scala 3
- `checkCodeStyle` — passed
- `+headerCheckAll` — passed
- `scalafmt --list --mode diff-ref=origin/main` — passed
- `git diff --check origin/main...HEAD` — passed
- `validatePullRequest` — not run per request; focused TLS, compatibility, style, and header checks above were run
- Qoder stdout blocker review — no must-fix findings

### References
Refs #3245
