### PR TITLE
fix(stream): notify BroadcastHub consumers on materializer shutdown

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.Done
-import pekko.stream.KillSwitches
+import pekko.stream.{ KillSwitches, Materializer }
 import pekko.stream.ThrottleMode
 import pekko.stream.impl.ActorPublisher
 import pekko.stream.testkit.StreamSpec
@@ -557,6 +557,28 @@ class HubSpec extends StreamSpec {
       a[TE] shouldBe thrownBy {
         Await.result(source.runWith(Sink.seq), 3.seconds.dilated)
       }
+    }
+
+    "notify consumers when hub materializer is shut down" in {
+      val hubMat = Materializer(system)
+      val upstream = TestPublisher.probe[Int]()
+      val source = Source.fromPublisher(upstream).runWith(BroadcastHub.sink(8))(hubMat)
+
+      val downstream = TestSubscriber.probe[Int]()
+      source.runWith(Sink.fromSubscriber(downstream))
+
+      downstream.request(1)
+      Thread.sleep(100)
+
+      upstream.sendNext(1)
+      downstream.expectNext(1)
+
+      hubMat.shutdown()
+
+      // The consumer must be notified (not left hanging), which is the fix for #3345.
+      // The signal is an error because the SubSink output boundary failure
+      // arrives before the postStop completion callback.
+      downstream.expectError()
     }
 
     "handle cancelled Sink" in {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -568,7 +568,7 @@ class HubSpec extends StreamSpec {
       source.runWith(Sink.fromSubscriber(downstream))
 
       downstream.request(1)
-      Thread.sleep(100)
+      upstream.expectRequest()
 
       upstream.sendNext(1)
       downstream.expectNext(1)

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -757,7 +757,7 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
       // so that materializer shutdown produces the correct signal.
 
       @tailrec def tryClose(): Unit = state.get() match {
-        case Closed(_) => // Already closed by onUpstreamFailure — fall through to notify wheel below
+        case Closed(_) => // Already closed by onUpstreamFailure — notify registered consumers directly
           notifyRegisteredConsumers()
         case open: Open =>
           if (state.compareAndSet(open, Closed(None))) {

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -652,21 +652,12 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
     override def onUpstreamFailure(ex: Throwable): Unit = {
       val failMessage = HubCompleted(Some(ex))
 
-      // Notify pending consumers and set tombstone
+      // Notify pending consumers and set tombstone.
+      // Registered consumers in the consumerWheel are notified by postStop.
       state.getAndSet(Closed(Some(ex))).asInstanceOf[Open].registrations.foreach { consumer =>
         consumer.callback.invoke(failMessage)
       }
 
-      // Notify registered consumers — skip null (empty) slots
-      var idx = 0
-      while (idx < consumerWheel.length) {
-        val bucket = consumerWheel(idx)
-        if (bucket ne null) {
-          val itr = bucket.valuesIterator
-          while (itr.hasNext) itr.next().callback.invoke(failMessage)
-        }
-        idx += 1
-      }
       failStage(ex)
     }
 
@@ -759,17 +750,37 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
     }
 
     override def postStop(): Unit = {
-      // Notify pending consumers and set tombstone
+      // Notify all consumers (pending and registered) when the stage stops.
+      // Registered consumers in the consumerWheel are notified here (not in onUpstreamFailure)
+      // so that materializer shutdown produces the correct signal.
 
       @tailrec def tryClose(): Unit = state.get() match {
-        case Closed(_)  => // Already closed, ignore
+        case Closed(_) => // Already closed by onUpstreamFailure — fall through to notify wheel below
+          notifyRegisteredConsumers()
         case open: Open =>
           if (state.compareAndSet(open, Closed(None))) {
             val completedMessage = HubCompleted(None)
             open.registrations.foreach { consumer =>
               consumer.callback.invoke(completedMessage)
             }
+            notifyRegisteredConsumers()
           } else tryClose()
+      }
+
+      def notifyRegisteredConsumers(): Unit = {
+        val message = state.get() match {
+          case Closed(Some(ex)) => HubCompleted(Some(ex))
+          case _                => HubCompleted(None)
+        }
+        var idx = 0
+        while (idx < consumerWheel.length) {
+          val bucket = consumerWheel(idx)
+          if (bucket ne null) {
+            val itr = bucket.valuesIterator
+            while (itr.hasNext) itr.next().callback.invoke(message)
+          }
+          idx += 1
+        }
       }
 
       tryClose()

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -25,6 +25,7 @@ import scala.collection.immutable.Queue
 import scala.collection.mutable.LongMap
 import scala.concurrent.{ Future, Promise }
 import scala.util.{ Failure, Success, Try }
+import scala.util.control.NonFatal
 
 import org.apache.pekko
 import pekko.NotUsed
@@ -655,7 +656,8 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
       // Notify pending consumers and set tombstone.
       // Registered consumers in the consumerWheel are notified by postStop.
       state.getAndSet(Closed(Some(ex))).asInstanceOf[Open].registrations.foreach { consumer =>
-        consumer.callback.invoke(failMessage)
+        try consumer.callback.invoke(failMessage)
+        catch { case NonFatal(_) => }
       }
 
       failStage(ex)
@@ -761,7 +763,8 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
           if (state.compareAndSet(open, Closed(None))) {
             val completedMessage = HubCompleted(None)
             open.registrations.foreach { consumer =>
-              consumer.callback.invoke(completedMessage)
+              try consumer.callback.invoke(completedMessage)
+              catch { case NonFatal(_) => }
             }
             notifyRegisteredConsumers()
           } else tryClose()
@@ -777,7 +780,10 @@ private[pekko] class BroadcastHub[T](startAfterNrOfConsumers: Int, bufferSize: I
           val bucket = consumerWheel(idx)
           if (bucket ne null) {
             val itr = bucket.valuesIterator
-            while (itr.hasNext) itr.next().callback.invoke(message)
+            while (itr.hasNext) {
+              try itr.next().callback.invoke(message)
+              catch { case NonFatal(_) => }
+            }
           }
           idx += 1
         }


### PR DESCRIPTION
### Motivation

When the materializer running a `BroadcastHub.sink` is shut down (e.g. the hosting actor stops or crashes), consumers materialized on a different materializer are not reliably notified of the hub's termination. The consumer source hangs indefinitely — neither `Completed` nor `Error` is received. See #3345.

### Modification

- Move registered-consumer (`consumerWheel`) notification from `onUpstreamFailure` to `postStop` so that `postStop` is the single notification point for all consumers.
- `postStop` now handles both `Open` (normal termination) and `Closed` (after upstream failure) states, ensuring registered consumers in the wheel always receive the appropriate signal.

**Before:** `onUpstreamFailure` iterated the `consumerWheel` to notify registered consumers, but `postStop` did not. This left a gap where late-registering consumers could miss notification during materializer shutdown.

**After:** `postStop` is the sole notification point for registered consumers, using the failure reason from the `Closed` state when applicable.

### Result

BroadcastHub consumers are reliably notified when the hub's materializer shuts down, preventing consumers from hanging indefinitely.

### Tests

- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.HubSpec"` — 51 passed, 0 failed
- Added new test: `"notify consumers when hub materializer is shut down"`

### References

Fixes #3345