### PR TITLE
fix: Java DSL SourceWithContext exposes Pair-typed shape in GraphDSL

### DIFF
--- a/docs/src/main/paradox/migration/migration-guide-1.x-2.x.md
+++ b/docs/src/main/paradox/migration/migration-guide-1.x-2.x.md
@@ -37,3 +37,8 @@ list before a second param list. Instead of `watchTermination(){ ... }`, you now
 In the Java API, `FSMTransitionHandlerBuilder.build` and `FSMTransitionHandlerBuilder.state` now use
 `pekko.japi.Pair` instead of `scala.Tuple2`. Java users need to update their code to use `Pair` instead of `Tuple2`.
 ([PR3378](https://github.com/apache/pekko/pull/3378))
+
+The Java DSL `SourceWithContext` graph shape now uses `pekko.japi.Pair` instead of `scala.Tuple2`.
+Java code that passes a `SourceWithContext` directly to `GraphDSL` must use `Pair`-typed stages.
+Code that converts it with `asSource()` already uses `Pair` and requires no changes.
+([PR3388](https://github.com/apache/pekko/pull/3388))

--- a/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceWithContextTest.java
+++ b/stream-tests/src/test/java/org/apache/pekko/stream/javadsl/SourceWithContextTest.java
@@ -22,9 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.japi.pf.PFBuilder;
+import org.apache.pekko.stream.ClosedShape;
 import org.apache.pekko.stream.StreamTestJupiter;
 import org.apache.pekko.testkit.PekkoJUnitJupiterActorSystemResource;
 import org.apache.pekko.testkit.PekkoSpec;
@@ -154,5 +156,33 @@ public class SourceWithContextTest extends StreamTestJupiter {
             .get(3, TimeUnit.SECONDS);
 
     assertEquals(List.of(new Pair<>(1, "one")), timedResult);
+  }
+
+  @Test
+  public void mustConnectPairTypedOutletToJavaSinkInGraphDsl() throws Exception {
+    SourceWithContext<Integer, String, String> contextSource =
+        Source.from(List.of(3, 5))
+            .mapMaterializedValue(ignored -> "upstream-control")
+            .asSourceWithContext(value -> "request-" + value)
+            .map(value -> value * 10);
+    Sink<Pair<Integer, String>, CompletionStage<List<Pair<Integer, String>>>> pairSink = Sink.seq();
+
+    RunnableGraph<Pair<String, CompletionStage<List<Pair<Integer, String>>>>> graph =
+        RunnableGraph.fromGraph(
+            GraphDSL.create(
+                contextSource,
+                pairSink,
+                Keep.both(),
+                (builder, sourceShape, sinkShape) -> {
+                  builder.from(sourceShape).to(sinkShape);
+                  return ClosedShape.getInstance();
+                }));
+
+    Pair<String, CompletionStage<List<Pair<Integer, String>>>> materialized = graph.run(system);
+
+    assertEquals("upstream-control", materialized.first());
+    assertEquals(
+        List.of(new Pair<>(30, "request-3"), new Pair<>(50, "request-5")),
+        materialized.second().toCompletableFuture().get(3, TimeUnit.SECONDS));
   }
 }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceWithContextSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceWithContextSpec.scala
@@ -20,6 +20,8 @@ import scala.jdk.CollectionConverters._
 import scala.util.control.NoStackTrace
 
 import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.impl.TraversalTestUtils
 import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.scaladsl.TestSink
 
@@ -62,6 +64,28 @@ class SourceWithContextSpec extends StreamSpec {
         .request(1)
         .expectNext("a")
         .expectComplete()
+    }
+
+    "add only the requested operators to the Java DSL graph" in {
+      def moduleCount[T](source: Source[T, NotUsed]): Int =
+        TraversalTestUtils
+          .testMaterialize(source.to(Sink.ignore).traversalBuilder)
+          .attributesAssignments
+          .size
+
+      val source = Source.single(1).asSourceWithContext(_.toString).asJava
+      val transformed = source
+        .map((value: Int) => value + 1)
+        .map((value: Int) => value + 1)
+        .map((value: Int) => value + 1)
+
+      val scalaModules = moduleCount(source.asScala.asSource)
+      val sourceModules = moduleCount(source.asSource().asScala)
+      val transformedModules = moduleCount(transformed.asSource().asScala)
+      withClue(s"scala=$scalaModules, java=$sourceModules, transformed=$transformedModules: ") {
+        sourceModules - scalaModules shouldBe 1
+        transformedModules - sourceModules shouldBe 3
+      }
     }
 
     "pass through contexts using map and filter" in {

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SourceWithContext.scala
@@ -82,10 +82,13 @@ object SourceWithContext {
  * use [[SourceWithContext#via]] to manually provide the context propagation for otherwise unsupported
  * operations.
  *
+ * When used as a [[Graph]], its outlet emits [[pekko.japi.Pair]] elements, matching [[SourceWithContext#asSource]].
+ *
  * Can be created by calling [[Source.asSourceWithContext]]
  */
 final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithContext[Out, Ctx, Mat])
-    extends GraphDelegate(delegate) {
+    extends GraphDelegate[SourceShape[Pair[Out @uncheckedVariance, Ctx @uncheckedVariance]], Mat @uncheckedVariance](
+      delegate.asSource.map { case (out, ctx) => Pair(out, ctx) }.asJava) {
 
   /**
    * Transform this flow by the regular flow. The given flow must support manual context propagation by
@@ -103,8 +106,7 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
   def via[Out2, Ctx2, Mat2](
       viaFlow: Graph[FlowShape[Pair[Out @uncheckedVariance, Ctx @uncheckedVariance], Pair[Out2, Ctx2]], Mat2])
       : SourceWithContext[Out2, Ctx2, Mat] =
-    viaScala(_.via(pekko.stream.scaladsl.Flow[(Out, Ctx)].map { case (o, c) => Pair(o, c) }.via(viaFlow).map(
-      _.toScala)))
+    SourceWithContext.fromPairs(asSource().via(viaFlow))
 
   /**
    * Transform this flow by the regular flow. The given flow works on the data portion of the stream and
@@ -152,7 +154,7 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
    * stream of a pair of (data, context).
    */
   def asSource(): Source[Pair[Out @uncheckedVariance, Ctx @uncheckedVariance], Mat @uncheckedVariance] =
-    delegate.asSource.map { case (o, c) => Pair(o, c) }.asJava
+    Source.fromGraph(this)
 
   // remaining operations in alphabetic order
 
@@ -565,7 +567,7 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
    */
   def to[Mat2](
       sink: Graph[SinkShape[Pair[Out @uncheckedVariance, Ctx @uncheckedVariance]], Mat2]): javadsl.RunnableGraph[Mat] =
-    RunnableGraph.fromGraph(asScala.asSource.map { case (o, e) => Pair(o, e) }.to(sink))
+    asSource().to(sink)
 
   /**
    * Connect this [[pekko.stream.javadsl.SourceWithContext]] to a [[pekko.stream.javadsl.Sink]],
@@ -574,7 +576,7 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
   def toMat[Mat2, Mat3](
       sink: Graph[SinkShape[Pair[Out @uncheckedVariance, Ctx @uncheckedVariance]], Mat2],
       combine: function.Function2[Mat, Mat2, Mat3]): javadsl.RunnableGraph[Mat3] =
-    RunnableGraph.fromGraph(asScala.asSource.map { case (o, e) => Pair(o, e) }.toMat(sink)(combinerToScala(combine)))
+    asSource().toMat(sink, combine)
 
   /**
    * Connect this [[pekko.stream.javadsl.SourceWithContext]] to a [[pekko.stream.javadsl.Sink]] and run it.


### PR DESCRIPTION
### Motivation

#2510 reports a Java GraphDSL boundary mismatch: `javadsl.SourceWithContext` exposes a tuple-typed graph shape, while Java stream stages use `pekko.japi.Pair`. A `SourceWithContext` passed directly to `GraphDSL.create` therefore cannot connect to a `Pair`-typed Java graph component without first calling `.asSource()`.

### Modification

- Keep the existing `scaladsl.SourceWithContext` delegate, public constructor, `asScala`, and ordinary context-operator path unchanged.
- Expose one `Pair`-typed graph view at the Java Graph boundary and reuse it from `asSource`, `via`, `to`, and `toMat`.
- Remove the constructor-signature MiMa exclusion; no binary-compatibility filter is needed.
- Add an independently authored closed-graph regression test that connects the `Pair`-typed outlet directly to a Java sink and asserts both emitted elements and the source materialized value.
- Add an exact graph-size regression test: the Java graph bridge contributes one module, and each requested Java operator contributes one module.
- Document the `Pair` graph contract and add a 1.x-to-2.x migration note for direct GraphDSL users.

### Result

`SourceWithContext` can now be used directly in Java GraphDSL with a `SourceShape<Pair<Out, Ctx>>`, while its existing Scala delegate and constructor descriptor remain unchanged.

The revised implementation also avoids the repeated conversion stages introduced by the initial version of this PR:

- Initial implementation: Java baseline `4` modules; three `map` calls produced `13` modules (`+9`).
- Revised implementation: Scala baseline `3`; Java graph bridge `4` (`+1`); three `map` calls produce `7` (`+3`).

Existing callers of `.asSource()` already receive `Pair` and require no migration. Code that passes `SourceWithContext` directly to GraphDSL should use `Pair`-typed stages, as documented in the migration guide.

### Tests

- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.javadsl.SourceWithContextTest org.apache.pekko.stream.scaladsl.SourceWithContextSpec org.apache.pekko.stream.javadsl.FlowWithContextTest org.apache.pekko.stream.scaladsl.FlowWithContextSpec org.apache.pekko.stream.javadsl.RetryFlowTest org.apache.pekko.stream.scaladsl.WithContextUsageSpec"` — passed, 45 tests on the final diff.
- `sbt "stream / mimaReportBinaryIssues"` — passed.
- `sbt "++3.3.8" "stream / mimaReportBinaryIssues"` — passed.
- `sbt "+mimaReportBinaryIssues"` — Scala 2.13 passed; the aggregate Scala 3 run was blocked by unrelated cyclic compilation errors in `remote/Remoting.scala`.
- `sbt "+headerCheckAll" "checkCodeStyle"` — passed.
- JDK 17 `sbt javafmtCheckAll` — passed.
- `scalafmt --list --mode diff-ref=origin/main` — passed.
- `sbt "docs / paradox"` — passed (existing duplicate-anchor warnings only).
- `git diff --check` — passed.
- `sbt validatePullRequest` — not completed: the local arm64 JVM could not load the x86-only `leveldbjni` 1.8 native library in `JournalNoCompactionSpec`.

### References

Fixes #2510
