### PR TITLE
Stop PersistentActor by default when RecoveryCompleted handler fails

### DIFF
--- a/docs/src/main/paradox/persistence.md
+++ b/docs/src/main/paradox/persistence.md
@@ -215,6 +215,10 @@ The actor will always receive a `RecoveryCompleted` message, even if there are n
 in the journal and the snapshot store is empty, or if it's a new persistent actor with a previously
 unused `persistenceId`.
 
+If handling `RecoveryCompleted` throws an exception, the failure is reported to the parent supervisor
+as an `ActorInitializationException`. The default supervision strategy stops the actor, while a custom
+supervision strategy may resume or restart it.
+
 If there is a problem with recovering the state of the actor from the journal, `onRecoveryFailure`
 is called (logging the error by default) and the actor will be stopped.
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
 import org.apache.pekko
-import pekko.actor.{ Actor, ActorCell, DeadLetter, StashOverflowException }
+import pekko.actor.{ Actor, ActorCell, ActorInitializationException, DeadLetter, StashOverflowException }
 import pekko.annotation.{ InternalApi, InternalStableApi }
 import pekko.dispatch.Envelope
 import pekko.event.{ Logging, LoggingAdapter }
@@ -792,9 +792,15 @@ private[persistence] trait Eventsourced
               sequenceNr = highestSeqNr
               setLastSequenceNr(highestSeqNr)
               _recoveryRunning = false
-              try Eventsourced.super.aroundReceive(recoveryBehavior, RecoveryCompleted)
-              finally transitToProcessingState() // in finally in case exception and resume strategy
-              // if exception from RecoveryCompleted the permit is returned in below catch
+              try {
+                Eventsourced.super.aroundReceive(recoveryBehavior, RecoveryCompleted)
+              } catch {
+                case NonFatal(t) =>
+                  throw ActorInitializationException(
+                    self,
+                    s"Exception in receiveRecover when handling RecoveryCompleted for persistenceId [$persistenceId]",
+                    t)
+              } finally transitToProcessingState()
               returnRecoveryPermit()
             case ReplayMessagesFailure(cause) =>
               timeoutCancellable.cancel()

--- a/persistence/src/test/scala/org/apache/pekko/persistence/RecoveryPermitterSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/RecoveryPermitterSpec.scala
@@ -27,6 +27,7 @@ import com.typesafe.config.ConfigFactory
 object RecoveryPermitterSpec {
 
   class TestExc extends RuntimeException("simulated exc") with NoStackTrace
+  final case class Supervised(cause: Throwable)
 
   def testProps(name: String, probe: ActorRef, throwFromRecoveryCompleted: Boolean = false): Props =
     Props(new TestPersistentActor(name, probe, throwFromRecoveryCompleted))
@@ -46,10 +47,28 @@ object RecoveryPermitterSpec {
         if (throwFromRecoveryCompleted)
           throw new TestExc
     }
+
     override def receiveCommand: Receive = {
       case "stop" =>
         context.stop(self)
     }
+  }
+
+  class RestartOnceSupervisor(childProps: Props, probe: ActorRef) extends Actor {
+    private var failures = 0
+
+    override val supervisorStrategy = OneForOneStrategy(loggingEnabled = false) {
+      case cause: ActorInitializationException =>
+        failures += 1
+        probe ! Supervised(cause)
+        if (failures == 1) SupervisorStrategy.Restart
+        else SupervisorStrategy.Stop
+    }
+
+    override def preStart(): Unit =
+      probe ! context.actorOf(childProps)
+
+    override def receive: Receive = Actor.emptyBehavior
   }
 
 }
