### PR TITLE
feat: add maxTotalBufferSize to MergeHub for aggregate queue bound

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -155,58 +155,95 @@ class HubSpec extends StreamSpec {
 
     "cancel new producers when maxTotalBufferSize is exceeded" in {
       val downstream = TestSubscriber.manualProbe[Int]()
-      // perProducerBufferSize=4, maxTotalBufferSize=8
-      val sink = Sink.fromSubscriber(downstream).runWith(MergeHub.source[Int](4, 8))
+      // perProducerBufferSize=4, maxTotalBufferSize=3
+      val sink = Sink.fromSubscriber(downstream).runWith(MergeHub.source[Int](4, 3))
 
       val sub = downstream.expectSubscription()
-      // Do not request any elements — downstream is stalled
 
-      // First producer connects and pushes up to 4 elements
+      // Producer connects and pushes 4 elements
       val upstream1 = TestPublisher.probe[Int]()
       Source.fromPublisher(upstream1).runWith(sink)
       for (i <- 1 to 4) upstream1.sendNext(i)
 
-      // Second producer connects and pushes up to 4 elements (total = 8 = maxTotalBufferSize)
+      // Consume 1 element: proves all 4 were enqueued (counter was 4, now 3 = threshold)
+      sub.request(1)
+      downstream.expectNext(1)
+
+      // Buffer count (3) >= maxTotalBufferSize (3): new producer is rejected
       val upstream2 = TestPublisher.probe[Int]()
       Source.fromPublisher(upstream2).runWith(sink)
-      for (i <- 5 to 8) upstream2.sendNext(i)
-
-      // Third producer should be cancelled because buffer is full
-      val upstream3 = TestPublisher.probe[Int]()
-      Source.fromPublisher(upstream3).runWith(sink)
-      upstream3.expectCancellation()
+      upstream2.expectCancellation()
 
       sub.cancel()
     }
 
     "allow new producers after elements are consumed from the aggregate buffer" in {
       val downstream = TestSubscriber.manualProbe[Int]()
-      // perProducerBufferSize=4, maxTotalBufferSize=4
-      val sink = Sink.fromSubscriber(downstream).runWith(MergeHub.source[Int](4, 4))
+      // perProducerBufferSize=4, maxTotalBufferSize=3
+      val sink = Sink.fromSubscriber(downstream).runWith(MergeHub.source[Int](4, 3))
 
       val sub = downstream.expectSubscription()
 
-      // First producer connects and pushes 4 elements (fills the buffer)
+      // First producer connects and pushes 4 elements
       val upstream1 = TestPublisher.probe[Int]()
       Source.fromPublisher(upstream1).runWith(sink)
       for (i <- 1 to 4) upstream1.sendNext(i)
 
-      // Second producer is cancelled because buffer is full
+      // Consume 1 to prove all 4 were enqueued (counter was 4, now 3 = threshold)
+      sub.request(1)
+      downstream.expectNext(1)
+
+      // Second producer is cancelled because buffer count (3) >= threshold (3)
       val upstream2 = TestPublisher.probe[Int]()
       Source.fromPublisher(upstream2).runWith(sink)
       upstream2.expectCancellation()
 
-      // Now consume all 4 elements, freeing the buffer
-      sub.request(4)
-      downstream.expectNext(1)
+      // Consume all remaining elements, freeing the buffer (counter drops to 0 < 3)
+      sub.request(3)
       downstream.expectNext(2)
       downstream.expectNext(3)
       downstream.expectNext(4)
 
-      // Now a new producer should be accepted
+      // Now a new producer should be accepted and its element delivered
       val upstream3 = TestPublisher.probe[Int]()
       Source.fromPublisher(upstream3).runWith(sink)
       upstream3.sendNext(5)
+      sub.request(1)
+      downstream.expectNext(5)
+
+      sub.cancel()
+    }
+
+    "allow already admitted producers to continue when buffer is full" in {
+      val downstream = TestSubscriber.manualProbe[Int]()
+      // perProducerBufferSize=4, maxTotalBufferSize=3
+      val sink = Sink.fromSubscriber(downstream).runWith(MergeHub.source[Int](4, 3))
+
+      val sub = downstream.expectSubscription()
+
+      // First producer connects and pushes 4 elements (counter = 4 > threshold 3)
+      val upstream1 = TestPublisher.probe[Int]()
+      Source.fromPublisher(upstream1).runWith(sink)
+      for (i <- 1 to 4) upstream1.sendNext(i)
+
+      // Consume 1 to prove elements were enqueued (counter = 3 = threshold)
+      sub.request(1)
+      downstream.expectNext(1)
+
+      // New producer is rejected
+      val upstream2 = TestPublisher.probe[Int]()
+      Source.fromPublisher(upstream2).runWith(sink)
+      upstream2.expectCancellation()
+
+      // But the already admitted producer can still push (it has remaining demand)
+      // Consume all remaining to make room and generate demand signals
+      sub.request(3)
+      downstream.expectNext(2)
+      downstream.expectNext(3)
+      downstream.expectNext(4)
+
+      // First producer received demand signal and can push more
+      upstream1.sendNext(5)
       sub.request(1)
       downstream.expectNext(5)
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -153,6 +153,66 @@ class HubSpec extends StreamSpec {
       sub.cancel()
     }
 
+    "cancel new producers when maxTotalBufferSize is exceeded" in {
+      val downstream = TestSubscriber.manualProbe[Int]()
+      // perProducerBufferSize=4, maxTotalBufferSize=8
+      val sink = Sink.fromSubscriber(downstream).runWith(MergeHub.source[Int](4, 8))
+
+      val sub = downstream.expectSubscription()
+      // Do not request any elements — downstream is stalled
+
+      // First producer connects and pushes up to 4 elements
+      val upstream1 = TestPublisher.probe[Int]()
+      Source.fromPublisher(upstream1).runWith(sink)
+      for (i <- 1 to 4) upstream1.sendNext(i)
+
+      // Second producer connects and pushes up to 4 elements (total = 8 = maxTotalBufferSize)
+      val upstream2 = TestPublisher.probe[Int]()
+      Source.fromPublisher(upstream2).runWith(sink)
+      for (i <- 5 to 8) upstream2.sendNext(i)
+
+      // Third producer should be cancelled because buffer is full
+      val upstream3 = TestPublisher.probe[Int]()
+      Source.fromPublisher(upstream3).runWith(sink)
+      upstream3.expectCancellation()
+
+      sub.cancel()
+    }
+
+    "allow new producers after elements are consumed from the aggregate buffer" in {
+      val downstream = TestSubscriber.manualProbe[Int]()
+      // perProducerBufferSize=4, maxTotalBufferSize=4
+      val sink = Sink.fromSubscriber(downstream).runWith(MergeHub.source[Int](4, 4))
+
+      val sub = downstream.expectSubscription()
+
+      // First producer connects and pushes 4 elements (fills the buffer)
+      val upstream1 = TestPublisher.probe[Int]()
+      Source.fromPublisher(upstream1).runWith(sink)
+      for (i <- 1 to 4) upstream1.sendNext(i)
+
+      // Second producer is cancelled because buffer is full
+      val upstream2 = TestPublisher.probe[Int]()
+      Source.fromPublisher(upstream2).runWith(sink)
+      upstream2.expectCancellation()
+
+      // Now consume all 4 elements, freeing the buffer
+      sub.request(4)
+      downstream.expectNext(1)
+      downstream.expectNext(2)
+      downstream.expectNext(3)
+      downstream.expectNext(4)
+
+      // Now a new producer should be accepted
+      val upstream3 = TestPublisher.probe[Int]()
+      Source.fromPublisher(upstream3).runWith(sink)
+      upstream3.sendNext(5)
+      sub.request(1)
+      downstream.expectNext(5)
+
+      sub.cancel()
+    }
+
     "work with long streams" in {
       val (sink, result) = MergeHub.source[Int](16).take(2000).toMat(Sink.seq)(Keep.both).run()
       Source(1 to 1000).runWith(sink)

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Hub.scala
@@ -84,8 +84,9 @@ object MergeHub {
    * @param perProducerBufferSize Buffer space used per producer.
    * @param maxTotalBufferSize Admission threshold for the total number of elements buffered across all producers.
    *   New producers are cancelled at registration when the buffered element count meets or exceeds this value.
-   *   Transient overshoot up to the per-producer buffer of concurrently admitted producers is possible.
+   *   Already admitted producers are unaffected and may continue to push up to their per-producer buffer.
    *   Use 0 for unlimited (default behavior).
+   * @since 2.0.0
    */
   def of[T](
       @nowarn("msg=never used") clazz: Class[T],
@@ -137,15 +138,16 @@ object MergeHub {
    * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
    * and any new producers using the [[Sink]] will be cancelled.
    *
-   * The materialized [[DrainingControl]] can be used to drain the Hub: any new produces using the [[Sink]] will be cancelled
+   * The materialized [[DrainingControl]] can be used to drain the Hub: any new producers using the [[Sink]] will be cancelled
    * and the Hub will be closed completing the [[Source]] as soon as all currently connected producers complete.
    *
    * @param clazz Type of elements this hub emits and consumes
-   * @param perProducerBufferSize Buffer space used per producer. Default value is 16.
+   * @param perProducerBufferSize Buffer space used per producer.
    * @param maxTotalBufferSize Admission threshold for the total number of elements buffered across all producers.
    *   New producers are cancelled at registration when the buffered element count meets or exceeds this value.
-   *   Transient overshoot up to the per-producer buffer of concurrently admitted producers is possible.
+   *   Already admitted producers are unaffected and may continue to push up to their per-producer buffer.
    *   Use 0 for unlimited (default behavior).
+   * @since 2.0.0
    */
   def withDraining[T](
       @nowarn("msg=never used") clazz: Class[T],

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Hub.scala
@@ -72,6 +72,34 @@ object MergeHub {
   /**
    * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
    * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
+   * arbitrary many times and each of the materializations will feed the elements into the original [[Source]].
+   *
+   * Every new materialization of the [[Source]] results in a new, independent hub, which materializes to its own
+   * [[Sink]] for feeding that materialization.
+   *
+   * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
+   * and any new producers using the [[Sink]] will be cancelled.
+   *
+   * @param clazz Type of elements this hub emits and consumes
+   * @param perProducerBufferSize Buffer space used per producer.
+   * @param maxTotalBufferSize Admission threshold for the total number of elements buffered across all producers.
+   *   New producers are cancelled at registration when the buffered element count meets or exceeds this value.
+   *   Transient overshoot up to the per-producer buffer of concurrently admitted producers is possible.
+   *   Use 0 for unlimited (default behavior).
+   */
+  def of[T](
+      @nowarn("msg=never used") clazz: Class[T],
+      perProducerBufferSize: Int,
+      maxTotalBufferSize: Int): Source[T, Sink[T, NotUsed]] = {
+    pekko.stream.scaladsl.MergeHub
+      .source[T](perProducerBufferSize, maxTotalBufferSize)
+      .mapMaterializedValue(_.asJava[T])
+      .asJava
+  }
+
+  /**
+   * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
+   * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
    * arbitrarily many times and each of the materializations will feed the elements into the original [[Source]].
    *
    * Every new materialization of the [[Source]] results in a new, independent hub, which materializes to its own
@@ -91,6 +119,40 @@ object MergeHub {
       perProducerBufferSize: Int): Source[T, pekko.japi.Pair[Sink[T, NotUsed], DrainingControl]] = {
     pekko.stream.scaladsl.MergeHub
       .sourceWithDraining[T](perProducerBufferSize)
+      .mapMaterializedValue {
+        case (sink, draining) =>
+          pekko.japi.Pair(sink.asJava[T], new DrainingControlImpl(draining): DrainingControl)
+      }
+      .asJava
+  }
+
+  /**
+   * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
+   * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
+   * arbitrarily many times and each of the materializations will feed the elements into the original [[Source]].
+   *
+   * Every new materialization of the [[Source]] results in a new, independent hub, which materializes to its own
+   * [[Sink]] for feeding that materialization.
+   *
+   * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
+   * and any new producers using the [[Sink]] will be cancelled.
+   *
+   * The materialized [[DrainingControl]] can be used to drain the Hub: any new produces using the [[Sink]] will be cancelled
+   * and the Hub will be closed completing the [[Source]] as soon as all currently connected producers complete.
+   *
+   * @param clazz Type of elements this hub emits and consumes
+   * @param perProducerBufferSize Buffer space used per producer. Default value is 16.
+   * @param maxTotalBufferSize Admission threshold for the total number of elements buffered across all producers.
+   *   New producers are cancelled at registration when the buffered element count meets or exceeds this value.
+   *   Transient overshoot up to the per-producer buffer of concurrently admitted producers is possible.
+   *   Use 0 for unlimited (default behavior).
+   */
+  def withDraining[T](
+      @nowarn("msg=never used") clazz: Class[T],
+      perProducerBufferSize: Int,
+      maxTotalBufferSize: Int): Source[T, pekko.japi.Pair[Sink[T, NotUsed], DrainingControl]] = {
+    pekko.stream.scaladsl.MergeHub
+      .sourceWithDraining[T](perProducerBufferSize, maxTotalBufferSize)
       .mapMaterializedValue {
         case (sink, draining) =>
           pekko.japi.Pair(sink.asJava[T], new DrainingControlImpl(draining): DrainingControl)

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -15,8 +15,7 @@ package org.apache.pekko.stream.scaladsl
 
 import java.util
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{ AtomicInteger, AtomicLong, AtomicReference }
 import java.util.concurrent.atomic.AtomicReferenceArray
 
 import scala.annotation.tailrec
@@ -89,6 +88,26 @@ object MergeHub {
    * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
    * and any new producers using the [[Sink]] will be cancelled.
    *
+   * @param perProducerBufferSize Buffer space used per producer. Default value is 16.
+   * @param maxTotalBufferSize Admission threshold for the total number of elements buffered across all producers.
+   *   New producers are cancelled at registration when the buffered element count meets or exceeds this value.
+   *   Transient overshoot up to the per-producer buffer of concurrently admitted producers is possible.
+   *   Use 0 for unlimited (default behavior).
+   */
+  def source[T](perProducerBufferSize: Int, maxTotalBufferSize: Int): Source[T, Sink[T, NotUsed]] =
+    Source.fromGraph(new MergeHub[T](perProducerBufferSize, false, maxTotalBufferSize)).mapMaterializedValue(_._1)
+
+  /**
+   * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
+   * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
+   * arbitrary many times and each of the materializations will feed the elements into the original [[Source]].
+   *
+   * Every new materialization of the [[Source]] results in a new, independent hub, which materializes to its own
+   * [[Sink]] for feeding that materialization.
+   *
+   * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
+   * and any new producers using the [[Sink]] will be cancelled.
+   *
    * The materialized [[DrainingControl]] can be used to drain the Hub: any new producers using the [[Sink]] will be cancelled
    * and the Hub will be closed completing the [[Source]] as soon as all currently connected producers complete.
    *
@@ -96,6 +115,31 @@ object MergeHub {
    */
   def sourceWithDraining[T](perProducerBufferSize: Int): Source[T, (Sink[T, NotUsed], DrainingControl)] =
     Source.fromGraph(new MergeHub[T](perProducerBufferSize, true))
+
+  /**
+   * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
+   * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
+   * arbitrary many times and each of the materializations will feed the elements into the original [[Source]].
+   *
+   * Every new materialization of the [[Source]] results in a new, independent hub, which materializes to its own
+   * [[Sink]] for feeding that materialization.
+   *
+   * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
+   * and any new producers using the [[Sink]] will be cancelled.
+   *
+   * The materialized [[DrainingControl]] can be used to drain the Hub: any new producers using the [[Sink]] will be cancelled
+   * and the Hub will be closed completing the [[Source]] as soon as all currently connected producers complete.
+   *
+   * @param perProducerBufferSize Buffer space used per producer. Default value is 16.
+   * @param maxTotalBufferSize Admission threshold for the total number of elements buffered across all producers.
+   *   New producers are cancelled at registration when the buffered element count meets or exceeds this value.
+   *   Transient overshoot up to the per-producer buffer of concurrently admitted producers is possible.
+   *   Use 0 for unlimited (default behavior).
+   */
+  def sourceWithDraining[T](
+      perProducerBufferSize: Int,
+      maxTotalBufferSize: Int): Source[T, (Sink[T, NotUsed], DrainingControl)] =
+    Source.fromGraph(new MergeHub[T](perProducerBufferSize, true, maxTotalBufferSize))
 
   /**
    * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
@@ -140,9 +184,13 @@ private[pekko] final class MergeHubDrainingControlImpl(drainAction: () => Unit) 
   }
 }
 
-private[pekko] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Boolean = false)
+private[pekko] class MergeHub[T](
+    perProducerBufferSize: Int,
+    drainingEnabled: Boolean = false,
+    maxTotalBufferSize: Int = 0)
     extends GraphStageWithMaterializedValue[SourceShape[T], (Sink[T, NotUsed], MergeHub.DrainingControl)] {
   require(perProducerBufferSize > 0, "Buffer size must be positive")
+  require(maxTotalBufferSize >= 0, "Max total buffer size must be non-negative (0 means unlimited)")
 
   val out: Outlet[T] = Outlet("MergeHub.out")
   override val shape: SourceShape[T] = SourceShape(out)
@@ -182,6 +230,7 @@ private[pekko] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Bo
      * processing of control messages. This causes no issues though, see the explanation in 'tryProcessNext'.
      */
     private val queue = new AbstractNodeQueue[Event] {}
+    private val totalBufferedElements = new AtomicInteger(0)
     @volatile private var needWakeup = false
     @volatile private var shuttingDown = false
     @volatile private var draining = false
@@ -224,6 +273,7 @@ private[pekko] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Bo
         needWakeup = false
         nextElem match {
           case Element(id, elem) =>
+            totalBufferedElements.decrementAndGet()
             demands(id).onElement()
             push(out, elem)
           // demand consumed by push — exit and wait for the next onPull
@@ -248,9 +298,14 @@ private[pekko] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Bo
 
     def isShuttingDown: Boolean = shuttingDown
     def isDraining: Boolean = drainingEnabled && draining
+    def isBufferFull: Boolean = maxTotalBufferSize > 0 && totalBufferedElements.get() >= maxTotalBufferSize
 
     // External API
     private[MergeHub] def enqueue(ev: Event): Unit = {
+      ev match {
+        case _: Element => totalBufferedElements.incrementAndGet()
+        case _          =>
+      }
       queue.add(ev)
       /*
        * Simple volatile var is enough, there is no need for a CAS here. The first important thing to note
@@ -325,7 +380,7 @@ private[pekko] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Bo
           private val id = idCounter.getAndIncrement()
 
           override def preStart(): Unit = {
-            if (!logic.isDraining && !logic.isShuttingDown) {
+            if (!logic.isDraining && !logic.isShuttingDown && !logic.isBufferFull) {
               logic.enqueue(Register(id, getAsyncCallback(onDemand)))
 
               // At this point, we could be in the unfortunate situation that:

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Hub.scala
@@ -88,11 +88,12 @@ object MergeHub {
    * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
    * and any new producers using the [[Sink]] will be cancelled.
    *
-   * @param perProducerBufferSize Buffer space used per producer. Default value is 16.
+   * @param perProducerBufferSize Buffer space used per producer.
    * @param maxTotalBufferSize Admission threshold for the total number of elements buffered across all producers.
    *   New producers are cancelled at registration when the buffered element count meets or exceeds this value.
-   *   Transient overshoot up to the per-producer buffer of concurrently admitted producers is possible.
+   *   Already admitted producers are unaffected and may continue to push up to their per-producer buffer.
    *   Use 0 for unlimited (default behavior).
+   * @since 2.0.0
    */
   def source[T](perProducerBufferSize: Int, maxTotalBufferSize: Int): Source[T, Sink[T, NotUsed]] =
     Source.fromGraph(new MergeHub[T](perProducerBufferSize, false, maxTotalBufferSize)).mapMaterializedValue(_._1)
@@ -130,11 +131,12 @@ object MergeHub {
    * The materialized [[DrainingControl]] can be used to drain the Hub: any new producers using the [[Sink]] will be cancelled
    * and the Hub will be closed completing the [[Source]] as soon as all currently connected producers complete.
    *
-   * @param perProducerBufferSize Buffer space used per producer. Default value is 16.
+   * @param perProducerBufferSize Buffer space used per producer.
    * @param maxTotalBufferSize Admission threshold for the total number of elements buffered across all producers.
    *   New producers are cancelled at registration when the buffered element count meets or exceeds this value.
-   *   Transient overshoot up to the per-producer buffer of concurrently admitted producers is possible.
+   *   Already admitted producers are unaffected and may continue to push up to their per-producer buffer.
    *   Use 0 for unlimited (default behavior).
+   * @since 2.0.0
    */
   def sourceWithDraining[T](
       perProducerBufferSize: Int,
@@ -380,6 +382,7 @@ private[pekko] class MergeHub[T](
           private val id = idCounter.getAndIncrement()
 
           override def preStart(): Unit = {
+            // Best-effort admission check: already admitted producers may overshoot the bound.
             if (!logic.isDraining && !logic.isShuttingDown && !logic.isBufferFull) {
               logic.enqueue(Register(id, getAsyncCallback(onDemand)))
 


### PR DESCRIPTION
### Motivation

`MergeHub.source` uses an unbounded `AbstractNodeQueue` as its central queue. While per-producer backpressure via `perProducerBufferSize` limits each individual producer's contribution, there is no aggregate bound across all producers. In dynamic scenarios where producers continuously materialize while downstream is stalled, the queue grows without limit, leading to OOM.

Fixes #3248

### Modification

- Add `maxTotalBufferSize` parameter to `MergeHub` (scaladsl + javadsl)
- Track buffered element count with `AtomicInteger` (incremented on enqueue, decremented on consume)
- New producers are cancelled at registration when the count meets or exceeds the threshold
- Default `0` preserves existing unlimited behavior (fully backward compatible)

New API methods:
- `MergeHub.source[T](perProducerBufferSize, maxTotalBufferSize)` (scaladsl)
- `MergeHub.sourceWithDraining[T](perProducerBufferSize, maxTotalBufferSize)` (scaladsl)
- `MergeHub.of[T](clazz, perProducerBufferSize, maxTotalBufferSize)` (javadsl)
- `MergeHub.withDraining[T](clazz, perProducerBufferSize, maxTotalBufferSize)` (javadsl)

### Result

Users can bound aggregate MergeHub queue growth via admission control, preventing OOM in dynamic producer churn scenarios. The bound is a soft admission threshold — transient overshoot up to the per-producer buffer of concurrently admitted producers is possible.

### Tests

- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.HubSpec -- -z MergeHub"` — 17 tests passed (including 2 new directional tests)
- `sbt "stream / mimaReportBinaryIssues"` — passed (purely additive API)
- `scalafmt --mode diff-ref=origin/main` — applied
- `sbt headerCreateAll` — applied

### References

Fixes #3248