### PR TITLE
deprecate BalancingDispatcherConfigurator and mark as internal API

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/dispatch/Dispatchers.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/Dispatchers.scala
@@ -319,12 +319,15 @@ private[pekko] object BalancingDispatcherConfigurator {
 }
 
 /**
+ * INTERNAL API
+ *
  * Configurator for creating `BalancingDispatcher`.
  * Returns the same dispatcher instance for each invocation
  * of the `dispatcher()` method.
  */
+@deprecated("Use BalancingPool instead of BalancingDispatcherConfigurator", "Pekko 2.0.0")
 @nowarn("msg=deprecated")
-class BalancingDispatcherConfigurator(_config: Config, _prerequisites: DispatcherPrerequisites)
+private[pekko] class BalancingDispatcherConfigurator(_config: Config, _prerequisites: DispatcherPrerequisites)
     extends MessageDispatcherConfigurator(BalancingDispatcherConfigurator.amendConfig(_config), _prerequisites) {
 
   private val instance = {

--- a/actor/src/main/scala/org/apache/pekko/routing/Balancing.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/Balancing.scala
@@ -79,6 +79,7 @@ private[pekko] final class BalancingRoutingLogic extends RoutingLogic {
  * @param routerDispatcher dispatcher to use for the router head actor, which handles
  *   supervision, death watch and router management messages
  */
+@nowarn("msg=deprecated")
 @SerialVersionUID(1L)
 final case class BalancingPool(
     nrOfInstances: Int,


### PR DESCRIPTION
### Motivation
`BalancingDispatcher` has been deprecated since Akka 2.3 with the recommendation to use `BalancingPool` instead. The `BalancingDispatcherConfigurator` class remained public and unmarked. Since Pekko 2.0.0 is a major release, it is time to deprecate and restrict visibility.

### Modification
- Add `@deprecated("Use BalancingPool instead of BalancingDispatcherConfigurator", "Pekko 2.0.0")` annotation
- Mark the class as `private[pekko]` (INTERNAL API)
- Add `@nowarn("msg=deprecated")` to `BalancingPool` which uses the configurator internally
- Update Scaladoc to indicate INTERNAL API

### Result
`BalancingDispatcherConfigurator` is no longer part of the public API. `BalancingPool` continues to work as the supported replacement. Users who referenced the configurator by full class name in config will still work (reflection-based loading is unaffected by Scala access modifiers), but direct code usage will produce deprecation warnings.

### Tests
- `sbt "actor-tests/Test/testOnly org.apache.pekko.actor.dispatch.BalancingDispatcherSpec org.apache.pekko.actor.dispatch.DispatchersSpec org.apache.pekko.actor.ActorConfigurationVerificationSpec"` — 33 tests passed
- `sbt "actor-tests/Test/testOnly org.apache.pekko.actor.dispatch.BalancingDispatcherModelSpec"` — 10 tests passed
- `sbt "actor-tests/Test/testOnly org.apache.pekko.actor.ActorMailboxSpec"` — 33 tests passed
- `sbt "actor/mimaReportBinaryIssues"` — no issues

### References
Refs #3384, Refs #2168