### PR TITLE
fix: remove stale Akka-era FIXME/TODO comments in dispatch module

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/dispatch/Dispatchers.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Dispatchers.scala
@@ -266,13 +266,7 @@ class Dispatchers @InternalApi private[pekko] (
         cfg.renderWithRedactions())
 
     cfg.getString("type") match {
-      case "Dispatcher"          => new DispatcherConfigurator(cfg, prerequisites)
-      case "BalancingDispatcher" =>
-        // FIXME remove this case in Akka 2.4
-        throw new IllegalArgumentException(
-          "BalancingDispatcher is deprecated, use a BalancingPool instead. " +
-          "During a migration period you can still use BalancingDispatcher by specifying the full class name: " +
-          classOf[BalancingDispatcherConfigurator].getName)
+      case "Dispatcher"       => new DispatcherConfigurator(cfg, prerequisites)
       case "PinnedDispatcher" => new PinnedDispatcherConfigurator(cfg, prerequisites)
       case fqn                =>
         val args = List(classOf[Config] -> cfg, classOf[DispatcherPrerequisites] -> prerequisites)

--- a/actor/src/main/scala/org/apache/pekko/dispatch/Mailboxes.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Mailboxes.scala
@@ -127,7 +127,6 @@ private[pekko] class Mailboxes(
     }
 
   // don’t care if this happens twice
-  private var mailboxSizeWarningIssued = false
   private var mailboxNonZeroPushTimeoutWarningIssued = false
 
   def getMailboxRequirement(config: Config) = config.getString("mailbox-requirement") match {
@@ -168,16 +167,6 @@ private[pekko] class Mailboxes(
     val hasMailboxType =
       dispatcherConfig.hasPath("mailbox-type") &&
       dispatcherConfig.getString("mailbox-type") != Deploy.NoMailboxGiven
-
-    // TODO remove in Akka 2.3
-    if (!hasMailboxType && !mailboxSizeWarningIssued && dispatcherConfig.hasPath("mailbox-size")) {
-      eventStream.publish(
-        Warning(
-          "mailboxes",
-          getClass,
-          s"ignoring setting 'mailbox-size' for dispatcher [$id], you need to specify 'mailbox-type=bounded'"))
-      mailboxSizeWarningIssued = true
-    }
 
     def verifyRequirements(mailboxType: MailboxType): MailboxType = {
       lazy val mqType: Class[?] = getProducedMessageQueueType(mailboxType)
@@ -227,7 +216,6 @@ private[pekko] class Mailboxes(
       case null =>
         // It doesn't matter if we create a mailbox type configurator that isn't used due to concurrent lookup.
         val newConfigurator = id match {
-          // TODO RK remove these two for Akka 2.3
           case "unbounded"                               => UnboundedMailbox()
           case "bounded"                                 => new BoundedMailbox(settings, config(id))
           case _ if id.startsWith(BoundedCapacityPrefix) =>


### PR DESCRIPTION
### Motivation
Issue #2168 requests removal of stale FIXME/TODO comments. The dispatch module contained three comments referencing Akka 2.3/2.4 migration periods that are long over.

### Modification
- Remove the `BalancingDispatcher` shortcut case in `Dispatchers` that threw a deprecation migration error (`FIXME remove in Akka 2.4`). Users can still use `BalancingDispatcherConfigurator` via full class name.
- Remove the `mailbox-size` warning in `Mailboxes` (`TODO remove in Akka 2.3`) along with its associated state variable.
- Remove the stale `TODO RK remove these two for Akka 2.3` comment on `unbounded`/`bounded` mailbox shortcuts which are still actively used in `reference.conf`.

### Result
Cleaner codebase without misleading stale migration comments. No behavioral change for supported configurations.

### Tests
- `sbt "actor-tests/Test/testOnly org.apache.pekko.actor.dispatch.DispatchersSpec"` — 22 tests passed
- `sbt "actor-tests/Test/testOnly org.apache.pekko.actor.dispatch.BalancingDispatcherSpec org.apache.pekko.actor.ActorMailboxSpec"` — 34 tests passed

### References
Refs #2168