### PR TITLE
fix: support java.math.BigInteger/BigDecimal in MetricNumericConverter

### DIFF
--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/Metric.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/Metric.scala
@@ -271,13 +271,15 @@ private[metrics] trait MetricNumericConverter {
    * May involve rounding or truncation.
    */
   def convertNumber(from: Any): Either[Long, Double] = from match {
-    case n: Int        => Left(n)
-    case n: Long       => Left(n)
-    case n: Double     => Right(n)
-    case n: Float      => Right(n)
-    case n: BigInt     => Left(n.longValue)
-    case n: BigDecimal => Right(n.doubleValue)
-    case x             => throw new IllegalArgumentException(s"Not a number [$x]")
+    case n: Int                  => Left(n)
+    case n: Long                 => Left(n)
+    case n: Double               => Right(n)
+    case n: Float                => Right(n)
+    case n: java.math.BigInteger => Left(n.longValue)
+    case n: java.math.BigDecimal => Right(n.doubleValue)
+    case n: BigInt               => Left(n.longValue)
+    case n: BigDecimal           => Right(n.doubleValue)
+    case x                       => throw new IllegalArgumentException(s"Not a number [$x]")
   }
 
 }

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/Metric.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/Metric.scala
@@ -275,10 +275,11 @@ private[metrics] trait MetricNumericConverter {
     case n: Long                 => Left(n)
     case n: Double               => Right(n)
     case n: Float                => Right(n)
-    case n: java.math.BigInteger => Left(n.longValue)
-    case n: java.math.BigDecimal => Right(n.doubleValue)
     case n: BigInt               => Left(n.longValue)
     case n: BigDecimal           => Right(n.doubleValue)
+    case n: java.math.BigInteger => Left(n.longValue)
+    case n: java.math.BigDecimal => Right(n.doubleValue)
+    case n: Number               => Left(n.longValue)
     case x                       => throw new IllegalArgumentException(s"Not a number [$x]")
   }
 

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/MessageSerializer.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/protobuf/MessageSerializer.scala
@@ -193,7 +193,14 @@ class MessageSerializer(val system: ExtendedActorSystem) extends SerializerWithS
         case n: jl.Long    => Number.newBuilder().setType(NumberType.Long).setValue64(n)
         case n: jl.Float   => Number.newBuilder().setType(NumberType.Float).setValue32(jl.Float.floatToIntBits(n))
         case n: jl.Integer => Number.newBuilder().setType(NumberType.Integer).setValue32(n)
-        case _             =>
+        case n: BigInt     => Number.newBuilder().setType(NumberType.Long).setValue64(n.longValue)
+        case n: BigDecimal =>
+          Number.newBuilder().setType(NumberType.Double).setValue64(jl.Double.doubleToLongBits(n.doubleValue))
+        case n: java.math.BigInteger => Number.newBuilder().setType(NumberType.Long).setValue64(n.longValue)
+        case n: java.math.BigDecimal =>
+          Number.newBuilder().setType(NumberType.Double).setValue64(jl.Double.doubleToLongBits(n.doubleValue))
+        case n: java.lang.Number => Number.newBuilder().setType(NumberType.Long).setValue64(n.longValue)
+        case _                   =>
           val bos = new ByteArrayOutputStream
           val out = new ObjectOutputStream(bos)
           out.writeObject(number)

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
@@ -39,6 +39,21 @@ class MetricNumericConverterSpec extends AnyWordSpec with Matchers with MetricNu
       convertNumber(0.0).isRight should ===(true)
     }
 
