### PR TITLE
refactor: convert org.apache.pekko.X imports to pekko.X style

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/ControlledExecutor.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/ControlledExecutor.scala
@@ -17,7 +17,8 @@ import java.util.LinkedList
 
 import scala.concurrent.ExecutionContextExecutor
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/LogbackUtil.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/LogbackUtil.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.actor.testkit.typed.internal
 
 import scala.annotation.tailrec
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturing.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturing.scala
@@ -19,7 +19,8 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
-import org.apache.pekko.actor.testkit.typed.internal.CapturingAppender
+import org.apache.pekko
+import pekko.actor.testkit.typed.internal.CapturingAppender
 
 import org.slf4j.LoggerFactory
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/LogCapturingExtension.scala
@@ -20,7 +20,8 @@ import scala.util.control.NonFatal
 import org.junit.jupiter.api.extension.{ ExtensionContext, InvocationInterceptor, ReflectiveInvocationContext }
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation
 
-import org.apache.pekko.actor.testkit.typed.internal.CapturingAppender
+import org.apache.pekko
+import pekko.actor.testkit.typed.internal.CapturingAppender
 
 import org.slf4j.LoggerFactory
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJUnit5Extension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJUnit5Extension.scala
@@ -20,7 +20,8 @@ package org.apache.pekko.actor.testkit.typed.javadsl
 import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
 import org.junit.platform.commons.support.AnnotationSupport
 
