### PR TITLE
docs: clarify pool management and resizer bounds

### DIFF
--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -240,10 +240,14 @@ pekko {
 
           enabled = off
 
-          # The fewest number of routees the router should ever have.
+          # These bounds are enforced when this resizer is invoked. Router
+          # management messages can move the pool outside them until the
+          # resizer runs again.
+
+          # The minimum pool size targeted by this resizer.
           lower-bound = 1
 
-          # The most number of routees the router should ever have.
+          # The maximum pool size targeted by this resizer.
           # Must be greater than or equal to lower-bound.
           upper-bound = 10
 
@@ -289,10 +293,14 @@ pekko {
 
           enabled = off
 
-          # The fewest number of routees the router should ever have.
+          # These bounds are enforced when this resizer is invoked. Router
+          # management messages can move the pool outside them until the
+          # resizer runs again.
+
+          # The minimum pool size targeted by this resizer.
           lower-bound = 1
 
-          # The most number of routees the router should ever have.
+          # The maximum pool size targeted by this resizer.
           # Must be greater than or equal to lower-bound.
           upper-bound = 10
 

--- a/actor/src/main/scala/org/apache/pekko/routing/Resizer.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/Resizer.scala
@@ -107,8 +107,10 @@ case object DefaultResizer {
 /**
  * Implementation of [[Resizer]] that adjust the [[Pool]] based on specified
  * thresholds.
- * @param lowerBound The fewest number of routees the router should ever have.
- * @param upperBound The most number of routees the router should ever have. Must be greater than or equal to `lowerBound`.
+ * Router management messages can move the pool outside the configured bounds
+ * until this resizer runs again.
+ * @param lowerBound The minimum pool size targeted when this resizer is invoked.
+ * @param upperBound The maximum pool size targeted when this resizer is invoked. Must be greater than or equal to `lowerBound`.
  * @param pressureThreshold Threshold to evaluate if routee is considered to be busy (under pressure).
  * Implementation depends on this value (default is 1).
  * <ul>

--- a/actor/src/main/scala/org/apache/pekko/routing/RouterConfig.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/RouterConfig.scala
@@ -444,6 +444,13 @@ final case class RemoveRoutee(routee: Routee) extends RouterManagementMesssage
  *
  * Positive `change` will add that number of routees to the [[Pool]].
  * Negative `change` will remove that number of routees from the [[Pool]].
+ * This is a direct management operation, so `change` is not constrained by the
+ * pool's initial `nrOfInstances` or by bounds configured on a [[Resizer]].
+ * A resizer may adjust the pool back within its bounds the next time it runs.
+ *
+ * If a resizable pool is reduced to zero routees, the ordinary message that
+ * triggers the next resize may be lost before new routees are added.
+ *
  * Routees are stopped by sending a [[pekko.actor.PoisonPill]] to the routee.
  * Precautions are taken reduce the risk of dropping messages that are concurrently
  * being routed to the removed routee, but it is not guaranteed that messages are not

--- a/docs/src/main/paradox/routing.md
+++ b/docs/src/main/paradox/routing.md
@@ -799,6 +799,12 @@ an ordinary message you are not guaranteed that the routees have been changed wh
 is routed. If you need to know when the change has been applied you can send `AddRoutee` followed by `GetRoutees`
 and when you receive the `Routees` reply you know that the preceding change has been applied.
 
+Routee-changing management messages directly change the routees. The `nr-of-instances` setting only defines the initial
+pool size, and changes made by management messages are not constrained by configured resizer bounds. A resizer may
+adjust the pool back within its bounds the next time it runs. If management messages reduce a resizable pool to zero
+routees, ordinary messages are lost until the resizer adds routees. A message that triggers a resize is routed without
+waiting for that resize to complete, so it may be lost if no routees have been added yet.
+
 <a id="resizable-routers"></a>
 ## Dynamically Resizable Pool
 


### PR DESCRIPTION
### Motivation

`AdjustPoolSize` is a direct management operation, but the resizer documentation described lower and upper bounds as values the router should ever have. This made the relationship between initial pool size, explicit management, and automatic resizing unclear in #3253.

### Modification

Clarify that `nr-of-instances` defines the initial pool size, routee-changing management messages may move a pool outside configured resizer bounds, and a later resize may restore the configured range. Document the asynchronous recovery and message-loss behavior when a resizable pool is reduced to zero routees.

### Result

Router management and automatic resizer responsibilities are documented consistently with the existing implementation and API contract.

### Tests

- Not run - docs only
- `sbt "actor / Compile / doc" "docs / paradox"`
- `sbt +headerCheckAll checkCodeStyle`
- `scalafmt --list --mode diff-ref=origin/main`
- `git diff --check origin/main`

### References

Refs #3253