+    "convert java.math.BigInteger and java.math.BigDecimal" in {
+      convertNumber(java.math.BigInteger.valueOf(42)).isLeft should ===(true)
+      convertNumber(java.math.BigInteger.valueOf(42)).left.get should ===(42L)
+      convertNumber(new java.math.BigDecimal("3.14")).isRight should ===(true)
+      convertNumber(new java.math.BigDecimal("3.14")).right.get should ===(3.14 +- 0.0001)
+    }
+
+    "define a metric with java.math.BigInteger and java.math.BigDecimal values" in {
+      val Some(intMetric) = Metric.create("big-int", java.math.BigInteger.valueOf(1024L), None): @unchecked
+      intMetric.value should ===(java.math.BigInteger.valueOf(1024L))
+
+      val Some(decMetric) = Metric.create("big-dec", new java.math.BigDecimal("99.9"), None): @unchecked
+      decMetric.value should ===(new java.math.BigDecimal("99.9"))
+    }
+
     "define a new metric" in {
       val Some(metric) = Metric.create(HeapMemoryUsed, 256L, decayFactor = Some(0.18)): @unchecked
       metric.name should ===(HeapMemoryUsed)

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
@@ -46,6 +46,17 @@ class MetricNumericConverterSpec extends AnyWordSpec with Matchers with MetricNu
       convertNumber(new java.math.BigDecimal("3.14")).right.get should ===(3.14 +- 0.0001)
     }
 
+    "convert any Number subtype" in {
+      convertNumber(42.toShort).isLeft should ===(true)
+      convertNumber(42.toShort).left.get should ===(42L)
+      convertNumber(7.toByte).isLeft should ===(true)
+      convertNumber(7.toByte).left.get should ===(7L)
+      convertNumber(new java.util.concurrent.atomic.AtomicInteger(99)).isLeft should ===(true)
+      convertNumber(new java.util.concurrent.atomic.AtomicInteger(99)).left.get should ===(99L)
+      convertNumber(new java.util.concurrent.atomic.AtomicLong(1234L)).isLeft should ===(true)
+      convertNumber(new java.util.concurrent.atomic.AtomicLong(1234L)).left.get should ===(1234L)
+    }
+
     "define a metric with java.math.BigInteger and java.math.BigDecimal values" in {
       val Some(intMetric) = Metric.create("big-int", java.math.BigInteger.valueOf(1024L), None): @unchecked
       intMetric.value should ===(java.math.BigInteger.valueOf(1024L))

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/protobuf/MessageSerializerSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/protobuf/MessageSerializerSpec.scala
@@ -63,7 +63,11 @@ class MessageSerializerSpec extends PekkoSpec("""
               Metric("bar2", Float.MaxValue, None),
               Metric("bar3", Int.MaxValue, None),
               Metric("bar4", Long.MaxValue, None),
-              Metric("bar5", BigInt(Long.MaxValue), None)))))
+              Metric("bar5", BigInt(Long.MaxValue), None),
+              Metric("bar6", BigDecimal("3.14"), None),
+              Metric("bar7", java.math.BigInteger.valueOf(9999L), None),
+              Metric("bar8", new java.math.BigDecimal("2.718"), None),
+              Metric("bar9", 42.toShort, None)))))
 
       checkSerialization(MetricsGossipEnvelope(a1.address, metricsGossip, true))
 


### PR DESCRIPTION
### Motivation
`MetricNumericConverter.convertNumber` only handled `scala.math.BigInt` and `scala.math.BigDecimal` but not `java.math.BigInteger` and `java.math.BigDecimal`. Since `Metric.value` is typed as `java.lang.Number`, Java users passing `java.math.BigInteger` or `java.math.BigDecimal` would get an `IllegalArgumentException`. The `NumberInputStream` deserializer also explicitly allows `java.math` classes through, so deserialized values could also fail.

### Modification
Add pattern match cases for `java.math.BigInteger` and `java.math.BigDecimal` in `convertNumber`, placed before the Scala `BigInt`/`BigDecimal` cases.

### Result
Java users can now use `java.math.BigInteger` and `java.math.BigDecimal` as `Metric` values without errors.

### Tests
- `sbt "cluster-metrics / Test / testOnly org.apache.pekko.cluster.metrics.MetricNumericConverterSpec"` — All 7 tests passed
- `sbt "cluster-metrics / Test / testOnly org.apache.pekko.cluster.metrics.protobuf.MessageSerializerSpec"` — All 2 tests passed

### References
None - discovered during Java API audit for Scala number type usage