### PR TITLE
Include sourceThread in typed actor MDC

### DIFF
--- a/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/actor-typed-tests/src/test/scala/org/apache/pekko/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -362,7 +362,8 @@ class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
         // not counting for example "pekkoSource", but it shouldn't have any other entries
         .withCustom(logEvent =>
           logEvent.mdc.keysIterator.forall(entry =>
-            entry.startsWith("pekko") || entry == "sourceActorSystem" || entry == "static") &&
+            entry.startsWith("pekko") || entry == "sourceActorSystem" || entry == ActorMdc.SourceThreadKey ||
+            entry == "static") &&
           logEvent.mdc("static") == "1")
         .expect {
           spawn(behaviors)
@@ -380,6 +381,21 @@ class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
         .withCustom(event => !event.mdc.contains("first"))
         .expect {
           ref ! Message(2, "second")
+        }
+    }
+
+    // Regression test for https://github.com/apache/pekko/issues/3239: typed actor MDC must include
+    // the "sourceThread" attribute (the dispatching thread), consistent with classic actors.
+    "include the sourceThread attribute in the MDC" in {
+      val behavior = Behaviors.setup[String] { context =>
+        context.log.info("with-source-thread")
+        Behaviors.empty
+      }
+      LoggingTestKit
+        .info("with-source-thread")
+        .withCustom(event => event.mdc.get(ActorMdc.SourceThreadKey).contains(event.threadName))
+        .expect {
+          spawn(behavior)
         }
     }
 

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorMdc.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/ActorMdc.scala
@@ -25,6 +25,9 @@ import org.slf4j.MDC
   val PekkoSourceKey = "pekkoSource"
   val PekkoTagsKey = "pekkoTags"
   val PekkoAddressKey = "pekkoAddress"
+  // Mirrors the classic Slf4jLogger MDC attribute (Slf4jLogger.mdcThreadAttributeName) so that
+  // typed and classic actor log entries can both be correlated with the dispatching thread.
+  val SourceThreadKey = "sourceThread"
 
   def setMdc(context: ActorContextImpl.LoggingContext): Unit = {
     // avoid access to MDC ThreadLocal if not needed, see details in LoggingContext
@@ -32,6 +35,9 @@ import org.slf4j.MDC
     MDC.put(PekkoSourceKey, context.pekkoSource)
     MDC.put(SourceActorSystemKey, context.sourceActorSystem)
     MDC.put(PekkoAddressKey, context.pekkoAddress)
+    // Typed actors log synchronously on the dispatcher thread that runs the actor, so the current
+    // thread is the source thread the user's log statements execute on.
+    MDC.put(SourceThreadKey, Thread.currentThread().getName)
     // empty string for no tags, a single tag or a comma separated list of tags
     if (context.tagsString.nonEmpty)
       MDC.put(PekkoTagsKey, context.tagsString)


### PR DESCRIPTION
### Motivation

Typed actor logging documents `sourceThread` as an MDC attribute, but `ActorMdc.setMdc` did not populate it. This made typed actor log entries inconsistent with classic actors and prevented correlation with the dispatcher thread.

### Modification

- Add the `sourceThread` MDC entry using the current dispatcher thread name.
- Add a regression test that verifies the MDC value matches the logging event thread.
- Update the existing typed MDC whitelist assertion for the documented key.

### Result

Typed actor log entries now include the documented `sourceThread` MDC value, consistent with classic actor logging.

### Tests

- Regression proof without the production `MDC.put`: focused `sourceThread` test failed as expected because the MDC key was absent.
- `sbt "actor-typed-tests / Test / testOnly org.apache.pekko.actor.typed.scaladsl.ActorLoggingSpec"` — 20 passed.
- `sbt "headerCreateAll" "+headerCheckAll" "checkCodeStyle"` — passed.
- `sbt "+mimaReportBinaryIssues"` — passed for Scala 2.13.18 and 3.3.8.
- `scalafmt --list --mode diff-ref=origin/main` — passed with no changed files reported.
- `git diff --check origin/main...HEAD` — passed.
- `sbt validatePullRequest` — attempted; the changed typed logging suite and affected actor suites passed, but the aggregate task failed on unrelated local/baseline cases: a JDK 25 JFR method-signature mismatch in cluster-sharding Multi-JVM, unavailable LevelDB JNI on macOS ARM in persistence-typed, and the existing `pekko.dispatch.UnboundedMailbox` class name in `jdocs.stream.IntegrationDocTest`.

### References

Fixes #3239
