### PR TITLE
Deprecate org.apache.pekko.dispatch.Futures

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/CompletionStagesTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/CompletionStagesTests.java
@@ -35,15 +35,14 @@ public class CompletionStagesTests {
     private final Duration timeout = Duration.create(5, TimeUnit.SECONDS);
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testAsScala() throws Exception {
         final CompletionStage<Integer> successCs = CompletableFuture.completedFuture(42);
         Future<Integer> scalaFuture = CompletionStages.asScala(successCs);
         assertEquals(42, Await.result(scalaFuture, timeout).intValue());
         //failed
         assertThrows(RuntimeException.class, () -> {
-            final CompletionStage<Integer> failedCs = Futures.failedCompletionStage(new RuntimeException(
-                "Simulated failure"));
+            final CompletionStage<Integer> failedCs = CompletableFuture.failedFuture(
+                new RuntimeException("Simulated failure"));
             Await.result(CompletionStages.asScala(failedCs), timeout);
         });
     }

--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/CompletionStagesTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/CompletionStagesTests.java
@@ -41,7 +41,7 @@ public class CompletionStagesTests {
         assertEquals(42, Await.result(scalaFuture, timeout).intValue());
         //failed
         assertThrows(RuntimeException.class, () -> {
-            final CompletionStage<Integer> failedCs = CompletableFuture.failedFuture(
+            final CompletionStage<Integer> failedCs = CompletableFuture.failedStage(
                 new RuntimeException("Simulated failure"));
             Await.result(CompletionStages.asScala(failedCs), timeout);
         });

--- a/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
+++ b/actor-tests/src/test/java/org/apache/pekko/dispatch/JavaFutureTests.java
@@ -42,14 +42,14 @@ public class JavaFutureTests {
 
   @Test
   public void mustBeAbleToCreateAJavaCompletionStage() throws Exception {
-    Future<Integer> f = Futures.successful(42);
-    CompletableFuture<Integer> cs = Futures.asJava(f).toCompletableFuture();
+    Future<Integer> f = scala.concurrent.Future$.MODULE$.successful(42);
+    CompletableFuture<Integer> cs = CompletionStages.fromScala(f).toCompletableFuture();
     assertEquals(42, cs.get(3, TimeUnit.SECONDS).intValue());
   }
 
   @Test
   public void blockMustBeCallable() throws Exception {
-    Promise<String> p = Futures.promise();
+    Promise<String> p = scala.concurrent.Promise$.MODULE$.apply();
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.success("foo");
     Await.ready(p.future(), d);
@@ -58,7 +58,7 @@ public class JavaFutureTests {
 
   @Test
   public void mapToMustBeCallable() throws Exception {
-    Promise<Object> p = Futures.promise();
+    Promise<Object> p = scala.concurrent.Promise$.MODULE$.apply();
     Future<String> f = p.future().mapTo(classTag(String.class));
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.success("foo");

--- a/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
@@ -341,7 +341,7 @@ public class PatternsTest {
   @Test
   public void testAfterFailedCallable() throws Exception {
     Callable<CompletionStage<String>> failedCallable =
-        () -> CompletableFuture.failedFuture(new IllegalStateException("Illegal!"));
+        () -> CompletableFuture.failedStage(new IllegalStateException("Illegal!"));
 
     CompletionStage<String> delayedFuture =
         Patterns.after(Duration.ofMillis(200), system.scheduler(), ec, failedCallable);
@@ -368,7 +368,7 @@ public class PatternsTest {
             Duration.ofMillis(200),
             system.scheduler(),
             ec,
-            () -> CompletableFuture.failedFuture(new IllegalStateException("Illegal!")));
+            () -> CompletableFuture.failedStage(new IllegalStateException("Illegal!")));
 
     CompletionStage<String> resultFuture =
         CompletionStages.firstCompletedOf(List.of(delayedFuture));

--- a/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pekko.actor.*;
 import org.apache.pekko.dispatch.CompletionStages;
-import org.apache.pekko.dispatch.Futures;
 import org.apache.pekko.testkit.PekkoJUnitJupiterActorSystemResource;
 import org.apache.pekko.testkit.PekkoSpec;
 import org.apache.pekko.testkit.TestProbe;
@@ -316,7 +315,7 @@ public class PatternsTest {
 
     Future<String> retriedFuture =
         Patterns.retry(
-            () -> Futures.successful(expected),
+            () -> scala.concurrent.Future$.MODULE$.successful(expected),
             3,
             scala.concurrent.duration.Duration.apply(200, "millis"),
             system.scheduler(),
@@ -340,10 +339,9 @@ public class PatternsTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testAfterFailedCallable() throws Exception {
     Callable<CompletionStage<String>> failedCallable =
-        () -> Futures.failedCompletionStage(new IllegalStateException("Illegal!"));
+        () -> CompletableFuture.failedFuture(new IllegalStateException("Illegal!"));
 
     CompletionStage<String> delayedFuture =
         Patterns.after(Duration.ofMillis(200), system.scheduler(), ec, failedCallable);
@@ -363,7 +361,6 @@ public class PatternsTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testAfterFailedFuture() throws Exception {
 
     CompletionStage<String> delayedFuture =
@@ -371,7 +368,7 @@ public class PatternsTest {
             Duration.ofMillis(200),
             system.scheduler(),
             ec,
-            () -> Futures.failedCompletionStage(new IllegalStateException("Illegal!")));
+            () -> CompletableFuture.failedFuture(new IllegalStateException("Illegal!")));
 
     CompletionStage<String> resultFuture =
         CompletionStages.firstCompletedOf(List.of(delayedFuture));

--- a/actor/src/main/scala/org/apache/pekko/dispatch/CompletionStages.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/CompletionStages.scala
@@ -158,7 +158,7 @@ object CompletionStages {
     if (iterator.hasNext) {
       iterator.next().thenCompose { v => foldWithNext[T, R](iterator, v, function) }
     } else {
-      CompletableFuture.failedFuture(new NoSuchElementException("reduce of an empty iterable of CompletionStages"))
+      CompletableFuture.failedStage(new NoSuchElementException("reduce of an empty iterable of CompletionStages"))
     }
   }
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/CompletionStages.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/CompletionStages.scala
@@ -22,8 +22,6 @@ import java.util.concurrent.{ CompletableFuture, CompletionStage, Executor }
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.{ BiConsumer, BiFunction }
 
-import scala.annotation.nowarn
-
 import org.apache.pekko
 
 /**
@@ -37,6 +35,16 @@ object CompletionStages {
   def asScala[T](stage: CompletionStage[T]): scala.concurrent.Future[T] = {
     import scala.jdk.FutureConverters._
     stage.asScala
+  }
+
+  /**
+   * Convert a Scala `Future` to a `CompletionStage`.
+   *
+   * @since 2.0.0
+   */
+  def fromScala[T](future: scala.concurrent.Future[T]): CompletionStage[T] = {
+    import scala.jdk.FutureConverters._
+    future.asJava
   }
 
   /**
@@ -143,7 +151,6 @@ object CompletionStages {
    *         or a `NoSuchElementException` if the given iterable is empty
    * @since 1.2.0
    */
-  @nowarn("msg=deprecated")
   def reduce[T <: AnyRef, R >: T](
       stages: java.lang.Iterable[? <: CompletionStage[? <: T]],
       function: pekko.japi.function.Function2[R, T, R]): CompletionStage[R] = {
@@ -151,7 +158,7 @@ object CompletionStages {
     if (iterator.hasNext) {
       iterator.next().thenCompose { v => foldWithNext[T, R](iterator, v, function) }
     } else {
-      Futures.failedCompletionStage(new NoSuchElementException("reduce of an empty iterable of CompletionStages"))
+      CompletableFuture.failedFuture(new NoSuchElementException("reduce of an empty iterable of CompletionStages"))
     }
   }
 

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -90,7 +90,7 @@ object Futures {
    *
    * @since 1.2.0
    */
-  @deprecated("Use scala.jdk.FutureConverters instead.", since = "2.0.0")
+  @deprecated("Use CompletionStages.fromScala instead.", since = "2.0.0")
   def asJava[T](future: Future[T]): CompletionStage[T] = {
     import scala.jdk.FutureConverters._
     future.asJava

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -131,7 +131,7 @@ object Futures {
   /**
    * Creates an already completed CompletionStage with the specified exception
    */
-  @deprecated("Use CompletableFuture.failedFuture instead.", since = "2.0.0")
+  @deprecated("Use CompletableFuture.failedStage instead.", since = "2.0.0")
   def failedCompletionStage[T](ex: Throwable): CompletionStage[T] = {
     val f = CompletableFuture.completedFuture[T](null.asInstanceOf[T])
     f.obtrudeException(ex)

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Future.scala
@@ -79,7 +79,10 @@ object ExecutionContexts {
 
 /**
  * Futures is the Java API for Futures and Promises
+ *
+ * @deprecated Use `CompletionStages` and standard `java.util.concurrent.CompletableFuture` APIs instead.
  */
+@deprecated("Use CompletionStages and standard java.util.concurrent.CompletableFuture APIs instead.", since = "2.0.0")
 object Futures {
 
   /**
@@ -87,6 +90,7 @@ object Futures {
    *
    * @since 1.2.0
    */
+  @deprecated("Use scala.jdk.FutureConverters instead.", since = "2.0.0")
   def asJava[T](future: Future[T]): CompletionStage[T] = {
     import scala.jdk.FutureConverters._
     future.asJava
@@ -101,6 +105,7 @@ object Futures {
    * @param executor the execution context on which the future is run
    * @return         the `Future` holding the result of the computation
    */
+  @deprecated("Use CompletableFuture.supplyAsync instead.", since = "2.0.0")
   def future[T](body: Callable[T], executor: ExecutionContext): Future[T] = Future(body.call)(executor)
 
   /**
@@ -108,22 +113,25 @@ object Futures {
    *
    * @return         the newly created `Promise` object
    */
+  @deprecated("Use new CompletableFuture instead.", since = "2.0.0")
   def promise[T](): Promise[T] = Promise[T]()
 
   /**
    * creates an already completed Promise with the specified exception
    */
+  @deprecated("Use CompletableFuture.failedFuture instead.", since = "2.0.0")
   def failed[T](exception: Throwable): Future[T] = Future.failed(exception)
 
   /**
    * Creates an already completed Promise with the specified result
    */
+  @deprecated("Use CompletableFuture.completedFuture instead.", since = "2.0.0")
   def successful[T](result: T): Future[T] = Future.successful(result)
 
   /**
    * Creates an already completed CompletionStage with the specified exception
    */
-  @deprecated("Use `CompletableFuture#failedStage` instead.", since = "2.0.0")
+  @deprecated("Use CompletableFuture.failedFuture instead.", since = "2.0.0")
   def failedCompletionStage[T](ex: Throwable): CompletionStage[T] = {
     val f = CompletableFuture.completedFuture[T](null.asInstanceOf[T])
     f.obtrudeException(ex)


### PR DESCRIPTION
### Motivation
Java users should not need to touch Scala `Future` at all. Standard `java.util.concurrent.CompletableFuture` and `CompletionStages` provide equivalent functionality. The `Futures` class was introduced when Akka still supported Java versions before Java 8.

### Modification
- Mark `Futures` object and all its methods as `@deprecated(since = "2.0.0")`
- Add `CompletionStages.fromScala` as replacement for `Futures.asJava`
- Replace internal `Futures.failedCompletionStage` usage in `CompletionStages.reduce` with `CompletableFuture.failedFuture`
- Migrate Java tests to use `CompletableFuture`/`CompletionStages` directly

### Result
Clear deprecation path for Java users toward standard Java APIs. Each deprecated method points to its specific replacement:
- `Futures.asJava` → `scala.jdk.FutureConverters` / `CompletionStages.fromScala`
- `Futures.future` → `CompletableFuture.supplyAsync`
- `Futures.promise` → `new CompletableFuture`
- `Futures.failed` → `CompletableFuture.failedFuture`
- `Futures.successful` → `CompletableFuture.completedFuture`
- `Futures.failedCompletionStage` → `CompletableFuture.failedFuture`

### Tests
- `sbt "actor-tests/Test/testOnly org.apache.pekko.dispatch.JavaFutureTests org.apache.pekko.dispatch.CompletionStagesTests org.apache.pekko.pattern.PatternsTest"` — 44 passed

### References
Fixes #1417