### PR TITLE
Rework stack walking code to avoid Class.forName

### DIFF
--- a/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/MultiNodeClusterShardingConfig.scala
+++ b/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/MultiNodeClusterShardingConfig.scala
@@ -26,9 +26,9 @@ object MultiNodeClusterShardingConfig {
 
   private[sharding] def testNameFromCallStack(classToStartFrom: Class[?]): String = {
 
-    def isAbstractClass(className: String): Boolean = {
+    def isAbstractClass(clazz: Class[_]): Boolean = {
       try {
-        Modifier.isAbstract(Class.forName(className).getModifiers)
+        Modifier.isAbstract(clazz.getModifiers)
       } catch {
         case _: Throwable => false // yes catch everything, best effort check
       }
@@ -36,22 +36,21 @@ object MultiNodeClusterShardingConfig {
 
     val startFrom = classToStartFrom.getName
     val filteredStack = Thread.currentThread.getStackTrace.iterator
-      .map(_.getClassName)
       // drop until we find the first occurrence of classToStartFrom
-      .dropWhile(!_.startsWith(startFrom))
+      .dropWhile(!_.getName.startsWith(startFrom))
       // then continue to the next entry after classToStartFrom that makes sense
       .dropWhile {
-        case `startFrom`                            => true
-        case str if str.startsWith(startFrom + "$") => true // lambdas inside startFrom etc
-        case str if isAbstractClass(str)            => true
-        case _                                      => false
+        case c if c.getName == startFrom                => true
+        case c if c.getName.startsWith(startFrom + "$") => true // lambdas inside startFrom etc
+        case c if isAbstractClass(c)                    => true
+        case _                                          => false
       }
 
     if (filteredStack.isEmpty)
-      throw new IllegalArgumentException(s"Couldn't find [${classToStartFrom.getName}] in call stack")
+      throw new IllegalArgumentException(s"Couldn't find [$startFrom] in call stack")
 
     // sanitize for actor system name
-    scrubActorSystemName(filteredStack.next())
+    scrubActorSystemName(filteredStack.next().getName)
   }
 
   /**

--- a/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/MultiNodeClusterShardingConfig.scala
+++ b/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/MultiNodeClusterShardingConfig.scala
@@ -26,7 +26,7 @@ object MultiNodeClusterShardingConfig {
 
   private[sharding] def testNameFromCallStack(classToStartFrom: Class[?]): String = {
 
-    def isAbstractClass(clazz: Class[_]): Boolean = {
+    def isAbstractClass(clazz: Class[?]): Boolean = {
       try {
         Modifier.isAbstract(clazz.getModifiers)
       } catch {

--- a/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/MultiNodeClusterShardingConfig.scala
+++ b/cluster-sharding/src/multi-jvm/scala/org/apache/pekko/cluster/sharding/MultiNodeClusterShardingConfig.scala
@@ -13,7 +13,9 @@
 
 package org.apache.pekko.cluster.sharding
 
+import java.lang.StackWalker.StackFrame
 import java.lang.reflect.Modifier
+import java.util.stream.{ Stream => JStream }
 
 import org.apache.pekko
 import pekko.cluster.MultiNodeClusterSpec
@@ -23,6 +25,10 @@ import pekko.remote.testkit.MultiNodeConfig
 import com.typesafe.config.{ Config, ConfigFactory }
 
 object MultiNodeClusterShardingConfig {
+
+  private val stackWalker: java.util.function.Function[JStream[StackFrame], Array[Class[?]]] =
+    (frames: JStream[StackFrame]) =>
+      frames.map(_.getDeclaringClass).toArray[Class[?]]((size: Int) => new Array[Class[?]](size))
 
   private[sharding] def testNameFromCallStack(classToStartFrom: Class[?]): String = {
 
@@ -35,7 +41,9 @@ object MultiNodeClusterShardingConfig {
     }
 
     val startFrom = classToStartFrom.getName
-    val filteredStack = Thread.currentThread.getStackTrace.iterator
+    val classes = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+      .walk(stackWalker)
+    val filteredStack = classes.iterator
       // drop until we find the first occurrence of classToStartFrom
       .dropWhile(!_.getName.startsWith(startFrom))
       // then continue to the next entry after classToStartFrom that makes sense

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
@@ -27,39 +27,39 @@ import org.apache.pekko.annotation.InternalApi
 @InternalApi
 private[pekko] object TestKitUtils {
 
-  private val stackWalker: java.util.function.Function[JStream[StackFrame], Array[String]] =
+  private val stackWalker: java.util.function.Function[JStream[StackFrame], Array[Class[_]]] =
     (frames: JStream[StackFrame]) =>
-      frames.map(_.getClassName).toArray[String]((size: Int) => new Array[String](size))
+      frames.map(_.getDeclaringClass).toArray[Class[_]]((size: Int) => new Array[Class[_]](size))
 
   def testNameFromCallStack(classToStartFrom: Class[?], testKitRegex: Regex): String = {
 
-    def isAbstractClass(className: String): Boolean = {
+    def isAbstractClass(clazz: Class[_]): Boolean = {
       try {
-        Modifier.isAbstract(Class.forName(className).getModifiers)
+        Modifier.isAbstract(clazz.getModifiers)
       } catch {
         case _: Throwable => false // yes catch everything, best effort check
       }
     }
 
     val startFrom = classToStartFrom.getName
-    val classNames = StackWalker.getInstance().walk(stackWalker)
-    val filteredStack = classNames.iterator
+    val classes = StackWalker.getInstance().walk(stackWalker)
+    val filteredStack = classes.iterator
       // drop until we find the first occurrence of classToStartFrom
-      .dropWhile(!_.startsWith(startFrom))
+      .dropWhile(!_.getName.startsWith(startFrom))
       // then continue to the next entry after classToStartFrom that makes sense
       .dropWhile {
-        case `startFrom`                            => true
-        case str if str.startsWith(startFrom + "$") => true // lambdas inside startFrom etc
-        case testKitRegex()                         => true // testkit internals
-        case str if isAbstractClass(str)            => true
-        case _                                      => false
+        case c if c.getName == startFrom                => true
+        case c if c.getName.startsWith(startFrom + "$") => true // lambdas inside startFrom etc
+        case c if testKitRegex().matches(c.getName)     => true // testkit internals
+        case c if isAbstractClass(c)                    => true
+        case _                                          => false
       }
 
     if (filteredStack.isEmpty)
-      throw new IllegalArgumentException(s"Couldn't find [${classToStartFrom.getName}] in call stack")
+      throw new IllegalArgumentException(s"Couldn't find [$startFrom] in call stack")
 
     // sanitize for actor system name
-    scrubActorSystemName(filteredStack.next())
+    scrubActorSystemName(filteredStack.next().getName)
   }
 
   /**

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
@@ -27,13 +27,13 @@ import org.apache.pekko.annotation.InternalApi
 @InternalApi
 private[pekko] object TestKitUtils {
 
-  private val stackWalker: java.util.function.Function[JStream[StackFrame], Array[Class[_]]] =
+  private val stackWalker: java.util.function.Function[JStream[StackFrame], Array[Class[?]]] =
     (frames: JStream[StackFrame]) =>
-      frames.map(_.getDeclaringClass).toArray[Class[_]]((size: Int) => new Array[Class[_]](size))
+      frames.map(_.getDeclaringClass).toArray[Class[?]]((size: Int) => new Array[Class[?]](size))
 
   def testNameFromCallStack(classToStartFrom: Class[?], testKitRegex: Regex): String = {
 
-    def isAbstractClass(clazz: Class[_]): Boolean = {
+    def isAbstractClass(clazz: Class[?]): Boolean = {
       try {
         Modifier.isAbstract(clazz.getModifiers)
       } catch {

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
@@ -42,7 +42,8 @@ private[pekko] object TestKitUtils {
     }
 
     val startFrom = classToStartFrom.getName
-    val classes = StackWalker.getInstance().walk(stackWalker)
+    val classes = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+      .walk(stackWalker)
     val filteredStack = classes.iterator
       // drop until we find the first occurrence of classToStartFrom
       .dropWhile(!_.getName.startsWith(startFrom))

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKitUtils.scala
@@ -50,7 +50,7 @@ private[pekko] object TestKitUtils {
       .dropWhile {
         case c if c.getName == startFrom                => true
         case c if c.getName.startsWith(startFrom + "$") => true // lambdas inside startFrom etc
-        case c if testKitRegex().matches(c.getName)     => true // testkit internals
+        case c if testKitRegex.matches(c.getName)       => true // testkit internals
         case c if isAbstractClass(c)                    => true
         case _                                          => false
       }


### PR DESCRIPTION
May make the code more complicated but relying on Class.forName to reload the class doesn't seem great.