### PR TITLE
introduce keystore-password config

### DIFF
--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -1265,6 +1265,10 @@ pekko {
           # This is a convention that people may follow if they wish to save themselves some configuration
           secret-mount-point = /var/run/secrets/pekko-tls/rotating-keys-engine
 
+          # Password for the in-memory keystore used to wrap PEM-loaded keys.
+          # Override this in production to avoid using the well-known default.
+          keystore-password = "changeit"
+
           # The absolute path the PEM file with the private key.
           key-file = ${pekko.remote.artery.ssl.rotating-keys-engine.secret-mount-point}/tls.key
           # The absolute path to the PEM file of the certificate for the private key above.

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ConfigSSLEngineProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ConfigSSLEngineProvider.scala
@@ -66,6 +66,16 @@ class ConfigSSLEngineProvider(protected val config: Config, protected val log: M
   val SSLRequireMutualAuthentication: Boolean = sslEngineConfig.SSLRequireMutualAuthentication
   val HostnameVerification: Boolean = sslEngineConfig.HostnameVerification
 
+  private val defaultPassword = "changeme"
+  // log default password warning once
+  if (SSLKeyStorePassword == defaultPassword || SSLKeyPassword == defaultPassword ||
+    SSLTrustStorePassword == defaultPassword)
+    log.warning(
+      LogMarker.Security,
+      "TLS/SSL is configured with default passwords. " +
+      "Set pekko.remote.artery.ssl.config-ssl-engine.key-store-password, " +
+      "key-password, and trust-store-password to secure values for production.")
+
   private val sslContext: SSLContext = {
     // log hostname verification warning once
     if (HostnameVerification)

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/PemManagersProvider.scala
@@ -39,17 +39,19 @@ private[ssl] object PemManagersProvider {
   private[ssl] def buildKeyManagers(
       privateKey: PrivateKey,
       cert: X509Certificate,
-      cacert: Certificate): Array[KeyManager] = {
+      cacert: Certificate,
+      keystorePassword: String = "changeit"): Array[KeyManager] = {
     val keyStore = KeyStore.getInstance("JKS")
     keyStore.load(null)
 
+    val passwordChars = keystorePassword.toCharArray
     keyStore.setCertificateEntry("cert", cert)
     keyStore.setCertificateEntry("cacert", cacert)
-    keyStore.setKeyEntry("private-key", privateKey, "changeit".toCharArray, Array(cert, cacert))
+    keyStore.setKeyEntry("private-key", privateKey, passwordChars, Array(cert, cacert))
 
     val kmf =
       KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
-    kmf.init(keyStore, "changeit".toCharArray)
+    kmf.init(keyStore, passwordChars)
     val keyManagers = kmf.getKeyManagers
     keyManagers
   }

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/RotatingKeysSSLEngineProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/RotatingKeysSSLEngineProvider.scala
@@ -32,6 +32,7 @@ import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.annotation.ApiMayChange
 import pekko.annotation.InternalApi
+import pekko.event.LogMarker
 import pekko.event.Logging
 import pekko.event.MarkerLoggingAdapter
 import pekko.remote.artery.tcp.SSLEngineProvider
@@ -69,9 +70,17 @@ final class RotatingKeysSSLEngineProvider(val config: Config, protected val log:
   private val SSLKeyFile: String = config.getString("key-file")
   private val SSLCertFile: String = config.getString("cert-file")
   private val SSLCACertFile: String = config.getString("ca-cert-file")
+  private val SSLKeystorePassword: String = config.getString("keystore-password")
 
   private val sslEngineConfig = new SSLEngineConfig(config)
   import sslEngineConfig._
+
+  // log default password warning once
+  if (SSLKeystorePassword == "changeit")
+    log.warning(
+      LogMarker.Security,
+      "TLS/SSL rotating-keys-engine is configured with the default keystore password. " +
+      "Set pekko.remote.artery.ssl.rotating-keys-engine.keystore-password to a secure value for production.")
 
   // build a PRNG (created once, reused on every instance of SSLContext
   private val rng: SecureRandom = SecureRandomFactory.createSecureRandom(SSLRandomNumberGenerator, log)
@@ -105,7 +114,8 @@ final class RotatingKeysSSLEngineProvider(val config: Config, protected val log:
   private def constructContext(): ConfiguredContext = {
     val (privateKey, cert, cacert) = readFiles()
     try {
-      val keyManagers: Array[KeyManager] = PemManagersProvider.buildKeyManagers(privateKey, cert, cacert)
+      val keyManagers: Array[KeyManager] =
+        PemManagersProvider.buildKeyManagers(privateKey, cert, cacert, SSLKeystorePassword)
       val trustManagers: Array[TrustManager] = PemManagersProvider.buildTrustManagers(cacert)
 
       val sessionVerifier = new PeerSubjectVerifier(cert)

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/netty/SSLEngineProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/netty/SSLEngineProvider.scala
@@ -71,6 +71,16 @@ class ConfigSSLEngineProvider(protected val log: MarkerLoggingAdapter, private v
 
   import settings._
 
+  private val defaultPassword = "changeme"
+  // log default password warning once
+  if (settings.SSLKeyStorePassword == defaultPassword || settings.SSLKeyPassword == defaultPassword ||
+    settings.SSLTrustStorePassword == defaultPassword)
+    log.warning(
+      LogMarker.Security,
+      "TLS/SSL is configured with default passwords. " +
+      "Set pekko.remote.classic.netty.ssl.security.key-store-password, " +
+      "key-password, and trust-store-password to secure values for production.")
+
   if (SSLHostnameVerification)
     log.debug("TLS/SSL hostname verification is enabled.")
   else


### PR DESCRIPTION
* the affected keystore is in memory so this is just a minor hardening
* adds logging if users don't override the passwords for keystores (including other ones)