@@ -62,7 +81,7 @@ class RecoveryPermitterSpec extends PersistenceSpec(ConfigFactory.parseString(s"
   import RecoveryPermitter._
   import RecoveryPermitterSpec._
 
-  system.eventStream.publish(TestEvent.Mute(EventFilter[TestExc]()))
+  system.eventStream.publish(TestEvent.Mute(EventFilter[ActorInitializationException]()))
 
   val permitter = Persistence(system).recoveryPermitter
   val p1 = TestProbe()
@@ -171,23 +190,43 @@ class RecoveryPermitterSpec extends PersistenceSpec(ConfigFactory.parseString(s"
       permitter.tell(ReturnRecoveryPermit, p4.ref)
     }
 
-    "return permit when actor throws from RecoveryCompleted" in {
+    "return permit and stop actor by default when it throws from RecoveryCompleted" in {
       requestPermit(p1)
       requestPermit(p2)
 
       val persistentActor = system.actorOf(testProps("p3", p3.ref, throwFromRecoveryCompleted = true))
+      p3.watch(persistentActor)
       p3.expectMsg(RecoveryCompleted)
       p3.expectMsg("postStop")
-      // it's restarting
-      (1 to 5).foreach { _ =>
+      p3.expectTerminated(persistentActor)
+
+      requestPermit(p4)
+
+      permitter.tell(ReturnRecoveryPermit, p1.ref)
+      permitter.tell(ReturnRecoveryPermit, p2.ref)
+      permitter.tell(ReturnRecoveryPermit, p4.ref)
+    }
+
+    "allow the parent supervisor to restart an actor that throws from RecoveryCompleted" in {
+      requestPermit(p1)
+      requestPermit(p2)
+
+      val supervisor = system.actorOf(
+        Props(new RestartOnceSupervisor(testProps("p3", p3.ref, throwFromRecoveryCompleted = true), p3.ref)))
+      val persistentActor = p3.expectMsgType[ActorRef]
+      p3.watch(persistentActor)
+
+      (1 to 2).foreach { _ =>
         p3.expectMsg(RecoveryCompleted)
+        p3.lastSender shouldBe persistentActor
+        p3.expectMsgPF(hint = "supervised ActorInitializationException caused by TestExc") {
+          case Supervised(cause: ActorInitializationException)
+              if cause.getActor == persistentActor && cause.getCause.isInstanceOf[TestExc] =>
+        }
         p3.expectMsg("postStop")
       }
-      // stop it
-      val stopProbe = TestProbe()
-      stopProbe.watch(persistentActor)
-      system.stop(persistentActor)
-      stopProbe.expectTerminated(persistentActor)
+      p3.expectTerminated(persistentActor)
+      system.stop(supervisor)
 
       requestPermit(p4)
 


### PR DESCRIPTION
### Motivation
A classic `PersistentActor` can enter an unbounded restart loop when its `RecoveryCompleted` handler throws because the Classic default decider restarts ordinary exceptions. Issues #3234 and #3249 describe the same trigger and root cause.

`RecoveryCompleted` runs after event replay has succeeded, so this failure should remain visible to the parent supervisor instead of being translated into an `onRecoveryFailure` replay failure.

### Modification
- Wrap `NonFatal` exceptions from the `RecoveryCompleted` handler in `ActorInitializationException` and pass them to Classic supervision.
- Preserve the existing processing-state transition and outer recovery-permit cleanup path.
- Add directional regression coverage for both the default Stop decision and a custom parent Restart decision.
- Document the resulting supervision contract.

### Result
The default supervision strategy stops the actor instead of repeatedly restarting it. A custom parent strategy can still Resume or Restart the same `ActorRef`, and the original exception is retained as the cause.

### Tests
- `sbt "persistence / Test / testOnly org.apache.pekko.persistence.RecoveryPermitterSpec"` — restart-direction test failed before the production change; 7 passed after it
- `sbt "persistence / Test / test"` — 62 passed
- `sbt docs/paradox` — passed with existing duplicate-anchor warnings
- `sbt headerCreateAll` — passed
- `sbt +headerCheckAll` — passed for Scala 2.13.18 and 3.3.8
- `sbt checkCodeStyle` — passed
- `sbt validatePullRequest` — ran for 24m44s; affected persistence, typed, query, cluster-sharding, multi-JVM, and docs tests completed. Overall exit 1 is limited to unchanged baseline/environment failures: `LeveldbJournalNativeSpec` cannot load the x86 `leveldbjni-all` 1.8 binary on macOS ARM64, and `IntegrationDocTest` references the existing invalid class `pekko.dispatch.UnboundedMailbox`
- `sbt sortImports` — not completed because the repository Scalafix rule fails against the current scala.meta with `NoSuchMethodError`; no unrelated changes were retained
- `scalafmt --list --mode diff-ref=origin/main` — passed
- `git diff --check` — passed
- Qoder stdout review — No must-fix findings

### References
Fixes #3234
Fixes #3249