### PR TITLE
WIP: avoid initializing classes via forName

### DIFF
--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/LoggerClass.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/LoggerClass.scala
@@ -70,7 +70,7 @@ private[pekko] object LoggerClass {
             lambdaNameIdx = nextName.indexOf("$$Lambda")
             if nextName.startsWith(cls.getName()) && lambdaNameIdx > 0
             lambdaClsOwner = nextName.substring(0, lambdaNameIdx)
-          } yield Class.forName(lambdaClsOwner)
+          } yield Class.forName(lambdaClsOwner, false, this.getClass.getClassLoader)
           // TODO: can potentially guard for ClassNotFoundException, but seems unlikely
           lambdaClsOwner.getOrElse(cls)
         case _ =>

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/CapabilityFlags.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/CapabilityFlags.scala
@@ -19,7 +19,7 @@ sealed abstract class CapabilityFlag {
   private val capturedStack = new Throwable().getStackTrace
     .filter(_.getMethodName.startsWith("supports"))
     .find { el =>
-      val clazz = Class.forName(el.getClassName)
+      val clazz = Class.forName(el.getClassName, false, this.getClass.getClassLoader)
       clazz.getDeclaredMethod(el.getMethodName).getReturnType == classOf[CapabilityFlag]
     }
     .map { _.getMethodName }


### PR DESCRIPTION
Probably doesn't help much but generally, it is a bad idea to take a class name and load it with its static initializers.
`this.getClass.getClassLoader` is the default classloader used by Class.forName.