### PR TITLE
Avoid receive timeout type pollution

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ReceiveTimeoutSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ReceiveTimeoutSpec.scala
@@ -21,6 +21,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.pekko
+import pekko.actor.dungeon.{ ReceiveTimeout => ReceiveTimeoutSupport }
 import pekko.testkit._
 
 object ReceiveTimeoutSpec {
@@ -79,6 +80,12 @@ class ReceiveTimeoutSpec extends PekkoSpec() {
   import ReceiveTimeoutSpec._
 
   "An actor with receive timeout" must {
+
+    "classify messages that do not influence the timeout" in {
+      ReceiveTimeoutSupport.isNotInfluenceReceiveTimeout(Identify(None)) should ===(true)
+      ReceiveTimeoutSupport.isNotInfluenceReceiveTimeout(TransparentTick) should ===(true)
+      ReceiveTimeoutSupport.isNotInfluenceReceiveTimeout(Tick) should ===(false)
+    }
 
     "get timeout" taggedAs TimingTest in {
       val timeoutLatch = TestLatch()

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ReceiveTimeoutSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ReceiveTimeoutSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.pekko
-import pekko.actor.dungeon.{ ReceiveTimeout => ReceiveTimeoutSupport }
+import pekko.actor.dungeon.{ ReceiveTimeoutCompat => ReceiveTimeoutSupport }
 import pekko.testkit._
 
 object ReceiveTimeoutSpec {

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/TimerSchedulerImpl.scala
@@ -117,7 +117,7 @@ import org.slf4j.Logger
     val nextGen = timerGen.next()
 
     val timerMsg =
-      if (pekko.actor.dungeon.ReceiveTimeout.isNotInfluenceReceiveTimeout(msg))
+      if (pekko.actor.dungeon.ReceiveTimeoutCompat.isNotInfluenceReceiveTimeout(msg))
         new TimerMsg(key, nextGen, this) with NotInfluenceReceiveTimeout
       else
         new TimerMsg(key, nextGen, this)

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/TimerSchedulerImpl.scala
@@ -117,7 +117,7 @@ import org.slf4j.Logger
     val nextGen = timerGen.next()
 
     val timerMsg =
-      if (msg.isInstanceOf[NotInfluenceReceiveTimeout])
+      if (pekko.actor.dungeon.ReceiveTimeout.isNotInfluenceReceiveTimeout(msg))
         new TimerMsg(key, nextGen, this) with NotInfluenceReceiveTimeout
       else
         new TimerMsg(key, nextGen, this)

--- a/actor/src/main/scala-2.13/org/apache/pekko/actor/dungeon/ReceiveTimeoutCompat.scala
+++ b/actor/src/main/scala-2.13/org/apache/pekko/actor/dungeon/ReceiveTimeoutCompat.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.actor.dungeon
+
+import org.apache.pekko.actor.Identify
+import org.apache.pekko.actor.NotInfluenceReceiveTimeout
+
+private[pekko] object ReceiveTimeoutCompat {
+
+  // Identify is also an AutoReceivedMessage. Checking its concrete class first avoids polluting its secondary
+  // supertype cache on JDKs affected by JDK-8180450 when actor runtime code also checks the AutoReceivedMessage marker.
+  @inline def isNotInfluenceReceiveTimeout(message: Any): Boolean =
+    message.isInstanceOf[Identify] || message.isInstanceOf[NotInfluenceReceiveTimeout]
+}

--- a/actor/src/main/scala-3/org/apache/pekko/actor/dungeon/ReceiveTimeoutCompat.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/actor/dungeon/ReceiveTimeoutCompat.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.actor.dungeon
+
+import org.apache.pekko.actor.Identify
+import org.apache.pekko.actor.NotInfluenceReceiveTimeout
+
+private[pekko] object ReceiveTimeoutCompat {
+
+  // Identify is also an AutoReceivedMessage. Checking its concrete class first avoids polluting its secondary
+  // supertype cache on JDKs affected by JDK-8180450 when actor runtime code also checks the AutoReceivedMessage marker.
+  inline def isNotInfluenceReceiveTimeout(message: Any): Boolean =
+    message.isInstanceOf[Identify] || message.isInstanceOf[NotInfluenceReceiveTimeout]
+}

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala
@@ -561,7 +561,7 @@ private[pekko] class ActorCell(
       }
     finally
       // Schedule or reschedule receive timeout
-      checkReceiveTimeoutIfNeeded(msg, timeoutBeforeReceive)
+      checkReceiveTimeoutIfNeeded(timeoutBeforeReceive)
   }
 
   def autoReceiveMessage(msg: Envelope): Unit = {

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/ReceiveTimeout.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/ReceiveTimeout.scala
@@ -19,14 +19,10 @@ import scala.concurrent.duration.FiniteDuration
 import org.apache.pekko
 import pekko.actor.ActorCell
 import pekko.actor.Cancellable
-import pekko.actor.Identify
-import pekko.actor.NotInfluenceReceiveTimeout
+import pekko.actor.dungeon.ReceiveTimeoutCompat
 
 private[pekko] object ReceiveTimeout {
   final val emptyReceiveTimeoutData: (Duration, Cancellable) = (Duration.Undefined, ActorCell.emptyCancellable)
-
-  def isNotInfluenceReceiveTimeout(message: Any): Boolean =
-    message.isInstanceOf[Identify] || message.isInstanceOf[NotInfluenceReceiveTimeout]
 }
 
 private[pekko] trait ReceiveTimeout { this: ActorCell =>
@@ -76,7 +72,7 @@ private[pekko] trait ReceiveTimeout { this: ActorCell =>
 
   protected def cancelReceiveTimeoutIfNeeded(message: Any): (Duration, Cancellable) = {
     val beforeReceive = receiveTimeoutData
-    if ((beforeReceive ne emptyReceiveTimeoutData) && !isNotInfluenceReceiveTimeout(message))
+    if ((beforeReceive ne emptyReceiveTimeoutData) && !ReceiveTimeoutCompat.isNotInfluenceReceiveTimeout(message))
       cancelReceiveTimeoutTask()
 
     // Returning the state from before cancellation lets checkReceiveTimeoutIfNeeded infer whether this message

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/ReceiveTimeout.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/ReceiveTimeout.scala
@@ -19,10 +19,16 @@ import scala.concurrent.duration.FiniteDuration
 import org.apache.pekko
 import pekko.actor.ActorCell
 import pekko.actor.Cancellable
+import pekko.actor.Identify
 import pekko.actor.NotInfluenceReceiveTimeout
 
 private[pekko] object ReceiveTimeout {
   final val emptyReceiveTimeoutData: (Duration, Cancellable) = (Duration.Undefined, ActorCell.emptyCancellable)
+
+  // Identify is also an AutoReceivedMessage. Checking its concrete class first avoids polluting its secondary
+  // supertype cache on JDKs affected by JDK-8180450 when actor runtime code also checks the AutoReceivedMessage marker.
+  @inline def isNotInfluenceReceiveTimeout(message: Any): Boolean =
+    message.isInstanceOf[Identify] || message.isInstanceOf[NotInfluenceReceiveTimeout]
 }
 
 private[pekko] trait ReceiveTimeout { this: ActorCell =>
@@ -37,9 +43,11 @@ private[pekko] trait ReceiveTimeout { this: ActorCell =>
   final def setReceiveTimeout(timeout: Duration): Unit = receiveTimeoutData = receiveTimeoutData.copy(_1 = timeout)
 
   /** Called after `ActorCell.receiveMessage` or `ActorCell.autoReceiveMessage`. */
-  protected def checkReceiveTimeoutIfNeeded(message: Any, beforeReceive: (Duration, Cancellable)): Unit =
-    if (hasTimeoutData || receiveTimeoutChanged(beforeReceive))
-      checkReceiveTimeout(!message.isInstanceOf[NotInfluenceReceiveTimeout] || receiveTimeoutChanged(beforeReceive))
+  protected def checkReceiveTimeoutIfNeeded(beforeReceive: (Duration, Cancellable)): Unit = {
+    val timeoutChanged = receiveTimeoutChanged(beforeReceive)
+    if (hasTimeoutData || timeoutChanged)
+      checkReceiveTimeout(timeoutChanged)
+  }
 
   final def checkReceiveTimeout(reschedule: Boolean): Unit = {
     val (recvTimeout, task) = receiveTimeoutData
@@ -69,10 +77,13 @@ private[pekko] trait ReceiveTimeout { this: ActorCell =>
     receiveTimeoutData ne beforeReceive
 
   protected def cancelReceiveTimeoutIfNeeded(message: Any): (Duration, Cancellable) = {
-    if (hasTimeoutData && !message.isInstanceOf[NotInfluenceReceiveTimeout])
+    val beforeReceive = receiveTimeoutData
+    if ((beforeReceive ne emptyReceiveTimeoutData) && !isNotInfluenceReceiveTimeout(message))
       cancelReceiveTimeoutTask()
 
-    receiveTimeoutData
+    // Returning the state from before cancellation lets checkReceiveTimeoutIfNeeded infer whether this message
+    // influenced the timeout without performing the type check a second time.
+    beforeReceive
   }
 
   private[pekko] def cancelReceiveTimeoutTask(): Unit =

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/ReceiveTimeout.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/ReceiveTimeout.scala
@@ -25,9 +25,7 @@ import pekko.actor.NotInfluenceReceiveTimeout
 private[pekko] object ReceiveTimeout {
   final val emptyReceiveTimeoutData: (Duration, Cancellable) = (Duration.Undefined, ActorCell.emptyCancellable)
 
-  // Identify is also an AutoReceivedMessage. Checking its concrete class first avoids polluting its secondary
-  // supertype cache on JDKs affected by JDK-8180450 when actor runtime code also checks the AutoReceivedMessage marker.
-  @inline def isNotInfluenceReceiveTimeout(message: Any): Boolean =
+  def isNotInfluenceReceiveTimeout(message: Any): Boolean =
     message.isInstanceOf[Identify] || message.isInstanceOf[NotInfluenceReceiveTimeout]
 }
 

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/TimerSchedulerImpl.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/TimerSchedulerImpl.scala
@@ -90,7 +90,7 @@ import pekko.util.OptionVal
     val nextGen = nextTimerGen()
 
     val timerMsg =
-      if (msg.isInstanceOf[NotInfluenceReceiveTimeout])
+      if (dungeon.ReceiveTimeout.isNotInfluenceReceiveTimeout(msg))
         NotInfluenceReceiveTimeoutTimerMsg(key, nextGen, this)
       else
         InfluenceReceiveTimeoutTimerMsg(key, nextGen, this)

--- a/actor/src/main/scala/org/apache/pekko/actor/dungeon/TimerSchedulerImpl.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/dungeon/TimerSchedulerImpl.scala
@@ -90,7 +90,7 @@ import pekko.util.OptionVal
     val nextGen = nextTimerGen()
 
     val timerMsg =
-      if (dungeon.ReceiveTimeout.isNotInfluenceReceiveTimeout(msg))
+      if (dungeon.ReceiveTimeoutCompat.isNotInfluenceReceiveTimeout(msg))
         NotInfluenceReceiveTimeoutTimerMsg(key, nextGen, this)
       else
         InfluenceReceiveTimeoutTimerMsg(key, nextGen, this)

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/ReceiveTimeoutTypePollutionBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/ReceiveTimeoutTypePollutionBenchmark.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.actor
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Thread)
+class ReceiveTimeoutTypePollutionInput {
+  private val messages = Array[AnyRef](Identify("id"), new Object)
+  private var index = 0
+
+  def next(): AnyRef = {
+    index = (index + 1) & 1
+    messages(index)
+  }
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(3)
+@Threads(12)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+class ReceiveTimeoutTypePollutionBenchmark {
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  def isAutoReceived(message: AnyRef): Boolean =
+    message.isInstanceOf[AutoReceivedMessage]
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  def isNotInfluenceReceiveTimeout(message: AnyRef): Boolean =
+    message.isInstanceOf[NotInfluenceReceiveTimeout]
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  def isNotInfluenceReceiveTimeoutGuarded(message: AnyRef): Boolean =
+    dungeon.ReceiveTimeout.isNotInfluenceReceiveTimeout(message)
+
+  @Benchmark
+  def typePolluted(input: ReceiveTimeoutTypePollutionInput): Int = {
+    val message = input.next()
+    val before = isNotInfluenceReceiveTimeout(message)
+    val auto = isAutoReceived(message)
+    val after = isNotInfluenceReceiveTimeout(message)
+    (if (before) 1 else 0) | (if (auto) 2 else 0) | (if (after) 4 else 0)
+  }
+
+  @Benchmark
+  def concreteTypeGuard(input: ReceiveTimeoutTypePollutionInput): Int = {
+    val message = input.next()
+    val before = isNotInfluenceReceiveTimeoutGuarded(message)
+    val auto = isAutoReceived(message)
+    val after = isNotInfluenceReceiveTimeoutGuarded(message)
+    (if (before) 1 else 0) | (if (auto) 2 else 0) | (if (after) 4 else 0)
+  }
+
+  @Benchmark
+  def concreteTypeGuardAndStateChange(input: ReceiveTimeoutTypePollutionInput): Int = {
+    val message = input.next()
+    val before = isNotInfluenceReceiveTimeoutGuarded(message)
+    val auto = isAutoReceived(message)
+    (if (before) 1 else 0) | (if (auto) 2 else 0)
+  }
+}

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/ReceiveTimeoutTypePollutionBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/ReceiveTimeoutTypePollutionBenchmark.scala
@@ -51,7 +51,7 @@ class ReceiveTimeoutTypePollutionBenchmark {
 
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   def isNotInfluenceReceiveTimeoutGuarded(message: AnyRef): Boolean =
-    dungeon.ReceiveTimeout.isNotInfluenceReceiveTimeout(message)
+    dungeon.ReceiveTimeoutCompat.isNotInfluenceReceiveTimeout(message)
 
   @Benchmark
   def typePolluted(input: ReceiveTimeoutTypePollutionInput): Int = {


### PR DESCRIPTION
### Motivation

`Identify` implements both `AutoReceivedMessage` and `NotInfluenceReceiveTimeout`. On JVMs affected by [JDK-8180450](https://bugs.openjdk.org/browse/JDK-8180450), alternating successful checks against those two secondary supertypes makes the same concrete `Klass` secondary-super cache ping-pong between marker types. The checks occur on the Actor receive-timeout path and can contend across actor-dispatcher threads.

The receive path also classified the same message against `NotInfluenceReceiveTimeout` twice.

### Modification

- Classify final `Identify` with a concrete-class guard before the `NotInfluenceReceiveTimeout` marker check.
- Return the pre-cancellation timeout state and infer the post-receive reschedule decision from the state transition, removing the second marker check.
- Add focused classification coverage.
- Add a 12-thread JMH benchmark for the polluted, concrete-guarded, and final production-shaped paths.

### Result

Receive-timeout behavior remains unchanged, while `Identify` no longer alternates the concrete class secondary-super cache between its two marker interfaces. The final path also performs one classification instead of two.

JMH throughput (`ops/us`, 12 threads, 3 forks, 5 x 1 s warmup and measurement iterations):

| Runtime | Polluted path | Concrete guard | Final path | Final / polluted |
| --- | ---: | ---: | ---: | ---: |
| JDK 17.0.17 | 824.700 +/- 10.066 | 1633.766 +/- 53.719 | 2205.529 +/- 92.313 | 2.67x |
| JDK 21.0.8 | 1125.827 +/- 16.496 | 1609.084 +/- 31.694 | 2158.924 +/- 36.895 | 1.92x |
| JDK 25.0.2 | 1717.703 +/- 77.349 | 1841.141 +/- 53.279 | 2467.700 +/- 262.562 | 1.44x |

JDK 21.0.8 and JDK 25 contain the JVM fix, so their remaining gain primarily measures the removed classification/call rather than secondary-super-cache contention. The JDK 25 result was noisier than the other runs.



### References

Refs #1668

- [JDK-8180450](https://bugs.openjdk.org/browse/JDK-8180450)
