### PR TITLE
workaround broken links

### DIFF
--- a/docs/src/main/paradox/typed/distributed-data.md
+++ b/docs/src/main/paradox/typed/distributed-data.md
@@ -674,7 +674,7 @@ All entries can be made durable by specifying:
 pekko.cluster.distributed-data.durable.keys = ["*"]
 ```
 
-@scala[[LMDB](https://symas.com/lmdb/technical/)]@java[[LMDB](https://github.com/lmdbjava/lmdbjava/)] is the default storage implementation. It is
+[LMDB](https://github.com/lmdbjava/lmdbjava/) is the default storage implementation. It is
 possible to replace that with another implementation by implementing the actor protocol described in
 `org.apache.pekko.cluster.ddata.DurableStore` and defining the `pekko.cluster.distributed-data.durable.store-actor-class`
 property for the new implementation.

--- a/docs/src/main/paradox/typed/handling-actor-responses-with-scala3.md
+++ b/docs/src/main/paradox/typed/handling-actor-responses-with-scala3.md
@@ -30,7 +30,6 @@ A more in-depth explanation of the concepts used in applying Scala 3's Union typ
 be found in the following blog posts:
 
 * [Using Dotty Union types with Akka Typed](https://blog.lunatech.com/posts/2020-02-12-using-dotty-union-types-with-akka-typed)
-* [Using Dotty Union types with Akka Typed - Part II](https://blog.lunatech.com/posts/2020-02-19-using-dotty-union-types-with-akka-typed-part-II)
 
 **Useful when:**
 


### PR DESCRIPTION
fixes #3340 
* the union type blog - we link to the blog and its still there but the part 2 link is now broken and the first part seems ok anyway
* seems ok to use the same LMDB link for both Scala and Java users