-import org.apache.pekko.actor.testkit.typed.annotations.JUnit5TestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.annotations.JUnit5TestKit
 
 @deprecated("Use TestKitJUnitJupiterExtension instead", "2.0.0")
 final class TestKitJUnit5Extension() extends AfterAllCallback with BeforeTestExecutionCallback {

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJUnitJupiterExtension.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestKitJUnitJupiterExtension.scala
@@ -20,7 +20,8 @@ package org.apache.pekko.actor.testkit.typed.javadsl
 import org.junit.jupiter.api.extension.{ AfterAllCallback, BeforeTestExecutionCallback, ExtensionContext }
 import org.junit.platform.commons.support.AnnotationSupport
 
-import org.apache.pekko.actor.testkit.typed.annotations.JUnitJupiterTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.annotations.JUnitJupiterTestKit
 
 final class TestKitJUnitJupiterExtension() extends AfterAllCallback with BeforeTestExecutionCallback {
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LogCapturing.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LogCapturing.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.actor.testkit.typed.scaladsl
 
 import scala.util.control.NonFatal
 
-import org.apache.pekko.actor.testkit.typed.internal.CapturingAppender
+import org.apache.pekko
+import pekko.actor.testkit.typed.internal.CapturingAppender
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Outcome

--- a/actor-testkit-typed/src/test/scala/docs/org/apache/pekko/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
+++ b/actor-testkit-typed/src/test/scala/docs/org/apache/pekko/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
@@ -17,7 +17,7 @@ import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
 import pekko.actor.typed.Scheduler
 //#test-header
-import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
+import pekko.actor.testkit.typed.scaladsl.ActorTestKit
 
 //#test-header
 import pekko.actor.typed._

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/JUnit5TestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/JUnit5TestKitBuilderSpec.scala
@@ -20,7 +20,7 @@ package org.apache.pekko.actor.testkit.typed.scaladsl
 import scala.annotation.nowarn
 
 import org.apache.pekko
-import org.apache.pekko.actor.testkit.typed.javadsl.JUnit5TestKitBuilder
+import pekko.actor.testkit.typed.javadsl.JUnit5TestKitBuilder
 import pekko.actor.typed.ActorSystem
 
 import org.scalatest.wordspec.AnyWordSpec

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/JUnitJupiterTestKitBuilderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/JUnitJupiterTestKitBuilderSpec.scala
@@ -18,7 +18,7 @@
 package org.apache.pekko.actor.testkit.typed.scaladsl
 
 import org.apache.pekko
-import org.apache.pekko.actor.testkit.typed.javadsl.JUnitJupiterTestKitBuilder
+import pekko.actor.testkit.typed.javadsl.JUnitJupiterTestKitBuilder
 import pekko.actor.typed.ActorSystem
 
 import org.scalatest.wordspec.AnyWordSpec

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.actor.testkit.typed.scaladsl
 
-import org.apache.pekko.actor.testkit.typed.LoggingEvent
+import org.apache.pekko
+import pekko.actor.testkit.typed.LoggingEvent
 
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
@@ -17,7 +17,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.Future
 
-import org.apache.pekko.actor.testkit.typed.TestException
+import org.apache.pekko
+import pekko.actor.testkit.typed.TestException
 
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestProbeSpec.scala
+++ b/actor-testkit-typed/src/test/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestProbeSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.actor.testkit.typed.scaladsl
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko
+import pekko.actor.typed.scaladsl.Behaviors
 
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/actor-tests/src/test/scala/org/apache/pekko/PekkoExceptionSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/PekkoExceptionSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko
 
 import java.lang.invoke.{ MethodHandles, MethodType }
 
-import org.apache.pekko.actor._
+import org.apache.pekko
+import pekko.actor._
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/AbstractActorPreRestartFinalSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/AbstractActorPreRestartFinalSpec.scala
@@ -22,7 +22,8 @@ import java.util.Optional
 import scala.concurrent.duration._
 import scala.runtime.BoxedUnit
 
-import org.apache.pekko.testkit.{ ImplicitSender, PekkoSpec, TestProbe }
+import org.apache.pekko
+import pekko.testkit.{ ImplicitSender, PekkoSpec, TestProbe }
 
 object AbstractActorPreRestartFinalSpec {
 

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/AddressSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/AddressSpec.scala
@@ -17,7 +17,8 @@
 
 package org.apache.pekko.actor
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 class AddressSpec extends PekkoSpec {
   "Address ordering" must {

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/FSMTimingSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/FSMTimingSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.actor
 
-import org.apache.pekko.testkit._
+import org.apache.pekko
+import pekko.testkit._
 import scala.concurrent.duration._
 
 class FSMTimingSpec extends PekkoSpec with ImplicitSender {

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/FSMTimingSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/FSMTimingSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.actor
 
 import org.apache.pekko
 import pekko.testkit._
+
 import scala.concurrent.duration._
 
 class FSMTimingSpec extends PekkoSpec with ImplicitSender {

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/HotSwapSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/HotSwapSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.actor
 
-import org.apache.pekko.testkit._
+import org.apache.pekko
+import pekko.testkit._
 
 object HotSwapSpec {
   abstract class Becomer extends Actor {}

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ReceiveTimeoutSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ReceiveTimeoutSpec.scala
@@ -20,7 +20,8 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import org.apache.pekko.testkit._
+import org.apache.pekko
+import pekko.testkit._
 
 object ReceiveTimeoutSpec {
   case object Tick

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/TimerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/TimerSpec.scala
@@ -19,7 +19,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import org.apache.pekko.testkit._
+import org.apache.pekko
+import pekko.testkit._
 
 object TimerSpec {
   sealed trait Command

--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/IdGeneratorSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/IdGeneratorSpec.scala
@@ -17,7 +17,8 @@
 
 package org.apache.pekko.io.dns
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 class IdGeneratorSpec extends PekkoSpec {
 

--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/DnsClientSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/DnsClientSpec.scala
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.{ immutable => im }
 
 import org.apache.pekko
-import org.apache.pekko.actor.Status.Failure
+import pekko.actor.Status.Failure
 import pekko.actor.Props
 import pekko.io.Udp
 import pekko.io.dns.{ ARecord, CachePolicy, RecordClass, RecordType }

--- a/actor-tests/src/test/scala/org/apache/pekko/pattern/CircuitBreakerMTSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/pattern/CircuitBreakerMTSpec.scala
@@ -18,7 +18,8 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 
-import org.apache.pekko.testkit._
+import org.apache.pekko
+import pekko.testkit._
 
 class CircuitBreakerMTSpec extends PekkoSpec {
   implicit val ec: ExecutionContextExecutor = system.dispatcher

--- a/actor-tests/src/test/scala/org/apache/pekko/serialization/NoVerification.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/serialization/NoVerification.scala
@@ -13,7 +13,8 @@
 
 package test.org.apache.pekko.serialization
 
-import org.apache.pekko.actor.NoSerializationVerificationNeeded
+import org.apache.pekko
+import pekko.actor.NoSerializationVerificationNeeded
 
 /**
  *  This is currently used in NoSerializationVerificationNeeded test cases in SerializeSpec,

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteIteratorSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteIteratorSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.util
 
 import java.nio.ByteOrder
 
-import org.apache.pekko.util.ByteIterator.ByteArrayIterator
+import org.apache.pekko
+import pekko.util.ByteIterator.ByteArrayIterator
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/actor-tests/src/test/scala/org/apache/pekko/util/DurationSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/DurationSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.util
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 class DurationSpec extends PekkoSpec {
 

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ManifestInfoSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ManifestInfoSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.util
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 class ManifestInfoSpec extends PekkoSpec {
   "ManifestInfo" should {

--- a/actor-tests/src/test/scala/org/apache/pekko/util/MessageBufferSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/MessageBufferSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.util
 
-import org.apache.pekko.actor.{ ActorPath, ActorRef, ActorRefProvider, MinimalActorRef }
+import org.apache.pekko
+import pekko.actor.{ ActorPath, ActorRef, ActorRefProvider, MinimalActorRef }
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ScheduledClockSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ScheduledClockSpec.scala
@@ -15,8 +15,9 @@ package org.apache.pekko.util
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.testkit.TimingTest
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
+import pekko.testkit.TimingTest
 
 class ScheduledClockSpec extends PekkoSpec {
 

--- a/actor-tests/src/test/scala/org/apache/pekko/util/TokenBucketSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/TokenBucketSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.util
 
 import scala.util.Random
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 class TokenBucketSpec extends PekkoSpec {
 

--- a/actor-tests/src/test/scala/other/SerializerOutsidePekkoPackage.scala
+++ b/actor-tests/src/test/scala/other/SerializerOutsidePekkoPackage.scala
@@ -15,7 +15,8 @@ package other
 
 import java.nio.charset.StandardCharsets
 
-import org.apache.pekko.serialization.SerializerWithStringManifest
+import org.apache.pekko
+import pekko.serialization.SerializerWithStringManifest
 
 class SerializerOutsidePekkoPackage extends SerializerWithStringManifest {
   override def identifier: Int = 999

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/FaultToleranceDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/FaultToleranceDocSpec.scala
@@ -14,9 +14,9 @@
 package docs.org.apache.pekko.typed
 
 import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 
 import scala.concurrent.duration._
-import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import scala.annotation.nowarn
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/FaultToleranceDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/FaultToleranceDocSpec.scala
@@ -13,8 +13,10 @@
 
 package docs.org.apache.pekko.typed
 
+import org.apache.pekko
+
 import scala.concurrent.duration._
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import scala.annotation.nowarn
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/SpawnProtocolDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/SpawnProtocolDocSpec.scala
@@ -20,6 +20,7 @@ import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ActorTestKit
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
+
 import docs.org.apache.pekko.typed.IntroSpec.HelloWorld
 import org.scalatest.wordspec.AnyWordSpecLike
 import scala.annotation.nowarn

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/SpawnProtocolDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/SpawnProtocolDocSpec.scala
@@ -25,7 +25,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import scala.annotation.nowarn
 
 //#imports1
-import org.apache.pekko
 import pekko.actor.typed.Behavior
 import pekko.actor.typed.SpawnProtocol
 import pekko.actor.typed.scaladsl.Behaviors
@@ -34,7 +33,6 @@ import pekko.actor.typed.scaladsl.LoggerOps
 //#imports1
 
 //#imports2
-import org.apache.pekko
 import pekko.actor.typed.ActorRef
 import pekko.actor.typed.ActorSystem
 import pekko.actor.typed.Props

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/StyleGuideDocExamples.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/StyleGuideDocExamples.scala
@@ -29,12 +29,11 @@ import scala.annotation.nowarn
 //#oo-style
 //#fun-style
 
-import org.apache.pekko
 import pekko.actor.typed.Behavior
 import pekko.actor.typed.scaladsl.ActorContext
 import pekko.actor.typed.scaladsl.Behaviors
 //#fun-style
-import org.apache.pekko.actor.typed.scaladsl.AbstractBehavior
+import pekko.actor.typed.scaladsl.AbstractBehavior
 import org.slf4j.Logger
 //#oo-style
 
@@ -437,7 +436,6 @@ object StyleGuideDocExamples {
     implicit val system: ActorSystem[Nothing] = ???
 
     // #ask-1
-    import org.apache.pekko
     import pekko.actor.typed.scaladsl.AskPattern._
     import pekko.util.Timeout
 

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/coexistence/ClassicWatchingTypedSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/coexistence/ClassicWatchingTypedSpec.scala
@@ -21,11 +21,11 @@ import pekko.actor.typed.scaladsl.Behaviors
 import pekko.testkit.TestKit
 //#adapter-import
 // adds support for actors to a classic actor system and context
-import org.apache.pekko.actor.typed.scaladsl.adapter._
+import pekko.actor.typed.scaladsl.adapter._
 //#adapter-import
-import org.apache.pekko.testkit.TestProbe
+import pekko.testkit.TestProbe
 //#import-alias
-import org.apache.pekko.{ actor => classic }
+import pekko.{ actor => classic }
 //#import-alias
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/coexistence/TypedWatchingClassicSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/coexistence/TypedWatchingClassicSpec.scala
@@ -20,11 +20,11 @@ import pekko.actor.typed.scaladsl.Behaviors
 import pekko.testkit.TestKit
 //#adapter-import
 // adds support for typed actors to a classic actor system and context
-import org.apache.pekko.actor.typed.scaladsl.adapter._
+import pekko.actor.typed.scaladsl.adapter._
 //#adapter-import
-import org.apache.pekko.testkit.TestProbe
+import pekko.testkit.TestProbe
 //#import-alias
-import org.apache.pekko.{ actor => classic }
+import pekko.{ actor => classic }
 //#import-alias
 import org.scalatest.wordspec.AnyWordSpec
 import scala.concurrent.duration._

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/myapp/package.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/myapp/package.scala
@@ -15,7 +15,8 @@ package docs.org.apache.pekko.typed
 
 //#loggerops-package-implicit
 import scala.language.implicitConversions
-import org.apache.pekko.actor.typed.scaladsl.LoggerOps
+import org.apache.pekko
+import pekko.actor.typed.scaladsl.LoggerOps
 import org.slf4j.Logger
 
 package object myapp {

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/myapp/package.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/myapp/package.scala
@@ -17,6 +17,7 @@ package docs.org.apache.pekko.typed
 import scala.language.implicitConversions
 import org.apache.pekko
 import pekko.actor.typed.scaladsl.LoggerOps
+
 import org.slf4j.Logger
 
 package object myapp {

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/PropsSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/PropsSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.actor.typed
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.LogCapturing
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.LogCapturing
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/eventstream/EventStreamDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/eventstream/EventStreamDocSpec.scala
@@ -17,10 +17,11 @@
 
 package org.apache.pekko.actor.typed.eventstream
 
-import org.apache.pekko.actor.{ AllDeadLetters, DeadLetter, Dropped, SuppressedDeadLetter, UnhandledMessage }
-import org.apache.pekko.actor.testkit.typed.scaladsl.{ LogCapturing, ScalaTestWithActorTestKit }
-import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko
+import pekko.actor.{ AllDeadLetters, DeadLetter, Dropped, SuppressedDeadLetter, UnhandledMessage }
+import pekko.actor.testkit.typed.scaladsl.{ LogCapturing, ScalaTestWithActorTestKit }
+import pekko.actor.typed.ActorSystem
+import pekko.actor.typed.scaladsl.Behaviors
 
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -19,7 +19,7 @@ import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
 
 import org.apache.pekko
-import org.apache.pekko.actor.testkit.typed.TestException
+import pekko.actor.testkit.typed.TestException
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
 import pekko.actor.testkit.typed.scaladsl.LoggingTestKit
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/Dispatchers.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/Dispatchers.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.actor.typed
 
 import scala.concurrent.ExecutionContextExecutor
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 object Dispatchers {
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/LogOptions.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/LogOptions.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.actor.typed
 
 import java.util.Optional
 
-import org.apache.pekko.annotation.{ DoNotInherit, InternalApi }
+import org.apache.pekko
+import pekko.annotation.{ DoNotInherit, InternalApi }
 
 import org.slf4j.Logger
 import org.slf4j.event.Level

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/TypedActorContext.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/TypedActorContext.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.actor.typed
 
-import org.apache.pekko.annotation.DoNotInherit
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 /**
  * This trait is not meant to be extended by user code. If you do so, you may

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/internal/DeliverySerializable.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/internal/DeliverySerializable.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.actor.typed.delivery.internal
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorMdc.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorMdc.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.actor.typed.internal
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 import org.slf4j.MDC
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/CachedProps.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/CachedProps.scala
@@ -13,8 +13,9 @@
 
 package org.apache.pekko.actor.typed.internal
 
-import org.apache.pekko.actor.typed.Props
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.actor.typed.Props
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/jfr/Events.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/jfr/Events.scala
@@ -19,7 +19,8 @@ import jdk.jfr.Event
 import jdk.jfr.Label
 import jdk.jfr.StackTrace
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 // requires jdk.jfr (available since JDK 9, project baseline is Java 17)
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/TimerScheduler.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/TimerScheduler.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.actor.typed.javadsl
 
 import java.time.Duration
 
-import org.apache.pekko.annotation.DoNotInherit
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 /**
  * Support for scheduled `self` messages in an actor.

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/TimerScheduler.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/TimerScheduler.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.actor.typed.scaladsl
 
 import scala.concurrent.duration.FiniteDuration
 
-import org.apache.pekko.annotation.DoNotInherit
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 /**
  * Support for scheduled `self` messages in an actor.

--- a/actor/src/main/scala-2.13/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-2.13/org/apache/pekko/util/ByteIterator.scala
@@ -22,7 +22,8 @@ import scala.collection.LinearSeq
 import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
 
-import org.apache.pekko.util.Collections.EmptyImmutableSeq
+import org.apache.pekko
+import pekko.util.Collections.EmptyImmutableSeq
 
 object ByteIterator {
   object ByteArrayIterator {

--- a/actor/src/main/scala-3/org/apache/pekko/util/ByteIterator.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/ByteIterator.scala
@@ -21,7 +21,8 @@ import scala.collection.LinearSeq
 import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
 
-import org.apache.pekko.util.Collections.EmptyImmutableSeq
+import org.apache.pekko
+import pekko.util.Collections.EmptyImmutableSeq
 
 object ByteIterator {
   object ByteArrayIterator {

--- a/actor/src/main/scala/org/apache/pekko/Done.scala
+++ b/actor/src/main/scala/org/apache/pekko/Done.scala
@@ -15,7 +15,8 @@ package org.apache.pekko
 
 import java.io.Serializable
 
-import org.apache.pekko.annotation.DoNotInherit
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 /**
  * Typically used together with `Future` to signal completion

--- a/actor/src/main/scala/org/apache/pekko/PekkoVersion.scala
+++ b/actor/src/main/scala/org/apache/pekko/PekkoVersion.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 final class UnsupportedPekkoVersion private[pekko] (msg: String) extends RuntimeException(msg)
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/ForkJoinExecutorConfigurator.scala
@@ -15,8 +15,9 @@ package org.apache.pekko.dispatch
 
 import java.util.concurrent.{ ExecutorService, ForkJoinPool, ForkJoinTask, ThreadFactory, TimeUnit }
 
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.util.JavaVersion
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.util.JavaVersion
 
 import com.typesafe.config.Config
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/VirtualizedExecutorService.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/VirtualizedExecutorService.scala
@@ -21,7 +21,8 @@ import java.util
 import java.util.concurrent.{ Callable, Executor, ExecutorService, Future, ThreadFactory, TimeUnit }
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * A virtualized executor service that creates a new virtual thread for each task.

--- a/actor/src/main/scala/org/apache/pekko/io/InetAddressDnsProvider.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/InetAddressDnsProvider.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.io
 
 import scala.annotation.nowarn
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/io/dns/IdGenerator.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/IdGenerator.scala
@@ -21,7 +21,8 @@ import java.security.SecureRandom
 import java.util.concurrent.ThreadLocalRandom
 import java.util.random.RandomGenerator
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/io/dns/RecordType.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/RecordType.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.io.dns
 
-import org.apache.pekko.util.OptionVal
+import org.apache.pekko
+import pekko.util.OptionVal
 
 /**
  * DNS Record Type

--- a/actor/src/main/scala/org/apache/pekko/japi/function/Function.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/function/Function.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.japi.function
 
 import scala.annotation.nowarn
 
-import org.apache.pekko.util.ConstantFun
+import org.apache.pekko
+import pekko.util.ConstantFun
 
 /**
  * A Function interface. Used to create first-class-functions is Java.

--- a/actor/src/main/scala/org/apache/pekko/routing/Listeners.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/Listeners.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.routing
 
 import java.util.{ Set, TreeSet }
 
-import org.apache.pekko.actor.{ Actor, ActorRef }
+import org.apache.pekko
+import pekko.actor.{ Actor, ActorRef }
 
 sealed trait ListenerMessage
 final case class Listen(listener: ActorRef) extends ListenerMessage

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -26,7 +26,8 @@ import scala.collection.mutable.{ Builder, WrappedArray }
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
-import org.apache.pekko.io.UnsynchronizedByteArrayInputStream
+import org.apache.pekko
+import pekko.io.UnsynchronizedByteArrayInputStream
 
 object ByteString {
 

--- a/actor/src/main/scala/org/apache/pekko/util/DoubleLinkedList.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/DoubleLinkedList.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.util
 
 import scala.collection.AbstractIterator
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/util/FrequencyList.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/FrequencyList.scala
@@ -16,7 +16,8 @@ package org.apache.pekko.util
 import scala.collection.{ immutable, mutable }
 import scala.concurrent.duration.FiniteDuration
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/FrequencySketch.scala
@@ -32,7 +32,8 @@ package org.apache.pekko.util
 import scala.annotation.nowarn
 import scala.util.hashing.MurmurHash3
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/util/ImmutableIntMap.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ImmutableIntMap.scala
@@ -12,11 +12,13 @@
  */
 
 package org.apache.pekko.util
+
 import java.util.Arrays
 
 import scala.annotation.tailrec
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/util/JavaVersion.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/JavaVersion.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.util
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/util/OptionVal.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/OptionVal.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.util
 
-import org.apache.pekko.annotation.InternalStableApi
+import org.apache.pekko
+import pekko.annotation.InternalStableApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/util/RecencyList.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/RecencyList.scala
@@ -16,7 +16,8 @@ package org.apache.pekko.util
 import scala.collection.{ immutable, mutable }
 import scala.concurrent.duration.FiniteDuration
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/util/Reflect.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/Reflect.scala
@@ -12,6 +12,7 @@
  */
 
 package org.apache.pekko.util
+
 import java.lang.StackWalker
 import java.lang.invoke.{ MethodHandle, MethodHandles, MethodType }
 import java.lang.reflect.{ Constructor, InvocationTargetException, Modifier, ParameterizedType, Type }
@@ -20,7 +21,8 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.control.NonFatal
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * Collection of internal reflection utilities which may or may not be

--- a/actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/SWARUtil.scala
@@ -18,7 +18,8 @@ package org.apache.pekko.util
 import java.lang.invoke.MethodHandles
 import java.nio.ByteOrder
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * SWAR (SIMD Within A Register) utility class. Internal Use Only.

--- a/actor/src/main/scala/org/apache/pekko/util/SegmentedRecencyList.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/SegmentedRecencyList.scala
@@ -16,7 +16,8 @@ package org.apache.pekko.util
 import scala.collection.{ immutable, mutable }
 import scala.concurrent.duration.FiniteDuration
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/actor/src/main/scala/org/apache/pekko/util/SerializedSuspendableExecutionContext.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/SerializedSuspendableExecutionContext.scala
@@ -19,7 +19,8 @@ import scala.annotation.{ switch, tailrec }
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
-import org.apache.pekko.dispatch.AbstractNodeQueue
+import org.apache.pekko
+import pekko.dispatch.AbstractNodeQueue
 
 private[pekko] object SerializedSuspendableExecutionContext {
   final val Off = 0

--- a/actor/src/main/scala/org/apache/pekko/util/Version.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/Version.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.util
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 object Version {
   val Zero: Version = Version("0.0.0")

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/AffinityPoolIdleCPULevelBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/AffinityPoolIdleCPULevelBenchmark.scala
@@ -17,7 +17,8 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.actor.BenchmarkActors._
+import org.apache.pekko
+import pekko.actor.BenchmarkActors._
 
 import com.typesafe.config.ConfigFactory
 

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/DirectByteBufferPoolBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/DirectByteBufferPoolBenchmark.scala
@@ -19,7 +19,8 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.io.DirectByteBufferPool
+import org.apache.pekko
+import pekko.io.DirectByteBufferPool
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/ForkJoinActorBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/ForkJoinActorBenchmark.scala
@@ -20,7 +20,8 @@ import scala.annotation.tailrec
 import BenchmarkActors._
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.testkit.TestProbe
+import org.apache.pekko
+import pekko.testkit.TestProbe
 
 import com.typesafe.config.ConfigFactory
 

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/ScheduleBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/ScheduleBenchmark.scala
@@ -22,7 +22,8 @@ import scala.concurrent.duration._
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.util.Timeout
+import org.apache.pekko
+import pekko.util.Timeout
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/bench-jmh/src/main/scala/org/apache/pekko/actor/StashCreationBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/actor/StashCreationBenchmark.scala
@@ -17,7 +17,8 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.testkit.TestProbe
+import org.apache.pekko
+import pekko.testkit.TestProbe
 
 import com.typesafe.config.ConfigFactory
 

--- a/bench-jmh/src/main/scala/org/apache/pekko/persistence/Common.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/persistence/Common.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence
 
-import org.apache.pekko.actor.Actor
+import org.apache.pekko
+import pekko.actor.Actor
 
 /** only as a "the best we could possibly get" baseline, does not persist anything */
 class BaselineActor(respondAfter: Int) extends Actor {

--- a/bench-jmh/src/main/scala/org/apache/pekko/remote/artery/LiteralEncodingBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/remote/artery/LiteralEncodingBenchmark.scala
@@ -20,7 +20,8 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.util.Unsafe
+import org.apache.pekko
+import pekko.util.Unsafe
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/remote/compress/HeavyHittersBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/remote/compress/HeavyHittersBenchmark.scala
@@ -18,7 +18,8 @@ import java.util.Random
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
-import org.apache.pekko.remote.artery.compress.TopHeavyHitters
+import org.apache.pekko
+import pekko.remote.artery.compress.TopHeavyHitters
 
 /**
  * On Macbook pro:

--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/BroadcastHubBenchRunner.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/BroadcastHubBenchRunner.scala
@@ -22,9 +22,10 @@ import java.util.concurrent.{ CountDownLatch, TimeUnit }
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.remote.artery.{ BenchTestSource, LatchSink }
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.remote.artery.{ BenchTestSource, LatchSink }
+import pekko.stream.scaladsl._
 
 import com.typesafe.config.ConfigFactory
 

--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/BroadcastHubBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/BroadcastHubBenchmark.scala
@@ -24,11 +24,12 @@ import scala.concurrent.duration._
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.remote.artery.{ BenchTestSource, LatchSink }
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream.testkit.scaladsl.StreamTestKit
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.remote.artery.{ BenchTestSource, LatchSink }
+import pekko.stream.scaladsl._
+import pekko.stream.testkit.scaladsl.StreamTestKit
 
 import com.typesafe.config.ConfigFactory
 

--- a/bench-jmh/src/main/scala/org/apache/pekko/stream/GraphStageConstructionBenchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/stream/GraphStageConstructionBenchmark.scala
@@ -30,16 +30,17 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.infra.Blackhole
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.impl.LinearTraversalBuilder
-import org.apache.pekko.stream.impl.Stages.DefaultAttributes
-import org.apache.pekko.stream.impl.fusing.GraphStages
-import org.apache.pekko.stream.impl.fusing.IterableSource
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.stream.scaladsl.Keep
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.stream.stage.GraphStageWithMaterializedValue
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.impl.LinearTraversalBuilder
+import pekko.stream.impl.Stages.DefaultAttributes
+import pekko.stream.impl.fusing.GraphStages
+import pekko.stream.impl.fusing.IterableSource
+import pekko.stream.scaladsl.Flow
+import pekko.stream.scaladsl.Keep
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
+import pekko.stream.stage.GraphStageWithMaterializedValue
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_apply_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_apply_Benchmark.scala
@@ -17,7 +17,8 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.util.ByteString.{ ByteString1, ByteStrings }
+import org.apache.pekko
+import pekko.util.ByteString.{ ByteString1, ByteStrings }
 
 @State(Scope.Benchmark)
 @Measurement(timeUnit = TimeUnit.MILLISECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_asInputStream_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_asInputStream_Benchmark.scala
@@ -23,7 +23,8 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
-import org.apache.pekko.io.UnsynchronizedByteArrayInputStream
+import org.apache.pekko
+import pekko.io.UnsynchronizedByteArrayInputStream
 
 /**
  * Compares ByteString.asInputStream and new ByteStreamArray(ByteString.toArray).

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_concat3way_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_concat3way_Benchmark.scala
@@ -15,7 +15,8 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
-import org.apache.pekko.util.ByteString.{ ByteString1C, ByteString2 }
+import org.apache.pekko
+import pekko.util.ByteString.{ ByteString1C, ByteString2 }
 
 /**
  * Directional benchmark for PR #2924, comparing the two candidate strategies for

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_copyToBuffer_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_copyToBuffer_Benchmark.scala
@@ -18,7 +18,8 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.util.ByteString.{ ByteString1C, ByteStrings }
+import org.apache.pekko
+import pekko.util.ByteString.{ ByteString1C, ByteStrings }
 
 @State(Scope.Benchmark)
 @Measurement(timeUnit = TimeUnit.MILLISECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_decode_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_decode_Benchmark.scala
@@ -18,7 +18,8 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.util.ByteString.{ ByteString1C, ByteStrings }
+import org.apache.pekko
+import pekko.util.ByteString.{ ByteString1C, ByteStrings }
 
 @State(Scope.Benchmark)
 @Measurement(timeUnit = TimeUnit.MILLISECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_dropRight_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_dropRight_Benchmark.scala
@@ -19,7 +19,8 @@ import scala.util.Random
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.util.ByteString.{ ByteString1, ByteStrings }
+import org.apache.pekko
+import pekko.util.ByteString.{ ByteString1, ByteStrings }
 
 @State(Scope.Benchmark)
 @Measurement(timeUnit = TimeUnit.MILLISECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_dropSliceTake_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_dropSliceTake_Benchmark.scala
@@ -17,7 +17,8 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.util.ByteString.{ ByteString1C, ByteStrings }
+import org.apache.pekko
+import pekko.util.ByteString.{ ByteString1C, ByteStrings }
 
 @State(Scope.Benchmark)
 @Measurement(timeUnit = TimeUnit.MILLISECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_drop_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_drop_Benchmark.scala
@@ -19,7 +19,8 @@ import scala.util.Random
 
 import org.openjdk.jmh.annotations._
 
-import org.apache.pekko.util.ByteString.{ ByteString1, ByteStrings }
+import org.apache.pekko
+import pekko.util.ByteString.{ ByteString1, ByteStrings }
 
 @State(Scope.Benchmark)
 @Measurement(timeUnit = TimeUnit.MILLISECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_take_Benchmark.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/ByteString_take_Benchmark.scala
@@ -19,7 +19,8 @@ import scala.util.Random
 
 import org.openjdk.jmh.annotations.{ Benchmark, Measurement, Scope, State }
 
-import org.apache.pekko.util.ByteString.{ ByteString1, ByteStrings }
+import org.apache.pekko
+import pekko.util.ByteString.{ ByteString1, ByteStrings }
 
 @State(Scope.Benchmark)
 @Measurement(timeUnit = TimeUnit.MILLISECONDS)

--- a/bench-jmh/src/main/scala/org/apache/pekko/util/LruBoundedCacheBench.scala
+++ b/bench-jmh/src/main/scala/org/apache/pekko/util/LruBoundedCacheBench.scala
@@ -20,7 +20,8 @@ import scala.util.Random
 
 import org.openjdk.jmh.annotations.{ Param, _ }
 
-import org.apache.pekko.remote.artery.LruBoundedCache
+import org.apache.pekko
+import pekko.remote.artery.LruBoundedCache
 
 @State(Scope.Benchmark)
 @Measurement(timeUnit = TimeUnit.MICROSECONDS)

--- a/cluster-metrics/src/multi-jvm/scala/org/apache/pekko/cluster/metrics/sample/StatsMessages.scala
+++ b/cluster-metrics/src/multi-jvm/scala/org/apache/pekko/cluster/metrics/sample/StatsMessages.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.metrics.sample
 
-import org.apache.pekko.serialization.jackson.CborSerializable
+import org.apache.pekko
+import pekko.serialization.jackson.CborSerializable
 
 //#messages
 final case class StatsJob(text: String) extends CborSerializable

--- a/cluster-metrics/src/multi-jvm/scala/org/apache/pekko/cluster/metrics/sample/StatsSampleSpec.scala
+++ b/cluster-metrics/src/multi-jvm/scala/org/apache/pekko/cluster/metrics/sample/StatsSampleSpec.scala
@@ -21,7 +21,7 @@ import pekko.cluster.ClusterEvent.{ CurrentClusterState, MemberUp }
 import scala.concurrent.duration._
 
 //#MultiNodeConfig
-import org.apache.pekko.remote.testkit.MultiNodeConfig
+import pekko.remote.testkit.MultiNodeConfig
 import com.typesafe.config.ConfigFactory
 
 object StatsSampleSpecConfig extends MultiNodeConfig {
@@ -76,7 +76,6 @@ class StatsSampleSpecMultiJvmNode3 extends StatsSampleSpec
 //#concrete-tests
 
 //#abstract-test
-import org.apache.pekko
 import pekko.remote.testkit.MultiNodeSpec
 import pekko.testkit.ImplicitSender
 import org.scalatest.BeforeAndAfterAll

--- a/cluster-metrics/src/multi-jvm/scala/org/apache/pekko/cluster/metrics/sample/StatsWorker.scala
+++ b/cluster-metrics/src/multi-jvm/scala/org/apache/pekko/cluster/metrics/sample/StatsWorker.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.metrics.sample
 
-import org.apache.pekko.actor.Actor
+import org.apache.pekko
+import pekko.actor.Actor
 
 //#worker
 class StatsWorker extends Actor {

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/EWMASpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/EWMASpec.scala
@@ -18,7 +18,8 @@ import java.util.concurrent.ThreadLocalRandom
 import scala.annotation.nowarn
 import scala.concurrent.duration._
 
-import org.apache.pekko.testkit.{ LongRunningTest, PekkoSpec }
+import org.apache.pekko
+import pekko.testkit.{ LongRunningTest, PekkoSpec }
 
 @nowarn
 class EWMASpec extends PekkoSpec(MetricsConfig.defaultEnabled) with MetricsCollectorFactory {

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingTypedSerializable.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/ClusterShardingTypedSerializable.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.sharding.typed.internal
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/Murmur2.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/internal/Murmur2.scala
@@ -22,7 +22,8 @@ package org.apache.pekko.cluster.sharding.typed.internal
 
 import java.nio.charset.StandardCharsets
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/cluster-sharding-typed/src/test/scala/docs/delivery/PointToPointDocExample.scala
+++ b/cluster-sharding-typed/src/test/scala/docs/delivery/PointToPointDocExample.scala
@@ -17,10 +17,10 @@ import java.util.UUID
 
 import scala.annotation.nowarn
 
-import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko
+import pekko.actor.typed.ActorSystem
 
 //#imports
-import org.apache.pekko
 import pekko.actor.typed.ActorRef
 import pekko.actor.typed.Behavior
 import pekko.actor.typed.delivery.ProducerController

--- a/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/AccountExampleSpec.scala
+++ b/cluster-sharding-typed/src/test/scala/docs/org/apache/pekko/cluster/sharding/typed/AccountExampleSpec.scala
@@ -13,11 +13,11 @@
 
 package docs.org.apache.pekko.cluster.sharding.typed
 
-import org.apache.pekko.Done
+import org.apache.pekko
+import pekko.Done
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
 import pekko.cluster.sharding.typed.scaladsl.ClusterSharding

--- a/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/FlightRecording.scala
+++ b/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/FlightRecording.scala
@@ -12,11 +12,13 @@
  */
 
 package org.apache.pekko.cluster.sharding
+
 import java.lang.invoke.{ MethodHandles, MethodType }
 import java.nio.file.Files
 import java.nio.file.Path
 
-import org.apache.pekko.actor.{ ActorSystem, ExtendedActorSystem }
+import org.apache.pekko
+import pekko.actor.{ ActorSystem, ExtendedActorSystem }
 
 /**
  * This will work on JDK11 and JDK8 built with the enable-jfr flag (8u262+).

--- a/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardedDaemonProcessIdSpec.scala
+++ b/cluster-sharding-typed/src/test/scala/org/apache/pekko/cluster/sharding/typed/internal/ShardedDaemonProcessIdSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.sharding.typed.internal
 
-import org.apache.pekko.cluster.sharding.typed.internal.ShardedDaemonProcessId.DecodedId
+import org.apache.pekko
+import pekko.cluster.sharding.typed.internal.ShardedDaemonProcessId.DecodedId
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardingQueries.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardingQueries.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster.sharding
 
 import scala.concurrent.duration.FiniteDuration
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /** INTERNAL API */
 @InternalApi

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/internal/jfr/Events.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/internal/jfr/Events.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster.sharding.internal.jfr
 
 import jdk.jfr.{ Category, Event, Label, StackTrace, Timespan }
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 // requires jdk.jfr (available since JDK 9, project baseline is Java 17)
 

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/internal/jfr/JFRShardingFlightRecorder.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/internal/jfr/JFRShardingFlightRecorder.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.sharding.internal.jfr
 
-import org.apache.pekko.cluster.sharding.ShardingFlightRecorder
+import org.apache.pekko
+import pekko.cluster.sharding.ShardingFlightRecorder
 
 class JFRShardingFlightRecorder extends ShardingFlightRecorder {
   override def rememberEntityOperation(duration: Long): Unit =

--- a/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/ClusterShardingGracefulShutdownSpec.scala
+++ b/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/ClusterShardingGracefulShutdownSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import org.apache.pekko
-import org.apache.pekko.Done
+import pekko.Done
 import pekko.actor._
 import pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import pekko.cluster.sharding.ShardRegion.{ CurrentRegions, GracefulShutdown }

--- a/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/ClusterShardingIncorrectSetupSpec.scala
+++ b/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/ClusterShardingIncorrectSetupSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.sharding
 
-import org.apache.pekko.testkit._
+import org.apache.pekko
+import pekko.testkit._
 
 object ClusterShardingIncorrectSetupSpecConfig
     extends MultiNodeClusterShardingConfig(

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/RememberEntitiesFailureSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/RememberEntitiesFailureSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 import org.apache.pekko
-import org.apache.pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
+import pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import pekko.Done
 import pekko.actor.{ Actor, ActorLogging, ActorRef, Props, Timers }
 import pekko.cluster.Cluster

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/ShardRegionDataTypesSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/ShardRegionDataTypesSpec.scala
@@ -17,7 +17,8 @@
 
 package org.apache.pekko.cluster.sharding
 
-import org.apache.pekko.cluster.sharding.ShardRegion._
+import org.apache.pekko
+import pekko.cluster.sharding.ShardRegion._
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/CompositeSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/CompositeSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster.sharding.passivation
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.cluster.sharding.ShardRegion
+import org.apache.pekko
+import pekko.cluster.sharding.ShardRegion
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/HillClimbingAdmissionOptimizerSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/HillClimbingAdmissionOptimizerSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.sharding.passivation
 
-import org.apache.pekko.cluster.sharding.internal.HillClimbingAdmissionOptimizer
+import org.apache.pekko
+import pekko.cluster.sharding.internal.HillClimbingAdmissionOptimizer
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/LeastFrequentlyUsedSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/LeastFrequentlyUsedSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster.sharding.passivation
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.cluster.sharding.ShardRegion
+import org.apache.pekko
+import pekko.cluster.sharding.ShardRegion
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/LeastRecentlyUsedSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/LeastRecentlyUsedSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster.sharding.passivation
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.cluster.sharding.ShardRegion
+import org.apache.pekko
+import pekko.cluster.sharding.ShardRegion
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/MostRecentlyUsedSpec.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/MostRecentlyUsedSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster.sharding.passivation
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.cluster.sharding.ShardRegion
+import org.apache.pekko
+import pekko.cluster.sharding.ShardRegion
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/simulator/SimulatorStats.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/simulator/SimulatorStats.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster.sharding.passivation.simulator
 
 import scala.concurrent.Future
 
-import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko
+import pekko.stream.scaladsl.Sink
 
 object SimulatorStats {
   def apply(): Sink[Simulator.Event, Future[ShardingStats]] =

--- a/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/ddata/typed/scaladsl/ReplicatorDocSpec.scala
+++ b/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/ddata/typed/scaladsl/ReplicatorDocSpec.scala
@@ -23,7 +23,6 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 
 // #sample
-import org.apache.pekko
 import pekko.actor.typed.ActorRef
 import pekko.actor.typed.Behavior
 import pekko.actor.typed.scaladsl.Behaviors

--- a/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/ddata/typed/scaladsl/ReplicatorDocSpec.scala
+++ b/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/ddata/typed/scaladsl/ReplicatorDocSpec.scala
@@ -19,6 +19,7 @@ import pekko.cluster.ddata.SelfUniqueAddress
 import pekko.cluster.ddata.typed.scaladsl.DistributedData
 import pekko.cluster.ddata.typed.scaladsl.Replicator
 import pekko.actor.testkit.typed.scaladsl._
+
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
+++ b/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ActorTestKit
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
 import pekko.testkit.SocketUtil
+
 import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec

--- a/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
+++ b/cluster-typed/src/test/scala/docs/org/apache/pekko/cluster/typed/BasicClusterExampleSpec.scala
@@ -22,7 +22,6 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 //#cluster-imports
-import org.apache.pekko
 import pekko.actor.typed._
 import pekko.actor.typed.scaladsl._
 import pekko.cluster.ClusterEvent._

--- a/cluster-typed/src/test/scala/org/apache/pekko/cluster/typed/ClusterDispatcherSelectorSpec.scala
+++ b/cluster-typed/src/test/scala/org/apache/pekko/cluster/typed/ClusterDispatcherSelectorSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.typed
 
-import org.apache.pekko.actor.typed.scaladsl.DispatcherSelectorSpec
+import org.apache.pekko
+import pekko.actor.typed.scaladsl.DispatcherSelectorSpec
 
 import com.typesafe.config.ConfigFactory
 

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterLogClass.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterLogClass.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/cluster/src/main/scala/org/apache/pekko/cluster/Gossip.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/Gossip.scala
@@ -22,7 +22,8 @@ import scala.concurrent.duration.Deadline
 import ClusterSettings.DataCenter
 import MemberStatus._
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/AppVersionSpec.scala
+++ b/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/AppVersionSpec.scala
@@ -16,8 +16,9 @@ package org.apache.pekko.cluster
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-import org.apache.pekko.remote.testkit.MultiNodeConfig
-import org.apache.pekko.util.Version
+import org.apache.pekko
+import pekko.remote.testkit.MultiNodeConfig
+import pekko.util.Version
 
 object AppVersionMultiJvmSpec extends MultiNodeConfig {
   val first = role("first")

--- a/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/MultiDcLastNodeSpec.scala
+++ b/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/MultiDcLastNodeSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.remote.testkit.MultiNodeConfig
+import org.apache.pekko
+import pekko.remote.testkit.MultiNodeConfig
 
 import com.typesafe.config.ConfigFactory
 

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterDomainEventSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterDomainEventSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster
 
 import scala.collection.immutable.SortedSet
 
-import org.apache.pekko.actor.Address
+import org.apache.pekko
+import pekko.actor.Address
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers

--- a/cluster/src/test/scala/org/apache/pekko/cluster/HeartbeatNodeRingPerfSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/HeartbeatNodeRingPerfSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster
 
-import org.apache.pekko.actor.Address
+import org.apache.pekko
+import pekko.actor.Address
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/cluster/src/test/scala/org/apache/pekko/cluster/HeartbeatNodeRingSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/HeartbeatNodeRingSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster
 
-import org.apache.pekko.actor.Address
+import org.apache.pekko
+import pekko.actor.Address
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/cluster/src/test/scala/org/apache/pekko/cluster/JoinConfigCompatCheckerSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/JoinConfigCompatCheckerSpec.scala
@@ -16,7 +16,8 @@ package org.apache.pekko.cluster
 import scala.collection.{ immutable => im }
 import scala.concurrent.duration._
 
-import org.apache.pekko.testkit.{ LongRunningTest, PekkoSpec }
+import org.apache.pekko
+import pekko.testkit.{ LongRunningTest, PekkoSpec }
 
 import com.typesafe.config.{ Config, ConfigFactory }
 

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ReachabilityPerfSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ReachabilityPerfSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster
 
 import scala.annotation.nowarn
 
-import org.apache.pekko.actor.Address
+import org.apache.pekko
+import pekko.actor.Address
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ReachabilitySpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ReachabilitySpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster
 
-import org.apache.pekko.actor.Address
+import org.apache.pekko
+import pekko.actor.Address
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/cluster/src/test/scala/org/apache/pekko/cluster/VectorClockSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/VectorClockSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.cluster
 
 import scala.collection.immutable.TreeMap
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 class VectorClockSpec extends PekkoSpec {
   import VectorClock._

--- a/cluster/src/test/scala/org/apache/pekko/cluster/sbr/LeaseMajoritySpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/sbr/LeaseMajoritySpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.sbr
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 import org.scalatest.concurrent.Eventually
 

--- a/discovery/src/test/scala/doc/org/apache/pekko/discovery/CompileOnlySpec.scala
+++ b/discovery/src/test/scala/doc/org/apache/pekko/discovery/CompileOnlySpec.scala
@@ -14,7 +14,6 @@
 package doc.org.apache.pekko.discovery
 
 import org.apache.pekko
-
 import pekko.actor.ActorSystem
 
 import scala.concurrent.Future

--- a/discovery/src/test/scala/doc/org/apache/pekko/discovery/CompileOnlySpec.scala
+++ b/discovery/src/test/scala/doc/org/apache/pekko/discovery/CompileOnlySpec.scala
@@ -13,7 +13,9 @@
 
 package doc.org.apache.pekko.discovery
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+
+import pekko.actor.ActorSystem
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/EstimatedSize.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/EstimatedSize.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.ddata
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API: Rough estimate in bytes of some serialized data elements. Used

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/FastMerge.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/FastMerge.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.ddata
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/Key.scala
+++ b/distributed-data/src/main/scala/org/apache/pekko/cluster/ddata/Key.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.ddata
 
-import org.apache.pekko.cluster.ddata.Key.UnspecificKey
+import org.apache.pekko
+import pekko.cluster.ddata.Key.UnspecificKey
 
 object Key {
 

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/STMultiNodeSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/STMultiNodeSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.ddata
 
-import org.apache.pekko.remote.testkit.MultiNodeSpecCallbacks
+import org.apache.pekko
+import pekko.remote.testkit.MultiNodeSpecCallbacks
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers

--- a/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/WildcardSubscribeSpec.scala
+++ b/distributed-data/src/multi-jvm/scala/org/apache/pekko/cluster/ddata/WildcardSubscribeSpec.scala
@@ -15,11 +15,12 @@ package org.apache.pekko.cluster.ddata
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.cluster.Cluster
-import org.apache.pekko.remote.testconductor.RoleName
-import org.apache.pekko.remote.testkit.MultiNodeConfig
-import org.apache.pekko.remote.testkit.MultiNodeSpec
-import org.apache.pekko.testkit._
+import org.apache.pekko
+import pekko.cluster.Cluster
+import pekko.remote.testconductor.RoleName
+import pekko.remote.testkit.MultiNodeConfig
+import pekko.remote.testkit.MultiNodeSpec
+import pekko.testkit._
 
 import com.typesafe.config.ConfigFactory
 

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/FlagSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/FlagSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.ddata
 
-import org.apache.pekko.cluster.ddata.Replicator.Changed
+import org.apache.pekko
+import pekko.cluster.ddata.Replicator.Changed
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/GSetSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/GSetSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.ddata
 
-import org.apache.pekko.cluster.ddata.Replicator.Changed
+import org.apache.pekko
+import pekko.cluster.ddata.Replicator.Changed
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ReplicatorSettingsSpec.scala
+++ b/distributed-data/src/test/scala/org/apache/pekko/cluster/ddata/ReplicatorSettingsSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.cluster.ddata
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike

--- a/docs/src/test/scala/docs/actor/ActorDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/ActorDocSpec.scala
@@ -334,7 +334,7 @@ final case class Give(thing: Any)
 
 //#receive-orElse
 
-import org.apache.pekko.actor.{ Actor, ActorRef, ActorSystem, PoisonPill, Props }
+import pekko.actor.{ Actor, ActorRef, ActorSystem, PoisonPill, Props }
 import scala.concurrent.duration._
 
 case object Ping

--- a/docs/src/test/scala/docs/actor/FSMDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/FSMDocSpec.scala
@@ -13,11 +13,11 @@
 
 package docs.actor
 
-import org.apache.pekko.testkit.{ PekkoSpec => MyFavoriteTestFrameWorkPlusPekkoTestKit }
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.testkit.{ PekkoSpec => MyFavoriteTestFrameWorkPlusPekkoTestKit }
+import pekko.util.ByteString
 
 //#test-code
-import org.apache.pekko
 import pekko.actor.Props
 import scala.collection.immutable
 

--- a/docs/src/test/scala/docs/actor/FaultHandlingDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/FaultHandlingDocSpec.scala
@@ -14,8 +14,8 @@
 package docs.actor
 
 import org.apache.pekko
-
 import pekko.actor.{ ActorRef, ActorSystem, Props, Terminated }
+
 import FaultHandlingDocSpec._
 
 //#testkit

--- a/docs/src/test/scala/docs/actor/FaultHandlingDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/FaultHandlingDocSpec.scala
@@ -13,7 +13,9 @@
 
 package docs.actor
 
-import org.apache.pekko.actor.{ ActorRef, ActorSystem, Props, Terminated }
+import org.apache.pekko
+
+import pekko.actor.{ ActorRef, ActorSystem, Props, Terminated }
 import FaultHandlingDocSpec._
 
 //#testkit
@@ -21,7 +23,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.apache.pekko.testkit.{ EventFilter, ImplicitSender, TestKit }
+import pekko.testkit.{ EventFilter, ImplicitSender, TestKit }
 
 //#testkit
 object FaultHandlingDocSpec {

--- a/docs/src/test/scala/docs/actor/InitializationDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/InitializationDocSpec.scala
@@ -13,8 +13,9 @@
 
 package docs.actor
 
-import org.apache.pekko.actor.{ Actor, Props }
-import org.apache.pekko.testkit.{ ImplicitSender, PekkoSpec }
+import org.apache.pekko
+import pekko.actor.{ Actor, Props }
+import pekko.testkit.{ ImplicitSender, PekkoSpec }
 
 object InitializationDocSpec {
 

--- a/docs/src/test/scala/docs/actor/PropsEdgeCaseSpec.scala
+++ b/docs/src/test/scala/docs/actor/PropsEdgeCaseSpec.scala
@@ -13,7 +13,8 @@
 
 package docs.actor
 
-import org.apache.pekko.actor.{ Actor, Props }
+import org.apache.pekko
+import pekko.actor.{ Actor, Props }
 import docs.CompileOnlySpec
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/docs/src/test/scala/docs/actor/PropsEdgeCaseSpec.scala
+++ b/docs/src/test/scala/docs/actor/PropsEdgeCaseSpec.scala
@@ -15,6 +15,7 @@ package docs.actor
 
 import org.apache.pekko
 import pekko.actor.{ Actor, Props }
+
 import docs.CompileOnlySpec
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/docs/src/test/scala/docs/actor/UnnestedReceives.scala
+++ b/docs/src/test/scala/docs/actor/UnnestedReceives.scala
@@ -15,6 +15,7 @@ package docs.actor
 
 import org.apache.pekko
 import pekko.actor._
+
 import scala.collection.mutable.ListBuffer
 
 /**

--- a/docs/src/test/scala/docs/actor/UnnestedReceives.scala
+++ b/docs/src/test/scala/docs/actor/UnnestedReceives.scala
@@ -13,7 +13,8 @@
 
 package docs.actor
 
-import org.apache.pekko.actor._
+import org.apache.pekko
+import pekko.actor._
 import scala.collection.mutable.ListBuffer
 
 /**

--- a/docs/src/test/scala/docs/actor/typed/BlockingDispatcherSample.scala
+++ b/docs/src/test/scala/docs/actor/typed/BlockingDispatcherSample.scala
@@ -13,8 +13,9 @@
 
 package docs.actor.typed
 
-import org.apache.pekko.actor.typed._
-import org.apache.pekko.actor.typed.scaladsl._
+import org.apache.pekko
+import pekko.actor.typed._
+import pekko.actor.typed.scaladsl._
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.{ ExecutionContext, Future }

--- a/docs/src/test/scala/docs/actor/typed/BlockingDispatcherSample.scala
+++ b/docs/src/test/scala/docs/actor/typed/BlockingDispatcherSample.scala
@@ -16,6 +16,7 @@ package docs.actor.typed
 import org.apache.pekko
 import pekko.actor.typed._
 import pekko.actor.typed.scaladsl._
+
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.{ ExecutionContext, Future }

--- a/docs/src/test/scala/docs/actor/typed/CoordinatedActorShutdownSpec.scala
+++ b/docs/src/test/scala/docs/actor/typed/CoordinatedActorShutdownSpec.scala
@@ -13,12 +13,13 @@
 
 package docs.actor.typed
 
-import org.apache.pekko.Done
-import org.apache.pekko.actor.{ Cancellable, CoordinatedShutdown }
-import org.apache.pekko.actor.typed.{ ActorRef, ActorSystem, Behavior }
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
-import org.apache.pekko.actor.typed.scaladsl.AskPattern._
-import org.apache.pekko.util.Timeout
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.{ Cancellable, CoordinatedShutdown }
+import pekko.actor.typed.{ ActorRef, ActorSystem, Behavior }
+import pekko.actor.typed.scaladsl.Behaviors
+import pekko.actor.typed.scaladsl.AskPattern._
+import pekko.util.Timeout
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/actor/typed/DispatcherDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/typed/DispatcherDocSpec.scala
@@ -13,7 +13,8 @@
 
 package docs.actor.typed
 
-import org.apache.pekko.actor.typed.scaladsl.ActorContext
+import org.apache.pekko
+import pekko.actor.typed.scaladsl.ActorContext
 
 object DispatcherDocSpec {
 

--- a/docs/src/test/scala/docs/actor/typed/PrintActor.scala
+++ b/docs/src/test/scala/docs/actor/typed/PrintActor.scala
@@ -13,8 +13,9 @@
 
 package docs.actor.typed
 
-import org.apache.pekko.actor.typed.Behavior
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko
+import pekko.actor.typed.Behavior
+import pekko.actor.typed.scaladsl.Behaviors
 
 // #print-actor
 object PrintActor {

--- a/docs/src/test/scala/docs/actor/typed/SharedMutableStateDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/typed/SharedMutableStateDocSpec.scala
@@ -13,9 +13,10 @@
 
 package docs.actor.typed
 
-import org.apache.pekko.actor.typed.scaladsl._
-import org.apache.pekko.actor.typed.{ ActorRef, Behavior }
-import org.apache.pekko.util.Timeout
+import org.apache.pekko
+import pekko.actor.typed.scaladsl._
+import pekko.actor.typed.{ ActorRef, Behavior }
+import pekko.util.Timeout
 
 import scala.collection.mutable
 import scala.concurrent.Future

--- a/docs/src/test/scala/docs/cluster/ClusterDocSpec.scala
+++ b/docs/src/test/scala/docs/cluster/ClusterDocSpec.scala
@@ -14,10 +14,9 @@
 package scala.docs.cluster
 
 import org.apache.pekko
-
 import pekko.cluster.Cluster
-
 import pekko.testkit.PekkoSpec
+
 import docs.CompileOnlySpec
 
 object ClusterDocSpec {

--- a/docs/src/test/scala/docs/cluster/ClusterDocSpec.scala
+++ b/docs/src/test/scala/docs/cluster/ClusterDocSpec.scala
@@ -13,9 +13,11 @@
 
 package scala.docs.cluster
 
-import org.apache.pekko.cluster.Cluster
+import org.apache.pekko
 
-import org.apache.pekko.testkit.PekkoSpec
+import pekko.cluster.Cluster
+
+import pekko.testkit.PekkoSpec
 import docs.CompileOnlySpec
 
 object ClusterDocSpec {

--- a/docs/src/test/scala/docs/cluster/FactorialBackend.scala
+++ b/docs/src/test/scala/docs/cluster/FactorialBackend.scala
@@ -16,11 +16,12 @@ package scala.docs.cluster
 import scala.annotation.tailrec
 import scala.concurrent.Future
 import com.typesafe.config.ConfigFactory
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.ActorLogging
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.actor.Props
-import org.apache.pekko.pattern.pipe
+import org.apache.pekko
+import pekko.actor.Actor
+import pekko.actor.ActorLogging
+import pekko.actor.ActorSystem
+import pekko.actor.Props
+import pekko.pattern.pipe
 
 //#backend
 class FactorialBackend extends Actor with ActorLogging {

--- a/docs/src/test/scala/docs/cluster/FactorialFrontend.scala
+++ b/docs/src/test/scala/docs/cluster/FactorialFrontend.scala
@@ -14,9 +14,6 @@
 package scala.docs.cluster
 
 import org.apache.pekko
-
-import scala.concurrent.duration._
-import com.typesafe.config.ConfigFactory
 import pekko.actor.Actor
 import pekko.actor.ActorLogging
 import pekko.actor.ActorSystem
@@ -24,6 +21,9 @@ import pekko.actor.Props
 import pekko.cluster.Cluster
 import pekko.routing.FromConfig
 import pekko.actor.ReceiveTimeout
+
+import scala.concurrent.duration._
+import com.typesafe.config.ConfigFactory
 import scala.util.Try
 import scala.concurrent.Await
 

--- a/docs/src/test/scala/docs/cluster/FactorialFrontend.scala
+++ b/docs/src/test/scala/docs/cluster/FactorialFrontend.scala
@@ -13,15 +13,17 @@
 
 package scala.docs.cluster
 
+import org.apache.pekko
+
 import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.ActorLogging
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.actor.Props
-import org.apache.pekko.cluster.Cluster
-import org.apache.pekko.routing.FromConfig
-import org.apache.pekko.actor.ReceiveTimeout
+import pekko.actor.Actor
+import pekko.actor.ActorLogging
+import pekko.actor.ActorSystem
+import pekko.actor.Props
+import pekko.cluster.Cluster
+import pekko.routing.FromConfig
+import pekko.actor.ReceiveTimeout
 import scala.util.Try
 import scala.concurrent.Await
 

--- a/docs/src/test/scala/docs/cluster/SimpleClusterListener2.scala
+++ b/docs/src/test/scala/docs/cluster/SimpleClusterListener2.scala
@@ -13,9 +13,10 @@
 
 package docs.cluster
 
-import org.apache.pekko.actor.{ Actor, ActorLogging }
-import org.apache.pekko.cluster.Cluster
-import org.apache.pekko.cluster.ClusterEvent._
+import org.apache.pekko
+import pekko.actor.{ Actor, ActorLogging }
+import pekko.cluster.Cluster
+import pekko.cluster.ClusterEvent._
 
 class SimpleClusterListener2 extends Actor with ActorLogging {
 

--- a/docs/src/test/scala/docs/cluster/TransformationBackend.scala
+++ b/docs/src/test/scala/docs/cluster/TransformationBackend.scala
@@ -14,16 +14,17 @@
 package scala.docs.cluster
 
 import scala.concurrent.duration._
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.actor.Props
-import org.apache.pekko.actor.RootActorPath
-import org.apache.pekko.cluster.Cluster
-import org.apache.pekko.cluster.ClusterEvent.CurrentClusterState
-import org.apache.pekko.cluster.ClusterEvent.MemberUp
-import org.apache.pekko.cluster.Member
-import org.apache.pekko.cluster.MemberStatus
+import org.apache.pekko
+import pekko.actor.Actor
+import pekko.actor.ActorRef
+import pekko.actor.ActorSystem
+import pekko.actor.Props
+import pekko.actor.RootActorPath
+import pekko.cluster.Cluster
+import pekko.cluster.ClusterEvent.CurrentClusterState
+import pekko.cluster.ClusterEvent.MemberUp
+import pekko.cluster.Member
+import pekko.cluster.MemberStatus
 import com.typesafe.config.ConfigFactory
 
 //#backend

--- a/docs/src/test/scala/docs/cluster/TransformationBackend.scala
+++ b/docs/src/test/scala/docs/cluster/TransformationBackend.scala
@@ -25,6 +25,7 @@ import pekko.cluster.ClusterEvent.CurrentClusterState
 import pekko.cluster.ClusterEvent.MemberUp
 import pekko.cluster.Member
 import pekko.cluster.MemberStatus
+
 import com.typesafe.config.ConfigFactory
 
 //#backend

--- a/docs/src/test/scala/docs/cluster/TransformationFrontend.scala
+++ b/docs/src/test/scala/docs/cluster/TransformationFrontend.scala
@@ -23,6 +23,7 @@ import pekko.actor.Props
 import pekko.actor.Terminated
 import pekko.pattern.ask
 import pekko.util.Timeout
+
 import com.typesafe.config.ConfigFactory
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/docs/src/test/scala/docs/cluster/TransformationFrontend.scala
+++ b/docs/src/test/scala/docs/cluster/TransformationFrontend.scala
@@ -15,13 +15,14 @@ package scala.docs.cluster
 
 import scala.util.Success
 import scala.concurrent.duration._
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.actor.Props
-import org.apache.pekko.actor.Terminated
-import org.apache.pekko.pattern.ask
-import org.apache.pekko.util.Timeout
+import org.apache.pekko
+import pekko.actor.Actor
+import pekko.actor.ActorRef
+import pekko.actor.ActorSystem
+import pekko.actor.Props
+import pekko.actor.Terminated
+import pekko.pattern.ask
+import pekko.util.Timeout
 import com.typesafe.config.ConfigFactory
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/docs/src/test/scala/docs/cluster/singleton/ClusterSingletonSupervision.scala
+++ b/docs/src/test/scala/docs/cluster/singleton/ClusterSingletonSupervision.scala
@@ -13,8 +13,10 @@
 
 package docs.cluster.singleton
 
+import org.apache.pekko
+
 //#singleton-supervisor-actor
-import org.apache.pekko.actor.{ Actor, Props, SupervisorStrategy }
+import pekko.actor.{ Actor, Props, SupervisorStrategy }
 class SupervisorActor(childProps: Props, override val supervisorStrategy: SupervisorStrategy) extends Actor {
   val child = context.actorOf(childProps, "supervised-child")
 
@@ -24,7 +26,7 @@ class SupervisorActor(childProps: Props, override val supervisorStrategy: Superv
 }
 //#singleton-supervisor-actor
 
-import org.apache.pekko.actor.Actor
+import pekko.actor.Actor
 abstract class ClusterSingletonSupervision extends Actor {
   import org.apache.pekko.actor.{ ActorRef, Props, SupervisorStrategy }
   def createSingleton(name: String, props: Props, supervisorStrategy: SupervisorStrategy): ActorRef = {

--- a/docs/src/test/scala/docs/config/ConfigDocSpec.scala
+++ b/docs/src/test/scala/docs/config/ConfigDocSpec.scala
@@ -16,6 +16,7 @@ package docs.config
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ActorTestKit
 import pekko.actor.typed.scaladsl.Behaviors
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/docs/src/test/scala/docs/config/ConfigDocSpec.scala
+++ b/docs/src/test/scala/docs/config/ConfigDocSpec.scala
@@ -13,13 +13,14 @@
 
 package docs.config
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ActorTestKit
+import pekko.actor.typed.scaladsl.Behaviors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 //#imports
-import org.apache.pekko.actor.typed.ActorSystem
+import pekko.actor.typed.ActorSystem
 import com.typesafe.config.ConfigFactory
 //#imports
 

--- a/docs/src/test/scala/docs/coordination/LeaseDocSpec.scala
+++ b/docs/src/test/scala/docs/coordination/LeaseDocSpec.scala
@@ -17,11 +17,12 @@ import scala.concurrent.Future
 
 import com.typesafe.config.ConfigFactory
 
-import org.apache.pekko.cluster.Cluster
-import org.apache.pekko.coordination.lease.LeaseSettings
-import org.apache.pekko.coordination.lease.scaladsl.Lease
-import org.apache.pekko.coordination.lease.scaladsl.LeaseProvider
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.cluster.Cluster
+import pekko.coordination.lease.LeaseSettings
+import pekko.coordination.lease.scaladsl.Lease
+import pekko.coordination.lease.scaladsl.LeaseProvider
+import pekko.testkit.PekkoSpec
 
 //#lease-example
 class SampleLease(settings: LeaseSettings) extends Lease(settings) {

--- a/docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
+++ b/docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
@@ -14,15 +14,14 @@
 package docs.ddata
 
 import org.apache.pekko
-
-import scala.concurrent.duration._
-
 import pekko.actor.Actor
 import pekko.cluster.ddata._
 import pekko.testkit.PekkoSpec
 import pekko.testkit.TestProbe
 import pekko.actor.ActorRef
 import pekko.serialization.SerializationExtension
+
+import scala.concurrent.duration._
 import jdocs.ddata
 
 object DistributedDataDocSpec {

--- a/docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
+++ b/docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
@@ -13,14 +13,16 @@
 
 package docs.ddata
 
+import org.apache.pekko
+
 import scala.concurrent.duration._
 
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.cluster.ddata._
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.testkit.TestProbe
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.serialization.SerializationExtension
+import pekko.actor.Actor
+import pekko.cluster.ddata._
+import pekko.testkit.PekkoSpec
+import pekko.testkit.TestProbe
+import pekko.actor.ActorRef
+import pekko.serialization.SerializationExtension
 import jdocs.ddata
 
 object DistributedDataDocSpec {

--- a/docs/src/test/scala/docs/ddata/ShoppingCart.scala
+++ b/docs/src/test/scala/docs/ddata/ShoppingCart.scala
@@ -15,13 +15,14 @@ package scala.docs.ddata
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.actor.Props
-import org.apache.pekko.cluster.ddata.DistributedData
-import org.apache.pekko.cluster.ddata.LWWMap
-import org.apache.pekko.cluster.ddata.LWWMapKey
-import org.apache.pekko.cluster.ddata.SelfUniqueAddress
+import org.apache.pekko
+import pekko.actor.Actor
+import pekko.actor.ActorRef
+import pekko.actor.Props
+import pekko.cluster.ddata.DistributedData
+import pekko.cluster.ddata.LWWMap
+import pekko.cluster.ddata.LWWMapKey
+import pekko.cluster.ddata.SelfUniqueAddress
 
 object ShoppingCart {
   import org.apache.pekko.cluster.ddata.Replicator._

--- a/docs/src/test/scala/docs/ddata/TwoPhaseSet.scala
+++ b/docs/src/test/scala/docs/ddata/TwoPhaseSet.scala
@@ -13,8 +13,9 @@
 
 package docs.ddata
 
-import org.apache.pekko.cluster.ddata.ReplicatedData
-import org.apache.pekko.cluster.ddata.GSet
+import org.apache.pekko
+import pekko.cluster.ddata.ReplicatedData
+import pekko.cluster.ddata.GSet
 
 //#twophaseset
 case class TwoPhaseSet(adds: GSet[String] = GSet.empty, removals: GSet[String] = GSet.empty) extends ReplicatedData {

--- a/docs/src/test/scala/docs/discovery/DnsDiscoveryDocSpec.scala
+++ b/docs/src/test/scala/docs/discovery/DnsDiscoveryDocSpec.scala
@@ -14,8 +14,8 @@
 package docs.discovery
 
 import org.apache.pekko
-
 import pekko.testkit.PekkoSpec
+
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/discovery/DnsDiscoveryDocSpec.scala
+++ b/docs/src/test/scala/docs/discovery/DnsDiscoveryDocSpec.scala
@@ -13,7 +13,9 @@
 
 package docs.discovery
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+
+import pekko.testkit.PekkoSpec
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
+++ b/docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
@@ -14,7 +14,6 @@
 package docs.dispatcher
 
 import org.apache.pekko
-
 import pekko.testkit.PekkoSpec
 import pekko.event.Logging
 import pekko.event.LoggingAdapter

--- a/docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
+++ b/docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
@@ -13,10 +13,12 @@
 
 package docs.dispatcher
 
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.event.Logging
-import org.apache.pekko.event.LoggingAdapter
-import org.apache.pekko.actor._
+import org.apache.pekko
+
+import pekko.testkit.PekkoSpec
+import pekko.event.Logging
+import pekko.event.LoggingAdapter
+import pekko.actor._
 
 object DispatcherDocSpec {
   val javaConfig = """

--- a/docs/src/test/scala/docs/event/EventBusDocSpec.scala
+++ b/docs/src/test/scala/docs/event/EventBusDocSpec.scala
@@ -14,11 +14,11 @@
 package docs.event
 
 import org.apache.pekko
-
-import scala.concurrent.duration._
 import pekko.testkit.PekkoSpec
 import pekko.actor.{ ActorRef, ActorSystem }
 import pekko.testkit.TestProbe
+
+import scala.concurrent.duration._
 
 object EventBusDocSpec {
 

--- a/docs/src/test/scala/docs/event/EventBusDocSpec.scala
+++ b/docs/src/test/scala/docs/event/EventBusDocSpec.scala
@@ -13,10 +13,12 @@
 
 package docs.event
 
+import org.apache.pekko
+
 import scala.concurrent.duration._
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.actor.{ ActorRef, ActorSystem }
-import org.apache.pekko.testkit.TestProbe
+import pekko.testkit.PekkoSpec
+import pekko.actor.{ ActorRef, ActorSystem }
+import pekko.testkit.TestProbe
 
 object EventBusDocSpec {
 

--- a/docs/src/test/scala/docs/extension/ExtensionDocSpec.scala
+++ b/docs/src/test/scala/docs/extension/ExtensionDocSpec.scala
@@ -15,12 +15,13 @@ package docs.extension
 
 import java.util.concurrent.atomic.AtomicLong
 
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.ClassicActorSystemProvider
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.actor.Actor
+import pekko.actor.ClassicActorSystemProvider
+import pekko.testkit.PekkoSpec
 
 //#extension
-import org.apache.pekko.actor.Extension
+import pekko.actor.Extension
 
 class CountExtensionImpl extends Extension {
   // Since this Extension is a shared instance
@@ -33,7 +34,6 @@ class CountExtensionImpl extends Extension {
 //#extension
 
 //#extensionid
-import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.actor.ExtensionId
 import pekko.actor.ExtensionIdProvider

--- a/docs/src/test/scala/docs/extension/SettingsExtensionDocSpec.scala
+++ b/docs/src/test/scala/docs/extension/SettingsExtensionDocSpec.scala
@@ -29,8 +29,8 @@ import pekko.actor.ClassicActorSystemProvider
 
 //#imports
 
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.testkit.PekkoSpec
+import pekko.actor.Actor
+import pekko.testkit.PekkoSpec
 
 //#extension
 class SettingsImpl(config: Config) extends Extension {

--- a/docs/src/test/scala/docs/faq/Faq.scala
+++ b/docs/src/test/scala/docs/faq/Faq.scala
@@ -13,7 +13,8 @@
 
 package docs.faq
 
-import org.apache.pekko.actor.Actor
+import org.apache.pekko
+import pekko.actor.Actor
 
 //#exhaustiveness-check
 object MyActor {

--- a/docs/src/test/scala/docs/io/IODocSpec.scala
+++ b/docs/src/test/scala/docs/io/IODocSpec.scala
@@ -21,7 +21,7 @@ import pekko.util.ByteString
 import java.net.InetSocketAddress
 //#imports
 
-import org.apache.pekko.testkit.PekkoSpec
+import pekko.testkit.PekkoSpec
 import scala.concurrent.duration._
 
 class DemoActor extends Actor {

--- a/docs/src/test/scala/docs/io/IODocSpec.scala
+++ b/docs/src/test/scala/docs/io/IODocSpec.scala
@@ -18,6 +18,7 @@ import org.apache.pekko
 import pekko.actor.{ Actor, ActorRef, Props }
 import pekko.io.{ IO, Tcp }
 import pekko.util.ByteString
+
 import java.net.InetSocketAddress
 //#imports
 

--- a/docs/src/test/scala/docs/io/ReadBackPressure.scala
+++ b/docs/src/test/scala/docs/io/ReadBackPressure.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.actor.{ Actor, ActorLogging, ActorRef, ActorSystem, Props }
 import pekko.io.Tcp._
 import pekko.io.{ IO, Tcp }
+
 import java.net.InetSocketAddress
 import pekko.testkit.{ ImplicitSender, PekkoSpec, TestProbe }
 import pekko.util.ByteString

--- a/docs/src/test/scala/docs/io/ReadBackPressure.scala
+++ b/docs/src/test/scala/docs/io/ReadBackPressure.scala
@@ -13,12 +13,13 @@
 
 package docs.io
 
-import org.apache.pekko.actor.{ Actor, ActorLogging, ActorRef, ActorSystem, Props }
-import org.apache.pekko.io.Tcp._
-import org.apache.pekko.io.{ IO, Tcp }
+import org.apache.pekko
+import pekko.actor.{ Actor, ActorLogging, ActorRef, ActorSystem, Props }
+import pekko.io.Tcp._
+import pekko.io.{ IO, Tcp }
 import java.net.InetSocketAddress
-import org.apache.pekko.testkit.{ ImplicitSender, PekkoSpec, TestProbe }
-import org.apache.pekko.util.ByteString
+import pekko.testkit.{ ImplicitSender, PekkoSpec, TestProbe }
+import pekko.util.ByteString
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration

--- a/docs/src/test/scala/docs/io/ScalaUdpMulticast.scala
+++ b/docs/src/test/scala/docs/io/ScalaUdpMulticast.scala
@@ -18,10 +18,11 @@ import java.net.DatagramSocket
 import java.nio.channels.DatagramChannel
 import java.nio.charset.StandardCharsets
 
-import org.apache.pekko.actor.{ Actor, ActorLogging, ActorRef }
-import org.apache.pekko.io.Inet.{ DatagramChannelCreator, SocketOptionV2 }
-import org.apache.pekko.io.{ IO, Udp }
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.actor.{ Actor, ActorLogging, ActorRef }
+import pekko.io.Inet.{ DatagramChannelCreator, SocketOptionV2 }
+import pekko.io.{ IO, Udp }
+import pekko.util.ByteString
 
 //#inet6-protocol-family
 final case class Inet6ProtocolFamily() extends DatagramChannelCreator {

--- a/docs/src/test/scala/docs/io/ScalaUdpMulticastSpec.scala
+++ b/docs/src/test/scala/docs/io/ScalaUdpMulticastSpec.scala
@@ -16,11 +16,12 @@ package docs.io
 import java.net.Inet6Address
 import java.net.NetworkInterface
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.actor.Props
-import org.apache.pekko.io.Udp
-import org.apache.pekko.testkit.SocketUtil
-import org.apache.pekko.testkit.TestKit
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.actor.Props
+import pekko.io.Udp
+import pekko.testkit.SocketUtil
+import pekko.testkit.TestKit
 import scala.jdk.CollectionConverters._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers

--- a/docs/src/test/scala/docs/io/ScalaUdpMulticastSpec.scala
+++ b/docs/src/test/scala/docs/io/ScalaUdpMulticastSpec.scala
@@ -22,6 +22,7 @@ import pekko.actor.Props
 import pekko.io.Udp
 import pekko.testkit.SocketUtil
 import pekko.testkit.TestKit
+
 import scala.jdk.CollectionConverters._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers

--- a/docs/src/test/scala/docs/io/UdpDocSpec.scala
+++ b/docs/src/test/scala/docs/io/UdpDocSpec.scala
@@ -19,6 +19,7 @@ import pekko.actor.Actor
 import pekko.io.IO
 import pekko.io.Udp
 import pekko.actor.ActorRef
+
 import java.net.InetSocketAddress
 import pekko.util.ByteString
 import pekko.testkit.TestProbe

--- a/docs/src/test/scala/docs/io/UdpDocSpec.scala
+++ b/docs/src/test/scala/docs/io/UdpDocSpec.scala
@@ -13,18 +13,19 @@
 
 package docs.io
 
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.io.IO
-import org.apache.pekko.io.Udp
-import org.apache.pekko.actor.ActorRef
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
+import pekko.actor.Actor
+import pekko.io.IO
+import pekko.io.Udp
+import pekko.actor.ActorRef
 import java.net.InetSocketAddress
-import org.apache.pekko.util.ByteString
-import org.apache.pekko.testkit.TestProbe
-import org.apache.pekko.actor.Props
+import pekko.util.ByteString
+import pekko.testkit.TestProbe
+import pekko.actor.Props
 import scala.concurrent.duration._
-import org.apache.pekko.actor.PoisonPill
-import org.apache.pekko.io.UdpConnected
+import pekko.actor.PoisonPill
+import pekko.io.UdpConnected
 
 object ScalaUdpDocSpec {
 

--- a/docs/src/test/scala/docs/pattern/BackoffSupervisorDocSpec.scala
+++ b/docs/src/test/scala/docs/pattern/BackoffSupervisorDocSpec.scala
@@ -13,10 +13,11 @@
 
 package docs.pattern
 
-import org.apache.pekko.actor.{ ActorContext, ActorSystem, OneForOneStrategy, Props, SupervisorStrategy }
-import org.apache.pekko.cluster.sharding.ShardRegion.Passivate
-import org.apache.pekko.pattern.{ BackoffOpts, BackoffSupervisor }
-import org.apache.pekko.testkit.TestActors.EchoActor
+import org.apache.pekko
+import pekko.actor.{ ActorContext, ActorSystem, OneForOneStrategy, Props, SupervisorStrategy }
+import pekko.cluster.sharding.ShardRegion.Passivate
+import pekko.pattern.{ BackoffOpts, BackoffSupervisor }
+import pekko.testkit.TestActors.EchoActor
 
 class BackoffSupervisorDocSpec {
 

--- a/docs/src/test/scala/docs/persistence/PersistenceDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceDocSpec.scala
@@ -13,9 +13,11 @@
 
 package docs.persistence
 
-import org.apache.pekko.actor._
-import org.apache.pekko.pattern.{ BackoffOpts, BackoffSupervisor }
-import org.apache.pekko.persistence._
+import org.apache.pekko
+
+import pekko.actor._
+import pekko.pattern.{ BackoffOpts, BackoffSupervisor }
+import pekko.persistence._
 
 import scala.concurrent.duration._
 

--- a/docs/src/test/scala/docs/persistence/PersistenceDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceDocSpec.scala
@@ -14,7 +14,6 @@
 package docs.persistence
 
 import org.apache.pekko
-
 import pekko.actor._
 import pekko.pattern.{ BackoffOpts, BackoffSupervisor }
 import pekko.persistence._

--- a/docs/src/test/scala/docs/persistence/PersistenceEventAdapterDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceEventAdapterDocSpec.scala
@@ -13,10 +13,11 @@
 
 package docs.persistence
 
-import org.apache.pekko.actor.{ ExtendedActorSystem, Props }
-import org.apache.pekko.persistence.journal.{ EventAdapter, EventSeq }
-import org.apache.pekko.persistence.{ PersistentActor, RecoveryCompleted }
-import org.apache.pekko.testkit.{ PekkoSpec, TestProbe }
+import org.apache.pekko
+import pekko.actor.{ ExtendedActorSystem, Props }
+import pekko.persistence.journal.{ EventAdapter, EventSeq }
+import pekko.persistence.{ PersistentActor, RecoveryCompleted }
+import pekko.testkit.{ PekkoSpec, TestProbe }
 import com.google.gson.{ Gson, JsonElement }
 
 import scala.collection.immutable

--- a/docs/src/test/scala/docs/persistence/PersistenceEventAdapterDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceEventAdapterDocSpec.scala
@@ -18,6 +18,7 @@ import pekko.actor.{ ExtendedActorSystem, Props }
 import pekko.persistence.journal.{ EventAdapter, EventSeq }
 import pekko.persistence.{ PersistentActor, RecoveryCompleted }
 import pekko.testkit.{ PekkoSpec, TestProbe }
+
 import com.google.gson.{ Gson, JsonElement }
 
 import scala.collection.immutable

--- a/docs/src/test/scala/docs/persistence/PersistenceMultiDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceMultiDocSpec.scala
@@ -11,7 +11,8 @@
  * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-import org.apache.pekko.persistence.{ PersistentActor, RuntimePluginConfig }
+import org.apache.pekko
+import pekko.persistence.{ PersistentActor, RuntimePluginConfig }
 import com.typesafe.config.ConfigFactory
 
 object PersistenceMultiDocSpec {

--- a/docs/src/test/scala/docs/persistence/PersistenceMultiDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceMultiDocSpec.scala
@@ -13,6 +13,7 @@
 
 import org.apache.pekko
 import pekko.persistence.{ PersistentActor, RuntimePluginConfig }
+
 import com.typesafe.config.ConfigFactory
 
 object PersistenceMultiDocSpec {

--- a/docs/src/test/scala/docs/persistence/PersistenceSchemaEvolutionDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceSchemaEvolutionDocSpec.scala
@@ -21,6 +21,7 @@ import pekko.actor.ActorSystem
 import pekko.persistence.journal.{ EventAdapter, EventSeq }
 import pekko.serialization.{ SerializationExtension, SerializerWithStringManifest }
 import pekko.testkit.TestKit
+
 import com.typesafe.config._
 import org.scalatest.wordspec.AnyWordSpec
 import spray.json.JsObject

--- a/docs/src/test/scala/docs/persistence/PersistenceSchemaEvolutionDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceSchemaEvolutionDocSpec.scala
@@ -16,10 +16,11 @@ package docs.persistence
 import java.io.NotSerializableException
 import java.nio.charset.StandardCharsets
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.persistence.journal.{ EventAdapter, EventSeq }
-import org.apache.pekko.serialization.{ SerializationExtension, SerializerWithStringManifest }
-import org.apache.pekko.testkit.TestKit
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.persistence.journal.{ EventAdapter, EventSeq }
+import pekko.serialization.{ SerializationExtension, SerializerWithStringManifest }
+import pekko.testkit.TestKit
 import com.typesafe.config._
 import org.scalatest.wordspec.AnyWordSpec
 import spray.json.JsObject

--- a/docs/src/test/scala/docs/persistence/PersistenceSerializerDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistenceSerializerDocSpec.scala
@@ -17,9 +17,10 @@ import com.typesafe.config._
 
 import scala.concurrent.duration._
 import org.scalatest.wordspec.AnyWordSpec
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.serialization.{ SerializationExtension, Serializer }
-import org.apache.pekko.testkit.TestKit
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.serialization.{ SerializationExtension, Serializer }
+import pekko.testkit.TestKit
 
 class PersistenceSerializerDocSpec extends AnyWordSpec {
 

--- a/docs/src/test/scala/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala
@@ -14,7 +14,6 @@
 package docs.persistence.query
 
 import org.apache.pekko
-
 import pekko.NotUsed
 import pekko.testkit.PekkoSpec
 import pekko.persistence.query.{ EventEnvelope, PersistenceQuery, Sequence }

--- a/docs/src/test/scala/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala
@@ -13,11 +13,13 @@
 
 package docs.persistence.query
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.persistence.query.{ EventEnvelope, PersistenceQuery, Sequence }
-import org.apache.pekko.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+
+import pekko.NotUsed
+import pekko.testkit.PekkoSpec
+import pekko.persistence.query.{ EventEnvelope, PersistenceQuery, Sequence }
+import pekko.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
+import pekko.stream.scaladsl.Source
 
 object LeveldbPersistenceQueryDocSpec {
   // #tagger

--- a/docs/src/test/scala/docs/persistence/query/MyEventsByTagSource.scala
+++ b/docs/src/test/scala/docs/persistence/query/MyEventsByTagSource.scala
@@ -13,10 +13,11 @@
 
 package docs.persistence.query
 
-import org.apache.pekko.persistence.query.{ EventEnvelope, Offset }
-import org.apache.pekko.serialization.SerializationExtension
-import org.apache.pekko.stream.{ ActorAttributes, ActorMaterializer, Attributes, Outlet, SourceShape }
-import org.apache.pekko.stream.stage.{ GraphStage, GraphStageLogic, OutHandler, TimerGraphStageLogic }
+import org.apache.pekko
+import pekko.persistence.query.{ EventEnvelope, Offset }
+import pekko.serialization.SerializationExtension
+import pekko.stream.{ ActorAttributes, ActorMaterializer, Attributes, Outlet, SourceShape }
+import pekko.stream.stage.{ GraphStage, GraphStageLogic, OutHandler, TimerGraphStageLogic }
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal

--- a/docs/src/test/scala/docs/persistence/testkit/Configuration.scala
+++ b/docs/src/test/scala/docs/persistence/testkit/Configuration.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.actor.typed.ActorSystem
 import pekko.persistence.testkit.{ PersistenceTestKitPlugin, PersistenceTestKitSnapshotPlugin }
 import pekko.persistence.testkit.scaladsl.{ PersistenceTestKit, SnapshotTestKit }
+
 import com.typesafe.config.ConfigFactory
 
 object TestKitTypedConf {

--- a/docs/src/test/scala/docs/persistence/testkit/Configuration.scala
+++ b/docs/src/test/scala/docs/persistence/testkit/Configuration.scala
@@ -13,9 +13,10 @@
 
 package docs.persistence.testkit
 
-import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.persistence.testkit.{ PersistenceTestKitPlugin, PersistenceTestKitSnapshotPlugin }
-import org.apache.pekko.persistence.testkit.scaladsl.{ PersistenceTestKit, SnapshotTestKit }
+import org.apache.pekko
+import pekko.actor.typed.ActorSystem
+import pekko.persistence.testkit.{ PersistenceTestKitPlugin, PersistenceTestKitSnapshotPlugin }
+import pekko.persistence.testkit.scaladsl.{ PersistenceTestKit, SnapshotTestKit }
 import com.typesafe.config.ConfigFactory
 
 object TestKitTypedConf {

--- a/docs/src/test/scala/docs/persistence/testkit/PersistenceInitSpec.scala
+++ b/docs/src/test/scala/docs/persistence/testkit/PersistenceInitSpec.scala
@@ -15,12 +15,13 @@ package docs.persistence.testkit
 
 import java.util.UUID
 
-import org.apache.pekko.Done
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
 //#imports
-import org.apache.pekko.persistence.testkit.scaladsl.PersistenceInit
+import pekko.persistence.testkit.scaladsl.PersistenceInit
 
 import scala.concurrent.Await
 import scala.concurrent.Future

--- a/docs/src/test/scala/docs/persistence/testkit/PersistenceInitSpec.scala
+++ b/docs/src/test/scala/docs/persistence/testkit/PersistenceInitSpec.scala
@@ -18,6 +18,7 @@ import java.util.UUID
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 
 //#imports

--- a/docs/src/test/scala/docs/persistence/testkit/TestKitExamples.scala
+++ b/docs/src/test/scala/docs/persistence/testkit/TestKitExamples.scala
@@ -13,10 +13,11 @@
 
 package docs.persistence.testkit
 
-import org.apache.pekko.persistence.typed.PersistenceId
-import org.apache.pekko.persistence.typed.scaladsl.Effect
-import org.apache.pekko.persistence.typed.scaladsl.EventSourcedBehavior
-import org.apache.pekko.serialization.jackson.CborSerializable
+import org.apache.pekko
+import pekko.persistence.typed.PersistenceId
+import pekko.persistence.typed.scaladsl.Effect
+import pekko.persistence.typed.scaladsl.EventSourcedBehavior
+import pekko.serialization.jackson.CborSerializable
 import com.typesafe.config.ConfigFactory
 import docs.persistence.testkit.PersistenceTestKitSampleSpec.{ Cmd, Evt, _ }
 import org.scalatest.BeforeAndAfterEach
@@ -34,7 +35,6 @@ object PersistenceTestKitSampleSpec {
 }
 
 //#test
-import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import pekko.persistence.testkit.PersistenceTestKitPlugin
 import pekko.persistence.testkit.scaladsl.PersistenceTestKit
@@ -74,7 +74,7 @@ class PersistenceTestKitSampleSpec
 //#test
 
 //#set-event-storage-policy
-import org.apache.pekko.persistence.testkit._
+import pekko.persistence.testkit._
 
 class SampleEventStoragePolicy extends EventStorage.JournalPolicies.PolicyType {
 

--- a/docs/src/test/scala/docs/persistence/testkit/TestKitExamples.scala
+++ b/docs/src/test/scala/docs/persistence/testkit/TestKitExamples.scala
@@ -18,6 +18,7 @@ import pekko.persistence.typed.PersistenceId
 import pekko.persistence.typed.scaladsl.Effect
 import pekko.persistence.typed.scaladsl.EventSourcedBehavior
 import pekko.serialization.jackson.CborSerializable
+
 import com.typesafe.config.ConfigFactory
 import docs.persistence.testkit.PersistenceTestKitSampleSpec.{ Cmd, Evt, _ }
 import org.scalatest.BeforeAndAfterEach

--- a/docs/src/test/scala/docs/remoting/RemoteDeploymentDocSpec.scala
+++ b/docs/src/test/scala/docs/remoting/RemoteDeploymentDocSpec.scala
@@ -13,10 +13,10 @@
 
 package docs.remoting
 
-import org.apache.pekko.actor.{ Actor, ActorRef, ActorSystem, ExtendedActorSystem }
-import org.apache.pekko.testkit.{ ImplicitSender, PekkoSpec }
-//#import
 import org.apache.pekko
+import pekko.actor.{ Actor, ActorRef, ActorSystem, ExtendedActorSystem }
+import pekko.testkit.{ ImplicitSender, PekkoSpec }
+//#import
 import pekko.actor.{ Address, AddressFromURIString, Deploy, Props }
 import pekko.remote.RemoteScope
 //#import

--- a/docs/src/test/scala/docs/routing/ConsistentHashingRouterDocSpec.scala
+++ b/docs/src/test/scala/docs/routing/ConsistentHashingRouterDocSpec.scala
@@ -13,10 +13,12 @@
 
 package docs.routing
 
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.testkit.ImplicitSender
-import org.apache.pekko.routing.FromConfig
-import org.apache.pekko.actor.ActorRef
+import org.apache.pekko
+
+import pekko.testkit.PekkoSpec
+import pekko.testkit.ImplicitSender
+import pekko.routing.FromConfig
+import pekko.actor.ActorRef
 
 object ConsistentHashingRouterDocSpec {
 

--- a/docs/src/test/scala/docs/routing/ConsistentHashingRouterDocSpec.scala
+++ b/docs/src/test/scala/docs/routing/ConsistentHashingRouterDocSpec.scala
@@ -14,7 +14,6 @@
 package docs.routing
 
 import org.apache.pekko
-
 import pekko.testkit.PekkoSpec
 import pekko.testkit.ImplicitSender
 import pekko.routing.FromConfig

--- a/docs/src/test/scala/docs/routing/CustomRouterDocSpec.scala
+++ b/docs/src/test/scala/docs/routing/CustomRouterDocSpec.scala
@@ -14,16 +14,16 @@
 package docs.routing
 
 import org.apache.pekko
-
 import pekko.testkit.PekkoSpec
 import pekko.testkit.ImplicitSender
 import pekko.actor.Actor
 import pekko.actor.Props
-import CustomRouterDocSpec.RedundancyRoutingLogic
-import scala.collection.immutable
 import pekko.actor.ActorSystem
 import pekko.routing.FromConfig
 import pekko.actor.ActorRef
+
+import CustomRouterDocSpec.RedundancyRoutingLogic
+import scala.collection.immutable
 
 object CustomRouterDocSpec {
 

--- a/docs/src/test/scala/docs/routing/CustomRouterDocSpec.scala
+++ b/docs/src/test/scala/docs/routing/CustomRouterDocSpec.scala
@@ -13,15 +13,17 @@
 
 package docs.routing
 
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.testkit.ImplicitSender
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.Props
+import org.apache.pekko
+
+import pekko.testkit.PekkoSpec
+import pekko.testkit.ImplicitSender
+import pekko.actor.Actor
+import pekko.actor.Props
 import CustomRouterDocSpec.RedundancyRoutingLogic
 import scala.collection.immutable
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.routing.FromConfig
-import org.apache.pekko.actor.ActorRef
+import pekko.actor.ActorSystem
+import pekko.routing.FromConfig
+import pekko.actor.ActorRef
 
 object CustomRouterDocSpec {
 
@@ -82,7 +84,6 @@ pekko.actor.deployment {
 }
 
 //#group
-import org.apache.pekko
 import pekko.dispatch.Dispatchers
 import pekko.routing.Group
 import pekko.routing.Router

--- a/docs/src/test/scala/docs/routing/RouterDocSpec.scala
+++ b/docs/src/test/scala/docs/routing/RouterDocSpec.scala
@@ -13,26 +13,28 @@
 
 package docs.routing
 
+import org.apache.pekko
+
 import scala.concurrent.duration._
-import org.apache.pekko.testkit._
-import org.apache.pekko.actor.{ Actor, ActorRef, Props }
-import org.apache.pekko.actor.Terminated
-import org.apache.pekko.routing.FromConfig
-import org.apache.pekko.routing.RoundRobinPool
-import org.apache.pekko.routing.RandomPool
-import org.apache.pekko.routing.RoundRobinGroup
-import org.apache.pekko.routing.SmallestMailboxPool
-import org.apache.pekko.routing.BroadcastPool
-import org.apache.pekko.routing.BroadcastGroup
-import org.apache.pekko.routing.ConsistentHashingGroup
-import org.apache.pekko.routing.ConsistentHashingPool
-import org.apache.pekko.routing.DefaultResizer
-import org.apache.pekko.routing.ScatterGatherFirstCompletedGroup
-import org.apache.pekko.routing.RandomGroup
-import org.apache.pekko.routing.ScatterGatherFirstCompletedPool
-import org.apache.pekko.routing.BalancingPool
-import org.apache.pekko.routing.TailChoppingGroup
-import org.apache.pekko.routing.TailChoppingPool
+import pekko.testkit._
+import pekko.actor.{ Actor, ActorRef, Props }
+import pekko.actor.Terminated
+import pekko.routing.FromConfig
+import pekko.routing.RoundRobinPool
+import pekko.routing.RandomPool
+import pekko.routing.RoundRobinGroup
+import pekko.routing.SmallestMailboxPool
+import pekko.routing.BroadcastPool
+import pekko.routing.BroadcastGroup
+import pekko.routing.ConsistentHashingGroup
+import pekko.routing.ConsistentHashingPool
+import pekko.routing.DefaultResizer
+import pekko.routing.ScatterGatherFirstCompletedGroup
+import pekko.routing.RandomGroup
+import pekko.routing.ScatterGatherFirstCompletedPool
+import pekko.routing.BalancingPool
+import pekko.routing.TailChoppingGroup
+import pekko.routing.TailChoppingPool
 import scala.jdk.CollectionConverters._
 
 object RouterDocSpec {

--- a/docs/src/test/scala/docs/routing/RouterDocSpec.scala
+++ b/docs/src/test/scala/docs/routing/RouterDocSpec.scala
@@ -14,8 +14,6 @@
 package docs.routing
 
 import org.apache.pekko
-
-import scala.concurrent.duration._
 import pekko.testkit._
 import pekko.actor.{ Actor, ActorRef, Props }
 import pekko.actor.Terminated
@@ -35,6 +33,8 @@ import pekko.routing.ScatterGatherFirstCompletedPool
 import pekko.routing.BalancingPool
 import pekko.routing.TailChoppingGroup
 import pekko.routing.TailChoppingPool
+
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 object RouterDocSpec {

--- a/docs/src/test/scala/docs/stream/BidiFlowDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/BidiFlowDocSpec.scala
@@ -13,12 +13,13 @@
 
 package docs.stream
 
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream._
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
+import pekko.stream.scaladsl._
+import pekko.stream._
+import pekko.util.ByteString
 import java.nio.ByteOrder
-import org.apache.pekko.stream.stage._
+import pekko.stream.stage._
 import scala.concurrent.duration._
 import scala.concurrent.Await
 

--- a/docs/src/test/scala/docs/stream/BidiFlowDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/BidiFlowDocSpec.scala
@@ -18,6 +18,7 @@ import pekko.testkit.PekkoSpec
 import pekko.stream.scaladsl._
 import pekko.stream._
 import pekko.util.ByteString
+
 import java.nio.ByteOrder
 import pekko.stream.stage._
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/CompositionDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/CompositionDocSpec.scala
@@ -13,12 +13,13 @@
 
 package docs.stream
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.scaladsl.Tcp.OutgoingConnection
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream._
+import pekko.stream.scaladsl.Tcp.OutgoingConnection
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
+import pekko.util.ByteString
 
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.ExecutionContext

--- a/docs/src/test/scala/docs/stream/FlowDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/FlowDocSpec.scala
@@ -22,6 +22,7 @@ import pekko.stream.Materializer
 import pekko.stream.{ ClosedShape, FlowShape, OverflowStrategy }
 import pekko.stream.scaladsl._
 import pekko.testkit.PekkoSpec
+
 import docs.CompileOnlySpec
 
 import scala.concurrent.{ Future, Promise }

--- a/docs/src/test/scala/docs/stream/FlowDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/FlowDocSpec.scala
@@ -13,14 +13,15 @@
 
 package docs.stream
 
-import org.apache.pekko.Done
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.{ Actor, ActorSystem, Cancellable }
-import org.apache.pekko.stream.CompletionStrategy
-import org.apache.pekko.stream.Materializer
-import org.apache.pekko.stream.{ ClosedShape, FlowShape, OverflowStrategy }
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.Done
+import pekko.NotUsed
+import pekko.actor.{ Actor, ActorSystem, Cancellable }
+import pekko.stream.CompletionStrategy
+import pekko.stream.Materializer
+import pekko.stream.{ ClosedShape, FlowShape, OverflowStrategy }
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
 import docs.CompileOnlySpec
 
 import scala.concurrent.{ Future, Promise }

--- a/docs/src/test/scala/docs/stream/FlowErrorDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/FlowErrorDocSpec.scala
@@ -19,6 +19,7 @@ import pekko.stream.Supervision
 import pekko.stream.scaladsl._
 import pekko.testkit.PekkoSpec
 import pekko.stream.ActorAttributes
+
 import scala.concurrent.duration._
 
 class FlowErrorDocSpec extends PekkoSpec {

--- a/docs/src/test/scala/docs/stream/FlowErrorDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/FlowErrorDocSpec.scala
@@ -14,10 +14,11 @@
 package docs.stream
 
 import scala.concurrent.Await
-import org.apache.pekko.stream.Supervision
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.stream.ActorAttributes
+import org.apache.pekko
+import pekko.stream.Supervision
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
+import pekko.stream.ActorAttributes
 import scala.concurrent.duration._
 
 class FlowErrorDocSpec extends PekkoSpec {

--- a/docs/src/test/scala/docs/stream/FlowParallelismDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/FlowParallelismDocSpec.scala
@@ -13,10 +13,11 @@
 
 package docs.stream
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.FlowShape
-import org.apache.pekko.stream.scaladsl.{ Balance, Flow, GraphDSL, Merge, Source }
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.FlowShape
+import pekko.stream.scaladsl.{ Balance, Flow, GraphDSL, Merge, Source }
+import pekko.testkit.PekkoSpec
 
 class FlowParallelismDocSpec extends PekkoSpec {
 

--- a/docs/src/test/scala/docs/stream/FlowStreamRefsDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/FlowStreamRefsDocSpec.scala
@@ -13,11 +13,13 @@
 
 package docs.stream
 
+import org.apache.pekko
+
 import docs.CompileOnlySpec
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.{ Actor, Props }
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
+import pekko.NotUsed
+import pekko.actor.{ Actor, Props }
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
 
 object FlowStreamRefsDocSpec {
   // #offer-source

--- a/docs/src/test/scala/docs/stream/FlowStreamRefsDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/FlowStreamRefsDocSpec.scala
@@ -14,12 +14,12 @@
 package docs.stream
 
 import org.apache.pekko
-
-import docs.CompileOnlySpec
 import pekko.NotUsed
 import pekko.actor.{ Actor, Props }
 import pekko.stream.scaladsl._
 import pekko.testkit.PekkoSpec
+
+import docs.CompileOnlySpec
 
 object FlowStreamRefsDocSpec {
   // #offer-source

--- a/docs/src/test/scala/docs/stream/GraphCyclesSpec.scala
+++ b/docs/src/test/scala/docs/stream/GraphCyclesSpec.scala
@@ -13,9 +13,10 @@
 
 package docs.stream
 
-import org.apache.pekko.stream.{ ClosedShape, OverflowStrategy }
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.stream.{ ClosedShape, OverflowStrategy }
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
 
 class GraphCyclesSpec extends PekkoSpec {
 

--- a/docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
@@ -13,10 +13,11 @@
 
 package docs.stream
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream._
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
 
 import scala.collection.immutable
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
@@ -13,12 +13,14 @@
 
 package docs.stream
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
-import org.apache.pekko.stream.stage._
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.testkit.{ TestPublisher, TestSubscriber }
-import org.apache.pekko.testkit.{ PekkoSpec, TestLatch }
+import org.apache.pekko
+
+import pekko.NotUsed
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import pekko.stream.stage._
+import pekko.stream._
+import pekko.stream.testkit.{ TestPublisher, TestSubscriber }
+import pekko.testkit.{ PekkoSpec, TestLatch }
 
 import scala.collection.mutable
 import scala.concurrent.{ Await, Future, Promise }

--- a/docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
@@ -14,7 +14,6 @@
 package docs.stream
 
 import org.apache.pekko
-
 import pekko.NotUsed
 import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import pekko.stream.stage._

--- a/docs/src/test/scala/docs/stream/GraphStageLoggingDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/GraphStageLoggingDocSpec.scala
@@ -15,9 +15,10 @@ package docs.stream
 
 import java.util.concurrent.ThreadLocalRandom
 
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.{ EventFilter, PekkoSpec }
+import org.apache.pekko
+import pekko.stream._
+import pekko.stream.scaladsl._
+import pekko.testkit.{ EventFilter, PekkoSpec }
 import scala.concurrent.ExecutionContext
 
 class GraphStageLoggingDocSpec extends PekkoSpec("pekko.loglevel = DEBUG") {

--- a/docs/src/test/scala/docs/stream/GraphStageLoggingDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/GraphStageLoggingDocSpec.scala
@@ -19,6 +19,7 @@ import org.apache.pekko
 import pekko.stream._
 import pekko.stream.scaladsl._
 import pekko.testkit.{ EventFilter, PekkoSpec }
+
 import scala.concurrent.ExecutionContext
 
 class GraphStageLoggingDocSpec extends PekkoSpec("pekko.loglevel = DEBUG") {

--- a/docs/src/test/scala/docs/stream/HubsDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/HubsDocSpec.scala
@@ -18,6 +18,7 @@ import pekko.NotUsed
 import pekko.stream.{ KillSwitches, UniqueKillSwitch }
 import pekko.stream.scaladsl._
 import pekko.testkit.PekkoSpec
+
 import docs.CompileOnlySpec
 
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/HubsDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/HubsDocSpec.scala
@@ -13,14 +13,15 @@
 
 package docs.stream
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.{ KillSwitches, UniqueKillSwitch }
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.{ KillSwitches, UniqueKillSwitch }
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
 import docs.CompileOnlySpec
 
 import scala.concurrent.duration._
-import org.apache.pekko.stream.ThrottleMode
+import pekko.stream.ThrottleMode
 
 class HubsDocSpec extends PekkoSpec with CompileOnlySpec {
 

--- a/docs/src/test/scala/docs/stream/IntegrationDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/IntegrationDocSpec.scala
@@ -15,22 +15,23 @@ package docs.stream
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.Done
-import org.apache.pekko.NotUsed
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream._
+import org.apache.pekko
+import pekko.Done
+import pekko.NotUsed
+import pekko.testkit.PekkoSpec
+import pekko.stream.scaladsl._
+import pekko.stream._
 
 import scala.concurrent.Future
-import org.apache.pekko.testkit.TestProbe
-import org.apache.pekko.actor.{ Actor, ActorLogging, ActorRef, Props }
+import pekko.testkit.TestProbe
+import pekko.actor.{ Actor, ActorLogging, ActorRef, Props }
 import com.typesafe.config.ConfigFactory
-import org.apache.pekko.util.Timeout
+import pekko.util.Timeout
 
 import scala.concurrent.ExecutionContext
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.apache.pekko.stream.scaladsl.Flow
+import pekko.stream.scaladsl.Flow
 import org.scalacheck.Gen.const
 
 object IntegrationDocSpec {

--- a/docs/src/test/scala/docs/stream/KillSwitchDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/KillSwitchDocSpec.scala
@@ -13,9 +13,10 @@
 
 package docs.stream
 
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream.{ DelayOverflowStrategy, KillSwitches }
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.stream.scaladsl._
+import pekko.stream.{ DelayOverflowStrategy, KillSwitches }
+import pekko.testkit.PekkoSpec
 import docs.CompileOnlySpec
 
 import scala.concurrent.Await

--- a/docs/src/test/scala/docs/stream/KillSwitchDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/KillSwitchDocSpec.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.stream.scaladsl._
 import pekko.stream.{ DelayOverflowStrategy, KillSwitches }
 import pekko.testkit.PekkoSpec
+
 import docs.CompileOnlySpec
 
 import scala.concurrent.Await

--- a/docs/src/test/scala/docs/stream/MigrationsScala.scala
+++ b/docs/src/test/scala/docs/stream/MigrationsScala.scala
@@ -13,8 +13,9 @@
 
 package docs.stream
 
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
 
 class MigrationsScala extends PekkoSpec {
 

--- a/docs/src/test/scala/docs/stream/RateTransformationDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/RateTransformationDocSpec.scala
@@ -13,14 +13,15 @@
 
 package docs.stream
 
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream.testkit.scaladsl._
+import org.apache.pekko
+import pekko.stream.scaladsl._
+import pekko.stream.testkit.scaladsl._
 
 import scala.util.Random
 import scala.math._
 import scala.concurrent.duration._
 import scala.collection.immutable
-import org.apache.pekko.testkit.{ PekkoSpec, TestLatch }
+import pekko.testkit.{ PekkoSpec, TestLatch }
 
 import scala.concurrent.Await
 

--- a/docs/src/test/scala/docs/stream/ReactiveStreamsDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/ReactiveStreamsDocSpec.scala
@@ -13,10 +13,11 @@
 
 package docs.stream
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl.{ Flow, Sink, Source }
-import org.apache.pekko.stream.testkit._
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl.{ Flow, Sink, Source }
+import pekko.stream.testkit._
+import pekko.testkit.PekkoSpec
 
 class ReactiveStreamsDocSpec extends PekkoSpec {
   import TwitterStreamQuickstartDocSpec._

--- a/docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -13,10 +13,11 @@
 
 package docs.stream
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.{ KillSwitches, RestartSettings }
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.{ KillSwitches, RestartSettings }
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
 import docs.CompileOnlySpec
 
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -18,6 +18,7 @@ import pekko.NotUsed
 import pekko.stream.{ KillSwitches, RestartSettings }
 import pekko.stream.scaladsl._
 import pekko.testkit.PekkoSpec
+
 import docs.CompileOnlySpec
 
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/SinkRecipeDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/SinkRecipeDocSpec.scala
@@ -13,7 +13,8 @@
 
 package docs.stream
 
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.stream.scaladsl.{ Sink, Source }
 import docs.stream.cookbook.RecipeSpec
 
 import scala.concurrent.Future

--- a/docs/src/test/scala/docs/stream/SinkRecipeDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/SinkRecipeDocSpec.scala
@@ -15,6 +15,7 @@ package docs.stream
 
 import org.apache.pekko
 import pekko.stream.scaladsl.{ Sink, Source }
+
 import docs.stream.cookbook.RecipeSpec
 
 import scala.concurrent.Future

--- a/docs/src/test/scala/docs/stream/StreamBuffersRateSpec.scala
+++ b/docs/src/test/scala/docs/stream/StreamBuffersRateSpec.scala
@@ -13,10 +13,11 @@
 
 package docs.stream
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream._
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
 
 class StreamBuffersRateSpec extends PekkoSpec {
 

--- a/docs/src/test/scala/docs/stream/StreamPartialGraphDSLDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/StreamPartialGraphDSLDocSpec.scala
@@ -13,10 +13,11 @@
 
 package docs.stream
 
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.actor.ActorRef
+import pekko.stream._
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
 
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
@@ -17,12 +17,13 @@ import scala.util._
 import scala.concurrent.duration._
 import scala.concurrent._
 
-import org.apache.pekko.Done
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream.testkit.scaladsl._
-import org.apache.pekko.testkit.{ PekkoSpec, TestProbe }
-import org.apache.pekko.pattern
+import org.apache.pekko
+import pekko.Done
+import pekko.stream._
+import pekko.stream.scaladsl._
+import pekko.stream.testkit.scaladsl._
+import pekko.testkit.{ PekkoSpec, TestProbe }
+import pekko.pattern
 
 class StreamTestKitDocSpec extends PekkoSpec {
 

--- a/docs/src/test/scala/docs/stream/SubstreamDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/SubstreamDocSpec.scala
@@ -13,8 +13,9 @@
 
 package docs.stream
 
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.testkit.PekkoSpec
 
 class SubstreamDocSpec extends PekkoSpec {
 

--- a/docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala
@@ -13,19 +13,21 @@
 
 package docs.stream
 
+import org.apache.pekko
+
 //#imports
 
-import org.apache.pekko.{ Done, NotUsed }
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.{ ClosedShape, OverflowStrategy }
-import org.apache.pekko.stream.scaladsl._
+import pekko.{ Done, NotUsed }
+import pekko.actor.ActorSystem
+import pekko.stream.{ ClosedShape, OverflowStrategy }
+import pekko.stream.scaladsl._
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.io.StdIn.readLine
 
 //#imports
 
-import org.apache.pekko.testkit.PekkoSpec
+import pekko.testkit.PekkoSpec
 import scala.concurrent.ExecutionContext
 
 object TwitterStreamQuickstartDocSpec {

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeByteStrings.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeByteStrings.scala
@@ -13,10 +13,11 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
-import org.apache.pekko.stream.scaladsl.{ Flow, Sink, Source }
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import pekko.stream.scaladsl.{ Flow, Sink, Source }
+import pekko.util.ByteString
 
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeDecompress.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeDecompress.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
+import pekko.util.ByteString
 
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeDroppyBroadcast.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeDroppyBroadcast.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.stream.{ ClosedShape, OverflowStrategy }
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.stream.{ ClosedShape, OverflowStrategy }
+import pekko.stream.scaladsl._
+import pekko.stream.testkit._
 
 class RecipeDroppyBroadcast extends RecipeSpec {
 

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeFlattenSeq.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeFlattenSeq.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeGlobalRateLimit.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeGlobalRateLimit.scala
@@ -13,12 +13,14 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.{ Actor, ActorRef, Props }
-import org.apache.pekko.stream.ClosedShape
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream.testkit._
-import org.apache.pekko.testkit._
+import org.apache.pekko
+
+import pekko.NotUsed
+import pekko.actor.{ Actor, ActorRef, Props }
+import pekko.stream.ClosedShape
+import pekko.stream.scaladsl._
+import pekko.stream.testkit._
+import pekko.testkit._
 
 import scala.collection.immutable
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeGlobalRateLimit.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeGlobalRateLimit.scala
@@ -14,7 +14,6 @@
 package docs.stream.cookbook
 
 import org.apache.pekko
-
 import pekko.NotUsed
 import pekko.actor.{ Actor, ActorRef, Props }
 import pekko.stream.ClosedShape

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeHold.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeHold.scala
@@ -13,9 +13,11 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.stream.Attributes
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+
+import pekko.stream.Attributes
+import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.stream.testkit._
 
 import scala.concurrent.duration._
 

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeHold.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeHold.scala
@@ -14,7 +14,6 @@
 package docs.stream.cookbook
 
 import org.apache.pekko
-
 import pekko.stream.Attributes
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.stream.testkit._

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeKeepAlive.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeKeepAlive.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl._
+import pekko.util.ByteString
 
 class RecipeKeepAlive extends RecipeSpec {
 

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeLoggingElements.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeLoggingElements.scala
@@ -13,11 +13,12 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.event.Logging
-import org.apache.pekko.event.LoggingAdapter
-import org.apache.pekko.stream.Attributes
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
-import org.apache.pekko.testkit.{ EventFilter, TestProbe }
+import org.apache.pekko
+import pekko.event.Logging
+import pekko.event.LoggingAdapter
+import pekko.stream.Attributes
+import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.testkit.{ EventFilter, TestProbe }
 
 class RecipeLoggingElements extends RecipeSpec {
 

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeManualTrigger.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeManualTrigger.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.stream.ClosedShape
 import pekko.stream.scaladsl._
 import pekko.stream.testkit._
+
 import scala.concurrent.duration._
 
 class RecipeManualTrigger extends RecipeSpec {

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeManualTrigger.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeManualTrigger.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.stream.ClosedShape
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.stream.ClosedShape
+import pekko.stream.scaladsl._
+import pekko.stream.testkit._
 import scala.concurrent.duration._
 
 class RecipeManualTrigger extends RecipeSpec {

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeMissedTicks.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeMissedTicks.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.scaladsl._
 import pekko.stream.testkit._
+
 import scala.concurrent.duration._
 import pekko.testkit.TestLatch
 import scala.concurrent.Await

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeMissedTicks.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeMissedTicks.scala
@@ -13,11 +13,12 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl._
+import pekko.stream.testkit._
 import scala.concurrent.duration._
-import org.apache.pekko.testkit.TestLatch
+import pekko.testkit.TestLatch
 import scala.concurrent.Await
 
 class RecipeMissedTicks extends RecipeSpec {

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeMultiGroupBy.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeMultiGroupBy.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.collection.immutable
 import scala.concurrent.Await

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeParseLines.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeParseLines.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
+import pekko.util.ByteString
 
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeReduceByKey.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeReduceByKey.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeReduceByKey.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeReduceByKey.scala
@@ -16,6 +16,7 @@ package docs.stream.cookbook
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.scaladsl._
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeSeq.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeSeq.scala
@@ -15,6 +15,7 @@ package docs.stream.cookbook
 
 import org.apache.pekko
 import pekko.stream.scaladsl._
+
 import scala.concurrent.Future
 
 class RecipeSeq extends RecipeSpec {

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeSeq.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeSeq.scala
@@ -13,7 +13,8 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.stream.scaladsl._
 import scala.concurrent.Future
 
 class RecipeSeq extends RecipeSpec {

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeSimpleDrop.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeSimpleDrop.scala
@@ -13,11 +13,12 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl.{ Flow, Sink, Source }
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl.{ Flow, Sink, Source }
+import pekko.stream.testkit._
 import scala.concurrent.duration._
-import org.apache.pekko.testkit.TestLatch
+import pekko.testkit.TestLatch
 import scala.concurrent.Await
 
 class RecipeSimpleDrop extends RecipeSpec {

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeSimpleDrop.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeSimpleDrop.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.stream.testkit._
+
 import scala.concurrent.duration._
 import pekko.testkit.TestLatch
 import scala.concurrent.Await

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeSourceFromFunction.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeSourceFromFunction.scala
@@ -15,8 +15,9 @@ package docs.stream.cookbook
 
 import java.util.UUID
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl._
 
 class RecipeSourceFromFunction extends RecipeSpec {
 

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeSpec.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeSpec.scala
@@ -13,7 +13,8 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 trait RecipeSpec extends PekkoSpec {
 

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeSplitter.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeSplitter.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.ActorSystem
 import pekko.stream.scaladsl.{ Sink, Source }
+
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeSplitter.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeSplitter.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeWorkerPool.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeWorkerPool.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.cookbook
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.FlowShape
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.FlowShape
+import pekko.stream.scaladsl._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/io/StreamFileDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/io/StreamFileDocSpec.scala
@@ -15,11 +15,12 @@ package docs.stream.io
 
 import java.nio.file.{ Files, Paths }
 
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.scaladsl.{ FileIO, Sink, Source }
-import org.apache.pekko.stream.testkit.Utils._
-import org.apache.pekko.util.ByteString
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.stream._
+import pekko.stream.scaladsl.{ FileIO, Sink, Source }
+import pekko.stream.testkit.Utils._
+import pekko.util.ByteString
+import pekko.testkit.PekkoSpec
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext

--- a/docs/src/test/scala/docs/stream/io/StreamTcpDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/io/StreamTcpDocSpec.scala
@@ -15,14 +15,15 @@ package docs.stream.io
 
 import java.util.concurrent.atomic.AtomicReference
 
-import org.apache.pekko.stream.scaladsl.Tcp._
-import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.testkit.PekkoSpec
-import org.apache.pekko.testkit.TestProbe
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.stream.scaladsl.Tcp._
+import pekko.stream.scaladsl._
+import pekko.testkit.PekkoSpec
+import pekko.testkit.TestProbe
+import pekko.util.ByteString
 
 import scala.concurrent.Future
-import org.apache.pekko.testkit.SocketUtil
+import pekko.testkit.SocketUtil
 import scala.concurrent.ExecutionContext
 
 class StreamTcpDocSpec extends PekkoSpec {

--- a/docs/src/test/scala/docs/stream/operators/BroadcastDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/BroadcastDocExample.scala
@@ -14,13 +14,11 @@
 package docs.stream.operators
 
 import org.apache.pekko
-
-import java.util.concurrent.ThreadLocalRandom
-
-import scala.concurrent.Future
-
 import pekko.actor.ActorSystem
 import pekko.stream.scaladsl.Broadcast
+
+import java.util.concurrent.ThreadLocalRandom
+import scala.concurrent.Future
 
 object BroadcastDocExample {
 

--- a/docs/src/test/scala/docs/stream/operators/BroadcastDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/BroadcastDocExample.scala
@@ -13,12 +13,14 @@
 
 package docs.stream.operators
 
+import org.apache.pekko
+
 import java.util.concurrent.ThreadLocalRandom
 
 import scala.concurrent.Future
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Broadcast
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Broadcast
 
 object BroadcastDocExample {
 

--- a/docs/src/test/scala/docs/stream/operators/JavaCollectorDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/JavaCollectorDocExample.scala
@@ -19,10 +19,11 @@ package docs.stream.operators
 
 import java.util.stream.Collectors
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.stream.scaladsl.StreamConverters
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
+import pekko.stream.scaladsl.StreamConverters
 
 object JavaCollectorDocExample {
 

--- a/docs/src/test/scala/docs/stream/operators/MapOption.scala
+++ b/docs/src/test/scala/docs/stream/operators/MapOption.scala
@@ -15,8 +15,8 @@ package docs.stream.operators
 
 //#imports
 import org.apache.pekko
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl._
+import pekko.NotUsed
+import pekko.stream.scaladsl._
 
 //#imports
 

--- a/docs/src/test/scala/docs/stream/operators/MergeSequenceDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/MergeSequenceDocExample.scala
@@ -14,7 +14,6 @@
 package docs.stream.operators
 
 import org.apache.pekko
-
 import pekko.actor.ActorSystem
 
 object MergeSequenceDocExample {

--- a/docs/src/test/scala/docs/stream/operators/MergeSequenceDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/MergeSequenceDocExample.scala
@@ -13,7 +13,9 @@
 
 package docs.stream.operators
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+
+import pekko.actor.ActorSystem
 
 object MergeSequenceDocExample {
 

--- a/docs/src/test/scala/docs/stream/operators/PartitionDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/PartitionDocExample.scala
@@ -14,7 +14,6 @@
 package docs.stream.operators
 
 import org.apache.pekko
-
 import pekko.actor.ActorSystem
 
 object PartitionDocExample {

--- a/docs/src/test/scala/docs/stream/operators/PartitionDocExample.scala
+++ b/docs/src/test/scala/docs/stream/operators/PartitionDocExample.scala
@@ -13,7 +13,9 @@
 
 package docs.stream.operators
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+
+import pekko.actor.ActorSystem
 
 object PartitionDocExample {
 

--- a/docs/src/test/scala/docs/stream/operators/SourceOperators.scala
+++ b/docs/src/test/scala/docs/stream/operators/SourceOperators.scala
@@ -13,8 +13,10 @@
 
 package docs.stream.operators
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.testkit.TestProbe
+import org.apache.pekko
+
+import pekko.actor.ActorSystem
+import pekko.testkit.TestProbe
 
 object SourceOperators {
 

--- a/docs/src/test/scala/docs/stream/operators/SourceOperators.scala
+++ b/docs/src/test/scala/docs/stream/operators/SourceOperators.scala
@@ -14,7 +14,6 @@
 package docs.stream.operators
 
 import org.apache.pekko
-
 import pekko.actor.ActorSystem
 import pekko.testkit.TestProbe
 

--- a/docs/src/test/scala/docs/stream/operators/WithContextSpec.scala
+++ b/docs/src/test/scala/docs/stream/operators/WithContextSpec.scala
@@ -13,7 +13,9 @@
 
 package docs.stream.operators
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+
+import pekko.testkit.PekkoSpec
 
 class WithContextSpec extends PekkoSpec {
 

--- a/docs/src/test/scala/docs/stream/operators/WithContextSpec.scala
+++ b/docs/src/test/scala/docs/stream/operators/WithContextSpec.scala
@@ -14,7 +14,6 @@
 package docs.stream.operators
 
 import org.apache.pekko
-
 import pekko.testkit.PekkoSpec
 
 class WithContextSpec extends PekkoSpec {

--- a/docs/src/test/scala/docs/stream/operators/converters/ToFromJavaIOStreams.scala
+++ b/docs/src/test/scala/docs/stream/operators/converters/ToFromJavaIOStreams.scala
@@ -16,14 +16,15 @@ package docs.stream.operators.converters
 // #import
 import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream }
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.IOResult
-import org.apache.pekko.stream.scaladsl.{ Flow, Keep, Sink, Source, StreamConverters }
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.IOResult
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source, StreamConverters }
+import pekko.util.ByteString
 
 import scala.util.Random
 // #import
-import org.apache.pekko.testkit.PekkoSpec
+import pekko.testkit.PekkoSpec
 import org.scalatest.concurrent.Futures
 
 import scala.concurrent.Future

--- a/docs/src/test/scala/docs/stream/operators/flow/ContraMap.scala
+++ b/docs/src/test/scala/docs/stream/operators/flow/ContraMap.scala
@@ -18,8 +18,9 @@
 package docs.stream.operators.flow
 
 //#imports
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl._
 
 //#imports
 

--- a/docs/src/test/scala/docs/stream/operators/flow/FromSinkAndSource.scala
+++ b/docs/src/test/scala/docs/stream/operators/flow/FromSinkAndSource.scala
@@ -13,19 +13,20 @@
 
 package docs.stream.operators.flow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.BroadcastHub
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.stream.scaladsl.Framing
-import org.apache.pekko.stream.scaladsl.Keep
-import org.apache.pekko.stream.scaladsl.MergeHub
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.stream.scaladsl.Tcp
-import org.apache.pekko.stream.testkit.TestPublisher
-import org.apache.pekko.stream.testkit.TestSubscriber
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.BroadcastHub
+import pekko.stream.scaladsl.Flow
+import pekko.stream.scaladsl.Framing
+import pekko.stream.scaladsl.Keep
+import pekko.stream.scaladsl.MergeHub
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
+import pekko.stream.scaladsl.Tcp
+import pekko.stream.testkit.TestPublisher
+import pekko.stream.testkit.TestSubscriber
+import pekko.util.ByteString
 
 import scala.concurrent.duration._
 

--- a/docs/src/test/scala/docs/stream/operators/flow/FutureFlow.scala
+++ b/docs/src/test/scala/docs/stream/operators/flow/FutureFlow.scala
@@ -13,10 +13,11 @@
 
 package docs.stream.operators.flow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Flow
+import pekko.stream.scaladsl.Source
 
 import scala.concurrent.Future
 

--- a/docs/src/test/scala/docs/stream/operators/flow/Lazy.scala
+++ b/docs/src/test/scala/docs/stream/operators/flow/Lazy.scala
@@ -15,10 +15,11 @@ package docs.stream.operators.flow
 
 import java.util
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Flow
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 
 object Lazy {
 

--- a/docs/src/test/scala/docs/stream/operators/flow/StatefulMap.scala
+++ b/docs/src/test/scala/docs/stream/operators/flow/StatefulMap.scala
@@ -12,8 +12,10 @@
  */
 
 package docs.stream.operators.flow
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object StatefulMap {
 

--- a/docs/src/test/scala/docs/stream/operators/flow/StatefulMapConcat.scala
+++ b/docs/src/test/scala/docs/stream/operators/flow/StatefulMapConcat.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.flow
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Flow
+import pekko.stream.scaladsl.Source
 
 import scala.annotation.nowarn
 

--- a/docs/src/test/scala/docs/stream/operators/sink/AsPublisher.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/AsPublisher.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.ExecutionContextExecutor
 

--- a/docs/src/test/scala/docs/stream/operators/sink/Cancelled.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/Cancelled.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.ExecutionContextExecutor
 

--- a/docs/src/test/scala/docs/stream/operators/sink/Collection.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/Collection.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 

--- a/docs/src/test/scala/docs/stream/operators/sink/Exists.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/Exists.scala
@@ -18,8 +18,9 @@
 package docs.stream.operators.sink
 
 //#imports
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl._
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ Await, ExecutionContext }

--- a/docs/src/test/scala/docs/stream/operators/sink/Fold.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/Fold.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 

--- a/docs/src/test/scala/docs/stream/operators/sink/FoldWhile.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/FoldWhile.scala
@@ -17,8 +17,9 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ Await, ExecutionContextExecutor }

--- a/docs/src/test/scala/docs/stream/operators/sink/ForAll.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/ForAll.scala
@@ -17,8 +17,9 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ Await, ExecutionContextExecutor, Future }

--- a/docs/src/test/scala/docs/stream/operators/sink/HeadOption.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/HeadOption.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 

--- a/docs/src/test/scala/docs/stream/operators/sink/Ignore.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/Ignore.scala
@@ -17,10 +17,11 @@ import java.util.UUID
 
 import scala.concurrent.Future
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 
 object Ignore {
   implicit val system: ActorSystem = ???

--- a/docs/src/test/scala/docs/stream/operators/sink/Lazy.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/Lazy.scala
@@ -13,10 +13,11 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Keep
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Keep
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 
 object Lazy {
 

--- a/docs/src/test/scala/docs/stream/operators/sink/NoneMatch.scala
+++ b/docs/src/test/scala/docs/stream/operators/sink/NoneMatch.scala
@@ -17,8 +17,9 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ Await, ExecutionContextExecutor, Future }

--- a/docs/src/test/scala/docs/stream/operators/source/Combine.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/Combine.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.source
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+import pekko.actor.ActorSystem
 // #imports
-import org.apache.pekko.stream.scaladsl.{ Concat, Merge, Source }
+import pekko.stream.scaladsl.{ Concat, Merge, Source }
 // ...
 
 // #imports

--- a/docs/src/test/scala/docs/stream/operators/source/From.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/From.scala
@@ -15,8 +15,9 @@ package docs.stream.operators.source
 
 import java.util.stream.IntStream
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object From {
 

--- a/docs/src/test/scala/docs/stream/operators/source/Lazy.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/Lazy.scala
@@ -13,10 +13,11 @@
 
 package docs.stream.operators.source
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 
 object Lazy {
 

--- a/docs/src/test/scala/docs/stream/operators/source/Restart.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/Restart.scala
@@ -13,17 +13,18 @@
 
 package docs.stream.operators.source
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.{ KillSwitches, RestartSettings, UniqueKillSwitch }
-import org.apache.pekko.stream.scaladsl.Keep
-import org.apache.pekko.stream.scaladsl.RestartSource
-import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.{ KillSwitches, RestartSettings, UniqueKillSwitch }
+import pekko.stream.scaladsl.Keep
+import pekko.stream.scaladsl.RestartSource
+import pekko.stream.scaladsl.Sink
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 // #imports
-import org.apache.pekko.stream.scaladsl.Source
+import pekko.stream.scaladsl.Source
 // #imports
 
 object Restart {

--- a/docs/src/test/scala/docs/stream/operators/source/Tick.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/Tick.scala
@@ -13,14 +13,15 @@
 
 package docs.stream.operators.source
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.Cancellable
-import org.apache.pekko.actor.typed.ActorRef
-import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.actor.typed.scaladsl.AskPattern._
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.util.Timeout
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.Cancellable
+import pekko.actor.typed.ActorRef
+import pekko.actor.typed.ActorSystem
+import pekko.stream.scaladsl.Source
+import pekko.actor.typed.scaladsl.AskPattern._
+import pekko.stream.scaladsl.Flow
+import pekko.util.Timeout
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/operators/source/Unfold.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/Unfold.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.source
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.scaladsl.Source
 
 object Unfold {
 

--- a/docs/src/test/scala/docs/stream/operators/source/UnfoldAsync.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/UnfoldAsync.scala
@@ -13,13 +13,14 @@
 
 package docs.stream.operators.source
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.typed.ActorRef
-import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.util.ByteString
-import org.apache.pekko.actor.typed.scaladsl.AskPattern._
-import org.apache.pekko.util.Timeout
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.typed.ActorRef
+import pekko.actor.typed.ActorSystem
+import pekko.stream.scaladsl.Source
+import pekko.util.ByteString
+import pekko.actor.typed.scaladsl.AskPattern._
+import pekko.util.Timeout
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/operators/source/UnfoldResource.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/UnfoldResource.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.source
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object UnfoldResource {
 

--- a/docs/src/test/scala/docs/stream/operators/source/UnfoldResourceAsync.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/UnfoldResourceAsync.scala
@@ -13,10 +13,11 @@
 
 package docs.stream.operators.source
 
-import org.apache.pekko.Done
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.Done
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 import scala.concurrent.Future
 

--- a/docs/src/test/scala/docs/stream/operators/source/Zip.scala
+++ b/docs/src/test/scala/docs/stream/operators/source/Zip.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.source
 
-import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.actor.typed.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object Zip {
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Collect.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Collect.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Flow, Sink, Source }
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Flow, Sink, Source }
 
 object Collect {
   private implicit val system: ActorSystem = null

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/CompletionTimeout.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/CompletionTimeout.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.Done
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Flow, Sink, Source }
+import org.apache.pekko
+import pekko.Done
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Flow, Sink, Source }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContextExecutor, Future }

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Conflate.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Conflate.scala
@@ -15,7 +15,8 @@ package docs.stream.operators.sourceorflow
 
 //#conflate
 //#conflateWithSeed
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.stream.scaladsl.Source
 
 //#conflateWithSeed
 //#conflate

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Drop.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Drop.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object Drop {
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/ExtrapolateAndExpand.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/ExtrapolateAndExpand.scala
@@ -13,15 +13,16 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.actor.Cancellable
-import org.apache.pekko.stream.DelayOverflowStrategy
-import org.apache.pekko.stream.scaladsl.DelayStrategy
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.actor.Cancellable
+import pekko.stream.DelayOverflowStrategy
+import pekko.stream.scaladsl.DelayStrategy
+import pekko.stream.scaladsl.Flow
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
+import pekko.util.ByteString
 import docs.stream.operators.sourceorflow.ExtrapolateAndExpand.fps
 import docs.stream.operators.sourceorflow.ExtrapolateAndExpand.nowInSeconds
 import docs.stream.operators.sourceorflow.ExtrapolateAndExpand.periodInMillis

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/ExtrapolateAndExpand.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/ExtrapolateAndExpand.scala
@@ -23,6 +23,7 @@ import pekko.stream.scaladsl.Flow
 import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
+
 import docs.stream.operators.sourceorflow.ExtrapolateAndExpand.fps
 import docs.stream.operators.sourceorflow.ExtrapolateAndExpand.nowInSeconds
 import docs.stream.operators.sourceorflow.ExtrapolateAndExpand.periodInMillis

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Filter.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Filter.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object Filter {
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/FlatMapConcat.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/FlatMapConcat.scala
@@ -12,9 +12,11 @@
  */
 
 package docs.stream.operators.sourceorflow
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object FlatMapConcat {
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/FlatMapMerge.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/FlatMapMerge.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object FlatMapMerge {
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/GroupBy.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/GroupBy.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object GroupBy {
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Grouped.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Grouped.scala
@@ -12,7 +12,9 @@
  */
 
 package docs.stream.operators.sourceorflow
-import org.apache.pekko.stream.scaladsl.Source
+
+import org.apache.pekko
+import pekko.stream.scaladsl.Source
 
 object Grouped {
   def groupedExample(): Unit = {

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/GroupedAdjacentBy.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/GroupedAdjacentBy.scala
@@ -13,7 +13,8 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.stream.scaladsl.Source
 
 import scala.collection.immutable
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/GroupedWeighted.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/GroupedWeighted.scala
@@ -15,6 +15,7 @@ package docs.stream.operators.sourceorflow
 
 import org.apache.pekko
 import pekko.stream.scaladsl.Source
+
 import scala.collection.immutable
 
 object GroupedWeighted {

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/GroupedWeighted.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/GroupedWeighted.scala
@@ -12,7 +12,9 @@
  */
 
 package docs.stream.operators.sourceorflow
-import org.apache.pekko.stream.scaladsl.Source
+
+import org.apache.pekko
+import pekko.stream.scaladsl.Source
 import scala.collection.immutable
 
 object GroupedWeighted {

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Intersperse.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Intersperse.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 
 object Intersperse {
   def main(args: Array[String]): Unit = {

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Limit.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Limit.scala
@@ -13,10 +13,11 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.typed.ActorSystem
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 
 import scala.concurrent.Future
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/LimitWeighted.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/LimitWeighted.scala
@@ -13,10 +13,11 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.typed.ActorSystem
+import pekko.stream.scaladsl.Source
+import pekko.util.ByteString
 
 import scala.concurrent.Future
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Log.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Log.scala
@@ -13,9 +13,10 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko
+import pekko.stream.scaladsl.Flow
 //#log
-import org.apache.pekko.stream.Attributes
+import pekko.stream.Attributes
 
 //#log
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/LogWithMarker.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/LogWithMarker.scala
@@ -13,9 +13,9 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.stream.scaladsl.Flow
-//#logWithMarker
 import org.apache.pekko
+import pekko.stream.scaladsl.Flow
+//#logWithMarker
 import pekko.event.LogMarker
 import pekko.stream.Attributes
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/MapConcat.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/MapConcat.scala
@@ -13,7 +13,8 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.stream.scaladsl.Source
 
 import scala.concurrent.ExecutionContext
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/MapError.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/MapError.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.ExecutionContext
 import scala.util.control.NoStackTrace

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/MapWithResource.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/MapWithResource.scala
@@ -17,8 +17,9 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 import java.net.URL
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/MergeLatest.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/MergeLatest.scala
@@ -12,8 +12,10 @@
  */
 
 package docs.stream.operators.sourceorflow
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 object MergeLatest {
   def main(args: Array[String]): Unit = {

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Monitor.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Monitor.scala
@@ -13,13 +13,14 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.FlowMonitor
-import org.apache.pekko.stream.FlowMonitorState
-import org.apache.pekko.stream.scaladsl.Keep
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.FlowMonitor
+import pekko.stream.FlowMonitorState
+import pekko.stream.scaladsl.Keep
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Reduce.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Reduce.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sink
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Scan.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Scan.scala
@@ -12,7 +12,9 @@
  */
 
 package docs.stream.operators.sourceorflow
-import org.apache.pekko.stream.scaladsl.Source
+
+import org.apache.pekko
+import pekko.stream.scaladsl.Source
 
 object Scan {
   def scanExample(): Unit = {

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/ScanAsync.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/ScanAsync.scala
@@ -13,7 +13,8 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.stream.scaladsl.Source
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Sliding.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Sliding.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+import pekko.stream.scaladsl.Source
+import pekko.actor.ActorSystem
 
 object Sliding {
   implicit val system: ActorSystem = ???

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Split.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Split.scala
@@ -19,8 +19,9 @@ import java.time.ZoneOffset
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 
 import scala.annotation.nowarn
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Throttle.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Throttle.scala
@@ -13,11 +13,12 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.ThrottleMode
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorSystem
+import pekko.stream.ThrottleMode
+import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 
 import scala.concurrent.duration._
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/Watch.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/Watch.scala
@@ -13,10 +13,11 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.stream.WatchedActorTerminatedException
-import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.actor.ActorRef
+import pekko.stream.WatchedActorTerminatedException
+import pekko.stream.scaladsl.Flow
 
 object Watch {
 

--- a/docs/src/test/scala/docs/stream/operators/sourceorflow/WatchTermination.scala
+++ b/docs/src/test/scala/docs/stream/operators/sourceorflow/WatchTermination.scala
@@ -13,8 +13,9 @@
 
 package docs.stream.operators.sourceorflow
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.stream.scaladsl.Source
 
 import scala.concurrent.ExecutionContext
 import scala.util.{ Failure, Success }

--- a/docs/src/test/scala/docs/testkit/ParentChildSpec.scala
+++ b/docs/src/test/scala/docs/testkit/ParentChildSpec.scala
@@ -15,14 +15,15 @@ package docs.testkit
 
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
-import org.apache.pekko.testkit.TestKitBase
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.actor.Props
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.testkit.TestProbe
-import org.apache.pekko.actor.ActorRefFactory
-import org.apache.pekko.testkit.TestKit
+import org.apache.pekko
+import pekko.testkit.TestKitBase
+import pekko.actor.ActorSystem
+import pekko.actor.Props
+import pekko.actor.Actor
+import pekko.actor.ActorRef
+import pekko.testkit.TestProbe
+import pekko.actor.ActorRefFactory
+import pekko.testkit.TestKit
 import org.scalatest.BeforeAndAfterAll
 
 /**

--- a/docs/src/test/scala/docs/testkit/ParentChildSpec.scala
+++ b/docs/src/test/scala/docs/testkit/ParentChildSpec.scala
@@ -24,6 +24,7 @@ import pekko.actor.ActorRef
 import pekko.testkit.TestProbe
 import pekko.actor.ActorRefFactory
 import pekko.testkit.TestKit
+
 import org.scalatest.BeforeAndAfterAll
 
 /**

--- a/docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
+++ b/docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
@@ -14,9 +14,9 @@
 package docs.testkit
 
 import org.apache.pekko
+import pekko.testkit._
 
 import scala.util.Success
-import pekko.testkit._
 
 //#imports-test-probe
 import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
+++ b/docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
@@ -13,13 +13,15 @@
 
 package docs.testkit
 
+import org.apache.pekko
+
 import scala.util.Success
-import org.apache.pekko.testkit._
+import pekko.testkit._
 
 //#imports-test-probe
 import scala.concurrent.duration._
-import org.apache.pekko.actor._
-import org.apache.pekko.testkit.TestProbe
+import pekko.actor._
+import pekko.testkit.TestProbe
 
 //#imports-test-probe
 

--- a/docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala
+++ b/docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala
@@ -22,6 +22,7 @@ package com.example
 
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 import pekko.actor.typed.PostStop
 import pekko.actor.typed.PreRestart

--- a/docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala
+++ b/docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala
@@ -20,15 +20,15 @@ package com.example
 //#print-refs
  */
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.apache.pekko.actor.typed.PostStop
-import org.apache.pekko.actor.typed.PreRestart
-import org.apache.pekko.actor.typed.Signal
-import org.apache.pekko.actor.typed.SupervisorStrategy
+import pekko.actor.typed.PostStop
+import pekko.actor.typed.PreRestart
+import pekko.actor.typed.Signal
+import pekko.actor.typed.SupervisorStrategy
 
 //#print-refs
-import org.apache.pekko
 import pekko.actor.typed.ActorSystem
 import pekko.actor.typed.Behavior
 import pekko.actor.typed.scaladsl.AbstractBehavior

--- a/docs/src/test/scala/typed/tutorial_2/IotApp.scala
+++ b/docs/src/test/scala/typed/tutorial_2/IotApp.scala
@@ -17,11 +17,13 @@ package typed.tutorial_2
 //#iot-app
 package com.example
 
+
 //#iot-app
  */
 
 //#iot-app
-import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko
+import pekko.actor.typed.ActorSystem
 
 object IotApp {
 

--- a/docs/src/test/scala/typed/tutorial_3/DeviceInProgress.scala
+++ b/docs/src/test/scala/typed/tutorial_3/DeviceInProgress.scala
@@ -13,6 +13,8 @@
 
 package typed.tutorial_3
 
+import org.apache.pekko
+
 /*
 //#read-protocol-1
 package com.example
@@ -20,8 +22,8 @@ package com.example
 //#read-protocol-1
  */
 
-import org.apache.pekko.actor.typed.PostStop
-import org.apache.pekko.actor.typed.Signal
+import pekko.actor.typed.PostStop
+import pekko.actor.typed.Signal
 
 object DeviceInProgress1 {
 

--- a/docs/src/test/scala/typed/tutorial_3/DeviceSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_3/DeviceSpec.scala
@@ -16,6 +16,7 @@ package typed.tutorial_3
 //#device-read-test
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class DeviceSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {

--- a/docs/src/test/scala/typed/tutorial_3/DeviceSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_3/DeviceSpec.scala
@@ -14,7 +14,8 @@
 package typed.tutorial_3
 
 //#device-read-test
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class DeviceSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {

--- a/docs/src/test/scala/typed/tutorial_4/DeviceGroup.scala
+++ b/docs/src/test/scala/typed/tutorial_4/DeviceGroup.scala
@@ -15,14 +15,15 @@ package typed.tutorial_4
 
 import scala.annotation.nowarn
 
-import org.apache.pekko.actor.typed.ActorRef
-import org.apache.pekko.actor.typed.Behavior
-import org.apache.pekko.actor.typed.PostStop
-import org.apache.pekko.actor.typed.Signal
-import org.apache.pekko.actor.typed.scaladsl.AbstractBehavior
-import org.apache.pekko.actor.typed.scaladsl.ActorContext
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
-import org.apache.pekko.actor.typed.scaladsl.LoggerOps
+import org.apache.pekko
+import pekko.actor.typed.ActorRef
+import pekko.actor.typed.Behavior
+import pekko.actor.typed.PostStop
+import pekko.actor.typed.Signal
+import pekko.actor.typed.scaladsl.AbstractBehavior
+import pekko.actor.typed.scaladsl.ActorContext
+import pekko.actor.typed.scaladsl.Behaviors
+import pekko.actor.typed.scaladsl.LoggerOps
 
 //#device-group-full
 //#device-group-register

--- a/docs/src/test/scala/typed/tutorial_4/DeviceGroupSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_4/DeviceGroupSpec.scala
@@ -16,6 +16,7 @@ package typed.tutorial_4
 import scala.concurrent.duration._
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_4.Device._
 import typed.tutorial_4.DeviceManager._

--- a/docs/src/test/scala/typed/tutorial_4/DeviceGroupSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_4/DeviceGroupSpec.scala
@@ -14,7 +14,8 @@
 package typed.tutorial_4
 
 import scala.concurrent.duration._
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_4.Device._
 import typed.tutorial_4.DeviceManager._

--- a/docs/src/test/scala/typed/tutorial_4/DeviceManager.scala
+++ b/docs/src/test/scala/typed/tutorial_4/DeviceManager.scala
@@ -13,13 +13,14 @@
 
 package typed.tutorial_4
 
-import org.apache.pekko.actor.typed.ActorRef
-import org.apache.pekko.actor.typed.Behavior
-import org.apache.pekko.actor.typed.PostStop
-import org.apache.pekko.actor.typed.Signal
-import org.apache.pekko.actor.typed.scaladsl.AbstractBehavior
-import org.apache.pekko.actor.typed.scaladsl.ActorContext
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko
+import pekko.actor.typed.ActorRef
+import pekko.actor.typed.Behavior
+import pekko.actor.typed.PostStop
+import pekko.actor.typed.Signal
+import pekko.actor.typed.scaladsl.AbstractBehavior
+import pekko.actor.typed.scaladsl.ActorContext
+import pekko.actor.typed.scaladsl.Behaviors
 
 //#device-manager-full
 object DeviceManager {

--- a/docs/src/test/scala/typed/tutorial_4/DeviceManagerSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_4/DeviceManagerSpec.scala
@@ -15,6 +15,7 @@ package typed.tutorial_4
 
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_4.DeviceManager._
 

--- a/docs/src/test/scala/typed/tutorial_4/DeviceManagerSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_4/DeviceManagerSpec.scala
@@ -13,7 +13,8 @@
 
 package typed.tutorial_4
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_4.DeviceManager._
 

--- a/docs/src/test/scala/typed/tutorial_4/DeviceSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_4/DeviceSpec.scala
@@ -13,7 +13,8 @@
 
 package typed.tutorial_4
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class DeviceSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {

--- a/docs/src/test/scala/typed/tutorial_4/DeviceSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_4/DeviceSpec.scala
@@ -15,6 +15,7 @@ package typed.tutorial_4
 
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class DeviceSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {

--- a/docs/src/test/scala/typed/tutorial_5/DeviceGroupQuerySpec.scala
+++ b/docs/src/test/scala/typed/tutorial_5/DeviceGroupQuerySpec.scala
@@ -16,6 +16,7 @@ package typed.tutorial_5
 import scala.concurrent.duration._
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_5.Device.Command
 import typed.tutorial_5.DeviceGroupQuery.WrappedRespondTemperature

--- a/docs/src/test/scala/typed/tutorial_5/DeviceGroupQuerySpec.scala
+++ b/docs/src/test/scala/typed/tutorial_5/DeviceGroupQuerySpec.scala
@@ -14,7 +14,8 @@
 package typed.tutorial_5
 
 import scala.concurrent.duration._
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_5.Device.Command
 import typed.tutorial_5.DeviceGroupQuery.WrappedRespondTemperature

--- a/docs/src/test/scala/typed/tutorial_5/DeviceGroupSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_5/DeviceGroupSpec.scala
@@ -14,7 +14,8 @@
 package typed.tutorial_5
 
 import scala.concurrent.duration._
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_5.Device._
 import typed.tutorial_5.DeviceManager._

--- a/docs/src/test/scala/typed/tutorial_5/DeviceGroupSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_5/DeviceGroupSpec.scala
@@ -16,6 +16,7 @@ package typed.tutorial_5
 import scala.concurrent.duration._
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_5.Device._
 import typed.tutorial_5.DeviceManager._

--- a/docs/src/test/scala/typed/tutorial_5/DeviceManagerSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_5/DeviceManagerSpec.scala
@@ -13,7 +13,8 @@
 
 package typed.tutorial_5
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_5.DeviceManager._
 

--- a/docs/src/test/scala/typed/tutorial_5/DeviceManagerSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_5/DeviceManagerSpec.scala
@@ -15,6 +15,7 @@ package typed.tutorial_5
 
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 import typed.tutorial_5.DeviceManager._
 

--- a/docs/src/test/scala/typed/tutorial_5/DeviceSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_5/DeviceSpec.scala
@@ -15,6 +15,7 @@ package typed.tutorial_5
 
 import org.apache.pekko
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class DeviceSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {

--- a/docs/src/test/scala/typed/tutorial_5/DeviceSpec.scala
+++ b/docs/src/test/scala/typed/tutorial_5/DeviceSpec.scala
@@ -13,7 +13,8 @@
 
 package typed.tutorial_5
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class DeviceSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {

--- a/osgi/src/test/scala/docs/osgi/Activator.scala
+++ b/osgi/src/test/scala/docs/osgi/Activator.scala
@@ -22,7 +22,6 @@ class SomeActor extends pekko.actor.Actor {
 }
 
 //#Activator
-import org.apache.pekko
 import pekko.actor.{ ActorSystem, Props }
 import org.osgi.framework.BundleContext
 import pekko.osgi.ActorSystemActivator

--- a/osgi/src/test/scala/org/apache/pekko/osgi/test/PingPong.scala
+++ b/osgi/src/test/scala/org/apache/pekko/osgi/test/PingPong.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.osgi.test
 
-import org.apache.pekko.actor.Actor
+import org.apache.pekko
+import pekko.actor.Actor
 
 /**
  * Simple ping-pong actor, used for testing

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/DurableStateChange.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/DurableStateChange.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence.query
 
-import org.apache.pekko.annotation.DoNotInherit
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 /**
  * The `DurableStateStoreQuery` stream elements for `DurableStateStoreQuery`.

--- a/persistence-query/src/test/scala/org/apache/pekko/persistence/query/TestClock.scala
+++ b/persistence-query/src/test/scala/org/apache/pekko/persistence/query/TestClock.scala
@@ -21,7 +21,8 @@ import java.time.ZoneOffset
 
 import scala.concurrent.duration.FiniteDuration
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/persistence-query/src/test/scala/org/apache/pekko/persistence/query/journal/leveldb/Cleanup.scala
+++ b/persistence-query/src/test/scala/org/apache/pekko/persistence/query/journal/leveldb/Cleanup.scala
@@ -17,7 +17,8 @@ import java.io.File
 
 import org.apache.commons.io.FileUtils
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 trait Cleanup { this: PekkoSpec =>
   val storageLocations =

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/scalatest/OptionalTests.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/scalatest/OptionalTests.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence.scalatest
 
-import org.apache.pekko.persistence.CapabilityFlag
+import org.apache.pekko
+import pekko.persistence.CapabilityFlag
 
 import org.scalatest.Informing
 

--- a/persistence-tck/src/test/scala/org/apache/pekko/persistence/japi/JavaJournalSpecSpec.scala
+++ b/persistence-tck/src/test/scala/org/apache/pekko/persistence/japi/JavaJournalSpecSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence.japi
 
-import org.apache.pekko.persistence.japi.journal.JavaJournalSpec
+import org.apache.pekko
+import pekko.persistence.japi.journal.JavaJournalSpec
 
 import org.scalatest.DoNotDiscover
 

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/ProcessingPolicy.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/ProcessingPolicy.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.persistence.testkit
 
 import scala.util.control.NoStackTrace
 
-import org.apache.pekko.annotation.{ ApiMayChange, InternalApi }
+import org.apache.pekko
+import pekko.annotation.{ ApiMayChange, InternalApi }
 
 /**
  * Policies allow to emulate behavior of the storage (failures and rejections).

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/CurrentTime.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/CurrentTime.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.persistence.testkit.internal
 
 import java.util.concurrent.atomic.AtomicLong
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/crdt/LwwTime.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/crdt/LwwTime.scala
@@ -12,7 +12,9 @@
  */
 
 package org.apache.pekko.persistence.typed.crdt
-import org.apache.pekko.persistence.typed.ReplicaId
+
+import org.apache.pekko
+import pekko.persistence.typed.ReplicaId
 
 /**
  * Utility class for comparing timestamp replica

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/crdt/OpCrdt.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/crdt/OpCrdt.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence.typed.crdt
 
-import org.apache.pekko.annotation.DoNotInherit
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 @DoNotInherit
 trait OpCrdt[Operation] { self =>

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/VersionVector.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/VersionVector.scala
@@ -12,10 +12,12 @@
  */
 
 package org.apache.pekko.persistence.typed.internal
+
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeMap
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/persistence-typed/src/test/scala/docs/org/apache/pekko/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
+++ b/persistence-typed/src/test/scala/docs/org/apache/pekko/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
@@ -28,13 +28,11 @@ import pekko.persistence.typed.EventSeq
 import pekko.persistence.typed.scaladsl.Recovery
 //#structure
 //#behavior
-import org.apache.pekko
 import pekko.persistence.typed.scaladsl.EventSourcedBehavior
 import pekko.persistence.typed.PersistenceId
 
 //#behavior
 //#structure
-import org.apache.pekko
 import pekko.persistence.typed.SnapshotFailed
 import scala.annotation.nowarn
 
@@ -215,7 +213,6 @@ object BasicPersistentBehaviorCompileOnly {
 
   object BehaviorWithContext {
     // #actor-context
-    import org.apache.pekko
     import pekko.persistence.typed.scaladsl.Effect
     import pekko.persistence.typed.scaladsl.EventSourcedBehavior.CommandHandler
 

--- a/persistence-typed/src/test/scala/docs/org/apache/pekko/persistence/typed/DurableStatePersistentBehaviorCompileOnly.scala
+++ b/persistence-typed/src/test/scala/docs/org/apache/pekko/persistence/typed/DurableStatePersistentBehaviorCompileOnly.scala
@@ -22,7 +22,6 @@ import pekko.persistence.typed.state.scaladsl.Effect
 
 //#structure
 //#behavior
-import org.apache.pekko
 import pekko.persistence.typed.state.scaladsl.DurableStateBehavior
 import pekko.persistence.typed.PersistenceId
 
@@ -116,7 +115,6 @@ object DurableStatePersistentBehaviorCompileOnly {
 
   object BehaviorWithContext {
     // #actor-context
-    import org.apache.pekko
     import pekko.persistence.typed.state.scaladsl.Effect
     import pekko.persistence.typed.state.scaladsl.DurableStateBehavior.CommandHandler
 

--- a/persistence-typed/src/test/scala/org/apache/pekko/persistence/typed/PersistenceIdSpec.scala
+++ b/persistence-typed/src/test/scala/org/apache/pekko/persistence/typed/PersistenceIdSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence.typed
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.LogCapturing
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.LogCapturing
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/persistence/src/main/scala-2/org/apache/pekko/persistence/TraitOrder.scala
+++ b/persistence/src/main/scala-2/org/apache/pekko/persistence/TraitOrder.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/persistence/src/main/scala-3/org/apache/pekko/persistence/TraitOrder.scala
+++ b/persistence/src/main/scala-3/org/apache/pekko/persistence/TraitOrder.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/persistence/src/main/scala/org/apache/pekko/persistence/JournalProtocol.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/JournalProtocol.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.persistence
 
 import scala.collection.immutable
 
-import org.apache.pekko.actor._
+import org.apache.pekko
+import pekko.actor._
 
 /**
  * INTERNAL API.

--- a/persistence/src/main/scala/org/apache/pekko/persistence/Protocol.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Protocol.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence
 
-import org.apache.pekko.actor.NoSerializationVerificationNeeded
+import org.apache.pekko
+import pekko.actor.NoSerializationVerificationNeeded
 
 /**
  * INTERNAL API.

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/LeveldbCompaction.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/LeveldbCompaction.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.persistence.journal.leveldb
 
-import org.apache.pekko.actor.{ Actor, ActorLogging }
+import org.apache.pekko
+import pekko.actor.{ Actor, ActorLogging }
 
 private[persistence] object LeveldbCompaction {
 

--- a/persistence/src/test/scala/org/apache/pekko/persistence/journal/AsyncWriteJournalResponseOrderSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/journal/AsyncWriteJournalResponseOrderSpec.scala
@@ -21,9 +21,10 @@ import scala.collection.{ immutable, mutable }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.Try
 
-import org.apache.pekko.persistence.{ AtomicWrite, JournalProtocol, PersistenceSpec, PersistentRepr }
-import org.apache.pekko.persistence.journal.AsyncWriteJournalResponseOrderSpec._
-import org.apache.pekko.testkit.ImplicitSender
+import org.apache.pekko
+import pekko.persistence.{ AtomicWrite, JournalProtocol, PersistenceSpec, PersistentRepr }
+import pekko.persistence.journal.AsyncWriteJournalResponseOrderSpec._
+import pekko.testkit.ImplicitSender
 
 /**
  * Verifies write response ordering logic for [[AsyncWriteJournal]].

--- a/pki/src/main/scala/org/apache/pekko/pki/pem/PEMDecoder.scala
+++ b/pki/src/main/scala/org/apache/pekko/pki/pem/PEMDecoder.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.pki.pem
 
 import java.util.Base64
 
-import org.apache.pekko.annotation.ApiMayChange
+import org.apache.pekko
+import pekko.annotation.ApiMayChange
 
 /**
  * Decodes lax PEM encoded data, according to

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -15,7 +15,8 @@ import com.lightbend.paradox.sbt.ParadoxPlugin
 import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport._
 import com.lightbend.paradox.apidoc.ApidocPlugin
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys.projectInfoVersion
-import org.apache.pekko.PekkoParadoxPlugin.autoImport._
+import org.apache.pekko
+import pekko.PekkoParadoxPlugin.autoImport._
 import sbt.Keys._
 import sbt._
 import sbtlicensereport.SbtLicenseReport.autoImportImpl.dumpLicenseReportAggregate

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -17,6 +17,7 @@ import com.lightbend.paradox.apidoc.ApidocPlugin
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys.projectInfoVersion
 import org.apache.pekko
 import pekko.PekkoParadoxPlugin.autoImport._
+
 import sbt.Keys._
 import sbt._
 import sbtlicensereport.SbtLicenseReport.autoImportImpl.dumpLicenseReportAggregate

--- a/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/artery/BenchmarkFileReporter.scala
+++ b/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/artery/BenchmarkFileReporter.scala
@@ -23,7 +23,8 @@ import java.time.format.DateTimeFormatter
 
 import scala.util.Try
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+import pekko.actor.ActorSystem
 
 /**
  * Simple to file logger for benchmark results. Will log relevant settings first to make sure

--- a/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/routing/RemoteRoundRobinSpec.scala
+++ b/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/routing/RemoteRoundRobinSpec.scala
@@ -17,12 +17,13 @@ import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import org.apache.pekko.actor.{ Actor, ActorRef, Address, PoisonPill, Props }
-import org.apache.pekko.pattern.ask
-import org.apache.pekko.remote.RemotingMultiNodeSpec
-import org.apache.pekko.remote.testkit.MultiNodeConfig
-import org.apache.pekko.routing._
-import org.apache.pekko.testkit._
+import org.apache.pekko
+import pekko.actor.{ Actor, ActorRef, Address, PoisonPill, Props }
+import pekko.pattern.ask
+import pekko.remote.RemotingMultiNodeSpec
+import pekko.remote.testkit.MultiNodeConfig
+import pekko.routing._
+import pekko.testkit._
 
 import com.typesafe.config.ConfigFactory
 

--- a/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/routing/RemoteScatterGatherSpec.scala
+++ b/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/routing/RemoteScatterGatherSpec.scala
@@ -15,18 +15,19 @@ package org.apache.pekko.remote.routing
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.actor.Address
-import org.apache.pekko.actor.PoisonPill
-import org.apache.pekko.actor.Props
-import org.apache.pekko.remote.RemotingMultiNodeSpec
-import org.apache.pekko.remote.testkit.MultiNodeConfig
-import org.apache.pekko.routing.Broadcast
-import org.apache.pekko.routing.RoutedActorRef
-import org.apache.pekko.routing.ScatterGatherFirstCompletedPool
-import org.apache.pekko.testkit._
-import org.apache.pekko.testkit.TestEvent._
+import org.apache.pekko
+import pekko.actor.Actor
+import pekko.actor.ActorRef
+import pekko.actor.Address
+import pekko.actor.PoisonPill
+import pekko.actor.Props
+import pekko.remote.RemotingMultiNodeSpec
+import pekko.remote.testkit.MultiNodeConfig
+import pekko.routing.Broadcast
+import pekko.routing.RoutedActorRef
+import pekko.routing.ScatterGatherFirstCompletedPool
+import pekko.testkit._
+import pekko.testkit.TestEvent._
 
 import com.typesafe.config.ConfigFactory
 

--- a/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/sample/MultiNodeSample.scala
+++ b/remote-tests/src/multi-jvm/scala/org/apache/pekko/remote/sample/MultiNodeSample.scala
@@ -17,7 +17,8 @@ package org.apache.pekko.remote.sample
 //#package
 
 //#config
-import org.apache.pekko.remote.testkit.{ MultiNodeConfig, STMultiNodeSpec }
+import org.apache.pekko
+import pekko.remote.testkit.{ MultiNodeConfig, STMultiNodeSpec }
 
 object MultiNodeSampleConfig extends MultiNodeConfig {
   val node1 = role("node1")
@@ -26,7 +27,6 @@ object MultiNodeSampleConfig extends MultiNodeConfig {
 //#config
 
 //#spec
-import org.apache.pekko
 import pekko.actor.{ Actor, Props }
 import pekko.remote.testkit.MultiNodeSpec
 import pekko.testkit.ImplicitSender

--- a/remote/src/main/scala/org/apache/pekko/remote/UniqueAddress.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/UniqueAddress.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.remote
 
-import org.apache.pekko.actor.Address
+import org.apache.pekko
+import pekko.actor.Address
 
 @SerialVersionUID(1L)
 final case class UniqueAddress(address: Address, uid: Long) extends Ordered[UniqueAddress] {

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/QuarantinedEvent.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/QuarantinedEvent.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.remote.artery
 
-import org.apache.pekko.remote.UniqueAddress
+import org.apache.pekko
+import pekko.remote.UniqueAddress
 
 final case class QuarantinedEvent(uniqueAddress: UniqueAddress) {
 

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/SessionVerifier.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/SessionVerifier.scala
@@ -16,7 +16,8 @@ package org.apache.pekko.remote.artery.tcp.ssl
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLSession
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * Allows hooking in extra verification before finishing the SSL handshake.

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettySSLSupport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/NettySSLSupport.scala
@@ -23,7 +23,8 @@ import io.netty.handler.ssl.SslHandler
 import io.netty.util.concurrent.Future
 
 import com.typesafe.config.Config
-import org.apache.pekko.event.MarkerLoggingAdapter
+import org.apache.pekko
+import pekko.event.MarkerLoggingAdapter
 
 /**
  * INTERNAL API

--- a/remote/src/test/scala/org/apache/pekko/remote/AckedDeliverySpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/AckedDeliverySpec.scala
@@ -18,7 +18,8 @@ import java.util.concurrent.ThreadLocalRandom
 import scala.annotation.nowarn
 import scala.annotation.tailrec
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 @nowarn("msg=deprecated")
 object AckedDeliverySpec {

--- a/remote/src/test/scala/org/apache/pekko/remote/RemoteActorMailboxSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/RemoteActorMailboxSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.remote
 
-import org.apache.pekko.actor.ActorMailboxSpec
+import org.apache.pekko
+import pekko.actor.ActorMailboxSpec
 
 import com.typesafe.config.ConfigFactory
 

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/ImmutableLongMapSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/ImmutableLongMapSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.remote.artery
 
 import scala.util.Random
 
-import org.apache.pekko.util.OptionVal
+import org.apache.pekko
+import pekko.util.OptionVal
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteFailureSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteFailureSpec.scala
@@ -16,8 +16,8 @@ package org.apache.pekko.remote.artery
 import scala.concurrent.duration._
 
 import org.apache.pekko
-import org.apache.pekko.actor.ActorIdentity
-import org.apache.pekko.actor.Identify
+import pekko.actor.ActorIdentity
+import pekko.actor.Identify
 import pekko.remote.EndpointDisassociatedException
 import pekko.serialization.jackson.CborSerializable
 import pekko.testkit.{ EventFilter, ImplicitSender, TestActors, TestEvent }

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RollingEventLogSimulationSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RollingEventLogSimulationSpec.scala
@@ -17,7 +17,8 @@ import scala.annotation.tailrec
 import scala.util.Random
 import scala.util.control.NonFatal
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 /*
  * This test is a simulation of the actual concurrent rolling log implemented in SnapshottableRollingEventLog. It

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/SerializationTransportInformationSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/SerializationTransportInformationSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.remote.artery
 
-import org.apache.pekko.remote.serialization.AbstractSerializationTransportInformationSpec
+import org.apache.pekko
+import pekko.remote.serialization.AbstractSerializationTransportInformationSpec
 
 class SerializationTransportInformationSpec
     extends AbstractSerializationTransportInformationSpec(ArterySpecSupport.defaultConfig)

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/TransientSerializationErrorSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/TransientSerializationErrorSpec.scala
@@ -13,6 +13,7 @@
 
 package org.apache.pekko.remote.artery
 
-import org.apache.pekko.remote.AbstractTransientSerializationErrorSpec
+import org.apache.pekko
+import pekko.remote.AbstractTransientSerializationErrorSpec
 
 class TransientSerializationErrorSpec extends AbstractTransientSerializationErrorSpec(ArterySpecSupport.defaultConfig)

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/compress/CompressionTableSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/compress/CompressionTableSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.remote.artery.compress
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 class CompressionTableSpec extends PekkoSpec {
 

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/compress/CompressionTestUtils.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/compress/CompressionTestUtils.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.remote.artery.compress
 
-import org.apache.pekko.actor._
+import org.apache.pekko
+import pekko.actor._
 
 object CompressionTestUtils {
 

--- a/remote/src/test/scala/org/apache/pekko/remote/transport/netty/NettySSLSupportSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/transport/netty/NettySSLSupportSpec.scala
@@ -21,7 +21,8 @@ import java.net.InetSocketAddress
 
 import scala.annotation.nowarn
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 @nowarn("msg=deprecated")
 class NettySSLSupportSpec extends PekkoSpec {

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/PekkoSerializationModule.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/PekkoSerializationModule.scala
@@ -18,7 +18,8 @@ import com.fasterxml.jackson.databind.{ DeserializationContext, JsonNode, Serial
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer
 
-import org.apache.pekko.serialization.{ SerializationExtension, Serializer, Serializers }
+import org.apache.pekko
+import pekko.serialization.{ SerializationExtension, Serializer, Serializers }
 
 final class PekkoSerializationSerializer extends StdScalarSerializer[AnyRef](classOf[AnyRef]) with ActorSystemAccess {
   def serialization = SerializationExtension(currentSystem())

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v1withv2/ItemAddedMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v1withv2/ItemAddedMigration.scala
@@ -14,7 +14,8 @@
 package doc.org.apache.pekko.serialization.jackson.v1withv2
 
 // #forward-one-rename
-import org.apache.pekko.serialization.jackson.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson.JacksonMigration
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v1withv2/ItemAddedMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v1withv2/ItemAddedMigration.scala
@@ -16,6 +16,7 @@ package doc.org.apache.pekko.serialization.jackson.v1withv2
 // #forward-one-rename
 import org.apache.pekko
 import pekko.serialization.jackson.JacksonMigration
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/CustomerMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/CustomerMigration.scala
@@ -16,6 +16,7 @@ package doc.org.apache.pekko.serialization.jackson.v2a
 // #structural
 import org.apache.pekko
 import pekko.serialization.jackson.JacksonMigration
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/CustomerMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/CustomerMigration.scala
@@ -14,7 +14,8 @@
 package doc.org.apache.pekko.serialization.jackson.v2a
 
 // #structural
-import org.apache.pekko.serialization.jackson.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson.JacksonMigration
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/OrderPlacedMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/OrderPlacedMigration.scala
@@ -13,7 +13,8 @@
 
 package doc.org.apache.pekko.serialization.jackson.v2a
 
-import org.apache.pekko.serialization.jackson.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson.JacksonMigration
 import com.fasterxml.jackson.databind.JsonNode
 
 // #rename-class

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/OrderPlacedMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2a/OrderPlacedMigration.scala
@@ -15,6 +15,7 @@ package doc.org.apache.pekko.serialization.jackson.v2a
 
 import org.apache.pekko
 import pekko.serialization.jackson.JacksonMigration
+
 import com.fasterxml.jackson.databind.JsonNode
 
 // #rename-class

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2b/ItemAddedMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2b/ItemAddedMigration.scala
@@ -17,7 +17,8 @@ package doc.org.apache.pekko.serialization.jackson.v2b
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.DoubleNode
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.apache.pekko.serialization.jackson.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson.JacksonMigration
 
 class ItemAddedMigration extends JacksonMigration {
 

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2c/ItemAddedMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2c/ItemAddedMigration.scala
@@ -14,7 +14,8 @@
 package doc.org.apache.pekko.serialization.jackson.v2c
 
 // #rename
-import org.apache.pekko.serialization.jackson.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson.JacksonMigration
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2c/ItemAddedMigration.scala
+++ b/serialization-jackson/src/test/scala/doc/org/apache/pekko/serialization/jackson/v2c/ItemAddedMigration.scala
@@ -16,6 +16,7 @@ package doc.org.apache.pekko.serialization.jackson.v2c
 // #rename
 import org.apache.pekko
 import pekko.serialization.jackson.JacksonMigration
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/PekkoSerializationModule.scala
+++ b/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/PekkoSerializationModule.scala
@@ -18,7 +18,8 @@ import tools.jackson.databind.{ DeserializationContext, JsonNode, SerializationC
 import tools.jackson.databind.deser.std.StdScalarDeserializer
 import tools.jackson.databind.ser.std.StdScalarSerializer
 
-import org.apache.pekko.serialization.{ SerializationExtension, Serializer, Serializers }
+import org.apache.pekko
+import pekko.serialization.{ SerializationExtension, Serializer, Serializers }
 
 final class PekkoSerializationSerializer extends StdScalarSerializer[AnyRef](classOf[AnyRef]) with ActorSystemAccess {
   def serialization = SerializationExtension(currentSystem())

--- a/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v1withv2/ItemAddedMigration.scala
+++ b/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v1withv2/ItemAddedMigration.scala
@@ -14,7 +14,8 @@
 package doc.org.apache.pekko.serialization.jackson3.v1withv2
 
 // #forward-one-rename
-import org.apache.pekko.serialization.jackson3.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson3.JacksonMigration
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v1withv2/ItemAddedMigration.scala
+++ b/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v1withv2/ItemAddedMigration.scala
@@ -16,6 +16,7 @@ package doc.org.apache.pekko.serialization.jackson3.v1withv2
 // #forward-one-rename
 import org.apache.pekko
 import pekko.serialization.jackson3.JacksonMigration
+
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2a/CustomerMigration.scala
+++ b/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2a/CustomerMigration.scala
@@ -14,7 +14,8 @@
 package doc.org.apache.pekko.serialization.jackson3.v2a
 
 // #structural
-import org.apache.pekko.serialization.jackson3.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson3.JacksonMigration
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2a/CustomerMigration.scala
+++ b/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2a/CustomerMigration.scala
@@ -16,6 +16,7 @@ package doc.org.apache.pekko.serialization.jackson3.v2a
 // #structural
 import org.apache.pekko
 import pekko.serialization.jackson3.JacksonMigration
+
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2a/OrderPlacedMigration.scala
+++ b/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2a/OrderPlacedMigration.scala
@@ -13,7 +13,8 @@
 
 package doc.org.apache.pekko.serialization.jackson3.v2a
 
-import org.apache.pekko.serialization.jackson3.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson3.JacksonMigration
 import tools.jackson.databind.JsonNode
 
 // #rename-class

--- a/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2a/OrderPlacedMigration.scala
+++ b/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2a/OrderPlacedMigration.scala
@@ -15,6 +15,7 @@ package doc.org.apache.pekko.serialization.jackson3.v2a
 
 import org.apache.pekko
 import pekko.serialization.jackson3.JacksonMigration
+
 import tools.jackson.databind.JsonNode
 
 // #rename-class

--- a/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2b/ItemAddedMigration.scala
+++ b/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2b/ItemAddedMigration.scala
@@ -17,7 +17,8 @@ package doc.org.apache.pekko.serialization.jackson3.v2b
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.DoubleNode
 import tools.jackson.databind.node.ObjectNode
-import org.apache.pekko.serialization.jackson3.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson3.JacksonMigration
 
 class ItemAddedMigration extends JacksonMigration {
 

--- a/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2c/ItemAddedMigration.scala
+++ b/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2c/ItemAddedMigration.scala
@@ -16,6 +16,7 @@ package doc.org.apache.pekko.serialization.jackson3.v2c
 // #rename
 import org.apache.pekko
 import pekko.serialization.jackson3.JacksonMigration
+
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.ObjectNode
 

--- a/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2c/ItemAddedMigration.scala
+++ b/serialization-jackson3/src/test/scala/doc/org/apache/pekko/serialization/jackson3/v2c/ItemAddedMigration.scala
@@ -14,7 +14,8 @@
 package doc.org.apache.pekko.serialization.jackson3.v2c
 
 // #rename
-import org.apache.pekko.serialization.jackson3.JacksonMigration
+import org.apache.pekko
+import pekko.serialization.jackson3.JacksonMigration
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.ObjectNode
 

--- a/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamConfiguration.scala
+++ b/stream-testkit/src/test/scala/org/apache/pekko/stream/testkit/StreamConfiguration.scala
@@ -19,7 +19,8 @@ package org.apache.pekko.stream.testkit
 
 import java.util.concurrent.TimeUnit
 
-import org.apache.pekko.testkit.TestKitBase
+import org.apache.pekko
+import pekko.testkit.TestKitBase
 
 import org.scalatest.time.{ Millis, Span }
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/CancelledSinkSubscriberTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/CancelledSinkSubscriberTest.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.tck
 
 import org.testng.SkipException
 
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.stream.scaladsl._
 
 import org.reactivestreams.Subscriber
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/EmptyPublisherTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/EmptyPublisherTest.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.tck
 
-import org.apache.pekko.stream.impl.EmptyPublisher
+import org.apache.pekko
+import pekko.stream.impl.EmptyPublisher
 
 import org.reactivestreams.Publisher
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/FlatMapConcatDoubleSubscriberTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/FlatMapConcatDoubleSubscriberTest.scala
@@ -16,7 +16,8 @@ package org.apache.pekko.stream.tck
 import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
 
-import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.pekko
+import pekko.stream.scaladsl.{ Sink, Source }
 
 import org.reactivestreams.{ Publisher, Subscriber }
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/FlatMapPrefixTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/FlatMapPrefixTest.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.tck
 
-import org.apache.pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import org.apache.pekko
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
 
 import org.reactivestreams.Publisher
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/FoldSinkSubscriberTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/FoldSinkSubscriberTest.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.tck
 
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.stream.scaladsl._
 
 import org.reactivestreams.Subscriber
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/ForeachSinkSubscriberTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/ForeachSinkSubscriberTest.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.tck
 
-import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko
+import pekko.stream.scaladsl._
 
 import org.reactivestreams.Subscriber
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/MapTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/MapTest.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.tck
 
-import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko
+import pekko.stream.scaladsl.Flow
 
 import org.reactivestreams.Processor
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/MaybeSourceTest.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/MaybeSourceTest.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.tck
 
-import org.apache.pekko.stream.scaladsl.{ Keep, Sink, Source }
+import org.apache.pekko
+import pekko.stream.scaladsl.{ Keep, Sink, Source }
 
 import org.reactivestreams.Publisher
 

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PekkoIdentityProcessorVerification.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PekkoIdentityProcessorVerification.scala
@@ -20,7 +20,8 @@ import java.util.concurrent.TimeUnit
 import org.scalatestplus.testng.TestNGSuiteLike
 import org.testng.annotations.AfterClass
 
-import org.apache.pekko.stream.testkit.TestPublisher
+import org.apache.pekko
+import pekko.stream.testkit.TestPublisher
 
 import org.reactivestreams.{ Processor, Publisher, Subscriber, Subscription }
 import org.reactivestreams.tck.IdentityProcessorVerification

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PekkoPublisherVerification.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PekkoPublisherVerification.scala
@@ -17,7 +17,8 @@ import scala.collection.immutable
 
 import org.scalatestplus.testng.TestNGSuiteLike
 
-import org.apache.pekko.stream.testkit.TestPublisher
+import org.apache.pekko
+import pekko.stream.testkit.TestPublisher
 
 import org.reactivestreams.Publisher
 import org.reactivestreams.tck.PublisherVerification

--- a/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PekkoSubscriberVerification.scala
+++ b/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/PekkoSubscriberVerification.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.tck
 
 import org.scalatestplus.testng.TestNGSuiteLike
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+import pekko.actor.ActorSystem
 
 import org.reactivestreams.tck.SubscriberBlackboxVerification
 import org.reactivestreams.tck.SubscriberWhiteboxVerification

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/impl/ResizableMultiReaderRingBufferSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/impl/ResizableMultiReaderRingBufferSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.impl
 
 import scala.util.Random
 
-import org.apache.pekko.stream.impl.ResizableMultiReaderRingBuffer._
+import org.apache.pekko
+import pekko.stream.impl.ResizableMultiReaderRingBuffer._
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/DeflateAutoFlushSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/DeflateAutoFlushSpec.scala
@@ -19,8 +19,9 @@ package org.apache.pekko.stream.io.compression
 
 import java.util.zip.Deflater
 
-import org.apache.pekko.stream.scaladsl.{ Compression, Flow }
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.stream.scaladsl.{ Compression, Flow }
+import pekko.util.ByteString
 
 class DeflateAutoFlushSpec extends DeflateSpec {
   override protected val encoderFlow: Flow[ByteString, ByteString, Any] =

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/GzipAutoFlushSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/compression/GzipAutoFlushSpec.scala
@@ -19,8 +19,9 @@ package org.apache.pekko.stream.io.compression
 
 import java.util.zip.Deflater
 
-import org.apache.pekko.stream.scaladsl.{ Compression, Flow }
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.stream.scaladsl.{ Compression, Flow }
+import pekko.util.ByteString
 
 class GzipAutoFlushSpec extends GzipSpec {
   override protected val encoderFlow: Flow[ByteString, ByteString, Any] =

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowBatchWeightedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowBatchWeightedSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.scaladsl
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.stream.testkit._
 
 class FlowBatchWeightedSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCollectTypeSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCollectTypeSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.apache.pekko.stream.testkit.StreamSpec
+import org.apache.pekko
+import pekko.stream.testkit.StreamSpec
 
 class FlowCollectTypeSpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowDropSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowDropSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom.{ current => random }
 
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.stream.testkit._
 
 class FlowDropSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowDropWithinSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowDropWithinSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.scaladsl
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.stream.testkit._
 
 class FlowDropWithinSpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFromFutureSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFromFutureSpec.scala
@@ -19,8 +19,9 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import org.apache.pekko.stream.testkit._
-import org.apache.pekko.stream.testkit.scaladsl.TestSink
+import org.apache.pekko
+import pekko.stream.testkit._
+import pekko.stream.testkit.scaladsl.TestSink
 
 @nowarn("msg=deprecated") // testing deprecated API
 class FlowFromFutureSpec extends StreamSpec {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom.{ current => random }
 
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.stream.testkit._
 
 class FlowMapSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrependSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrependSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.stream.scaladsl
 
 import org.apache.pekko
 import pekko.testkit.PekkoSpec
+
 import scala.annotation.nowarn
 
 @nowarn // for keeping imports

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrependSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrependSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 import scala.annotation.nowarn
 
 @nowarn // for keeping imports

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowTakeWithinSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowTakeWithinSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.scaladsl
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.stream.testkit._
 
 class FlowTakeWithinSpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LastSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LastSinkSpec.scala
@@ -18,7 +18,8 @@ import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.stream.testkit._
 
 class LastSinkSpec extends StreamSpec with ScriptedTest {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SinkFoldSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SinkFoldSpec.scala
@@ -17,7 +17,8 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.apache.pekko.stream.testkit.StreamSpec
+import org.apache.pekko
+import pekko.stream.testkit.StreamSpec
 
 class SinkFoldSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceSpec.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.Done
 import pekko.stream.testkit.Utils.TE
 import pekko.testkit.DefaultTimeout
+
 import org.scalatest.time.{ Millis, Span }
 
 import scala.annotation.nowarn

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.time.{ Millis, Span }
 import scala.annotation.nowarn
 import scala.concurrent.{ Await, Future }
 //#imports
-import org.apache.pekko.stream._
+import pekko.stream._
 
 //#imports
 import pekko.NotUsed

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SubscriberSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SubscriberSinkSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.apache.pekko.stream.testkit._
+import org.apache.pekko
+import pekko.stream.testkit._
 
 class SubscriberSinkSpec extends StreamSpec("""
     pekko.stream.materializer.initial-input-buffer-size = 2

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SubscriberSourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SubscriberSourceSpec.scala
@@ -16,7 +16,8 @@ package org.apache.pekko.stream.scaladsl
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import org.apache.pekko.stream.testkit.StreamSpec
+import org.apache.pekko
+import pekko.stream.testkit.StreamSpec
 
 class SubscriberSourceSpec extends StreamSpec {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/TlsEngineSelectionSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/TlsEngineSelectionSpec.scala
@@ -17,7 +17,8 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.apache.pekko.testkit.PekkoSpec
+import org.apache.pekko
+import pekko.testkit.PekkoSpec
 
 class TlsEngineSelectionSpec extends PekkoSpec {
 

--- a/stream-typed/src/test/scala/docs/scaladsl/ActorFlowSpec.scala
+++ b/stream-typed/src/test/scala/docs/scaladsl/ActorFlowSpec.scala
@@ -18,7 +18,6 @@ import pekko.NotUsed
 import pekko.pattern.StatusReply
 
 //#imports
-import org.apache.pekko
 import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.stream.typed.scaladsl.ActorFlow
 import pekko.actor.typed.ActorRef

--- a/stream/src/main/scala/org/apache/pekko/stream/CompletionStrategy.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/CompletionStrategy.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream
 
-import org.apache.pekko.annotation.{ DoNotInherit, InternalApi }
+import org.apache.pekko
+import pekko.annotation.{ DoNotInherit, InternalApi }
 
 @DoNotInherit
 sealed trait CompletionStrategy

--- a/stream/src/main/scala/org/apache/pekko/stream/FlowMonitor.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/FlowMonitor.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream
 
-import org.apache.pekko.stream.FlowMonitorState.StreamState
+import org.apache.pekko
+import pekko.stream.FlowMonitorState.StreamState
 
 /**
  * Used to monitor the state of a stream

--- a/stream/src/main/scala/org/apache/pekko/stream/QueueOfferResult.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/QueueOfferResult.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream
 
-import org.apache.pekko.annotation.DoNotInherit
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 /**
  * Not for user extension

--- a/stream/src/main/scala/org/apache/pekko/stream/SubscriptionWithCancelException.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/SubscriptionWithCancelException.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream
 
 import scala.util.control.NoStackTrace
 
-import org.apache.pekko.annotation.DoNotInherit
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 import org.reactivestreams.Subscription
 

--- a/stream/src/main/scala/org/apache/pekko/stream/Supervision.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Supervision.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream
 
-import org.apache.pekko.japi.{ function => japi }
+import org.apache.pekko
+import pekko.japi.{ function => japi }
 
 object Supervision {
   sealed trait Directive

--- a/stream/src/main/scala/org/apache/pekko/stream/WatchedActorTerminatedException.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/WatchedActorTerminatedException.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream
 
-import org.apache.pekko.actor.ActorRef
+import org.apache.pekko
+import pekko.actor.ActorRef
 
 /**
  * Used as failure exception by an `ask` operator if the target actor terminates.

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/CompletedPublishers.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/CompletedPublishers.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.impl
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ContextPropagation.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ContextPropagation.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.impl
 
-import org.apache.pekko.annotation.InternalStableApi
+import org.apache.pekko
+import pekko.annotation.InternalStableApi
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ResizableMultiReaderRingBuffer.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ResizableMultiReaderRingBuffer.scala
@@ -18,7 +18,8 @@ import scala.util.control.NoStackTrace
 
 import ResizableMultiReaderRingBuffer.{ Cursor, Cursors, NothingToReadException }
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/SeqActorName.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/SeqActorName.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.stream.impl
 
 import java.util.concurrent.atomic.AtomicLong
 
-import org.apache.pekko.annotation.{ DoNotInherit, InternalApi }
+import org.apache.pekko
+import pekko.annotation.{ DoNotInherit, InternalApi }
 
 /**
  * INTERNAL API

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/SourceSink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/SourceSink.scala
@@ -18,7 +18,7 @@
 package org.apache.pekko.stream.impl.fusing
 
 import org.apache.pekko
-import org.apache.pekko.stream.impl.Stages.DefaultAttributes
+import pekko.stream.impl.Stages.DefaultAttributes
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 import pekko.stream.{ ActorAttributes, Attributes, Inlet, SinkShape, StreamSubscriptionTimeoutTerminationMode }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/io/TlsEngineHelpers.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/io/TlsEngineHelpers.scala
@@ -20,7 +20,8 @@ package org.apache.pekko.stream.impl.io
 import java.nio.ByteBuffer
 import javax.net.ssl.SSLEngine
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API.

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/StreamRefs.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/StreamRefs.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.javadsl
 
-import org.apache.pekko.stream._
+import org.apache.pekko
+import pekko.stream._
 
 /**
  * Factories for creating stream refs.

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Materialization.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Materialization.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import org.apache.pekko.NotUsed
+import org.apache.pekko
+import pekko.NotUsed
 
 /**
  * Convenience functions for often-encountered purposes like keeping only the

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestActors.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestActors.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.testkit
 
-import org.apache.pekko.actor.{ Actor, ActorRef, Props }
+import org.apache.pekko
+import pekko.actor.{ Actor, ActorRef, Props }
 
 /**
  * A collection of common actor patterns used in tests.

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestBarrier.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestBarrier.scala
@@ -18,7 +18,8 @@ import java.util.concurrent.{ CyclicBarrier, TimeUnit, TimeoutException }
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+import pekko.actor.ActorSystem
 
 class TestBarrierTimeoutException(message: String) extends RuntimeException(message)
 

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
@@ -19,7 +19,8 @@ import java.util.stream.{ Stream => JStream }
 
 import scala.util.matching.Regex
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestLatch.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestLatch.scala
@@ -19,7 +19,8 @@ import scala.concurrent.{ Awaitable, CanAwait }
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+import pekko.actor.ActorSystem
 
 /**
  * A count down latch wrapper for use in testing.

--- a/testkit/src/test/scala/org/apache/pekko/testkit/DefaultTimeoutSpec.scala
+++ b/testkit/src/test/scala/org/apache/pekko/testkit/DefaultTimeoutSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.testkit
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+import pekko.actor.ActorSystem
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers

--- a/testkit/src/test/scala/org/apache/pekko/testkit/ImplicitSenderSpec.scala
+++ b/testkit/src/test/scala/org/apache/pekko/testkit/ImplicitSenderSpec.scala
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.testkit
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko
+import pekko.actor.ActorSystem
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers

--- a/testkit/src/test/scala/org/apache/pekko/testkit/TestFSMRefSpec.scala
+++ b/testkit/src/test/scala/org/apache/pekko/testkit/TestFSMRefSpec.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.testkit
 
 import scala.concurrent.duration._
 
-import org.apache.pekko.actor._
+import org.apache.pekko
+import pekko.actor._
 
 class TestFSMRefSpec extends PekkoSpec {
 


### PR DESCRIPTION
### Motivation
The Pekko codebase uses two import styles: `import org.apache.pekko.X` for the bare package import and `import pekko.X` for the shorter form. However, many files still use the fully qualified `import org.apache.pekko.X.Y.Z` style for individual imports instead of the shorter `import pekko.X.Y.Z` style.

### Modification
A one-time transformation was applied across all 411 Scala source files:
- `import org.apache.pekko.X.Y.Z` → `import pekko.X.Y.Z`
- `import org.apache.pekko` is added as a bare package import at the top of each affected file (if not already present)

This rewrites 885 individual import statements. Auto-generated files in `target/` directories are excluded.

The transformation was performed with a text-based script that:
1. Replaces `org.apache.pekko.` prefix with `pekko.` in import statements
2. Adds `import org.apache.pekko` after the package declaration for files that need it
3. Preserves grouped imports (`import org.apache.pekko.actor.{ A, B }` → `import pekko.actor.{ A, B }`)
4. Preserves wildcard imports (`import org.apache.pekko.actor._` → `import pekko.actor._`)

Scalafmt was run after the transformation to normalize formatting.

### Result
All Scala source files now use the shorter `pekko.X` import style consistently. The `import org.apache.pekko` bare import is present in all files that use `pekko.*` imports.

### Tests
Not run - import refactoring only, no behavioral changes.

### References
None - import style improvement