### PR TITLE
warn if pekko-remote is not using tls

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/RemoteActorRefProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemoteActorRefProvider.scala
@@ -34,7 +34,7 @@ import pekko.event.EventStream
 import pekko.event.Logging
 import pekko.event.Logging.Error
 import pekko.event.LogMarker
-import pekko.event.LoggingAdapter
+import pekko.event.MarkerLoggingAdapter
 import pekko.pattern.pipe
 import pekko.remote.artery.ArterySettings
 import pekko.remote.artery.ArterySettings.AeronUpd
@@ -195,7 +195,7 @@ private[pekko] class RemoteActorRefProvider(
 
   @volatile
   private var _log = local.log
-  def log: LoggingAdapter = _log
+  def log: MarkerLoggingAdapter = _log
 
   override def rootPath: ActorPath = local.rootPath
   override def deadLetters: InternalActorRef = local.deadLetters

--- a/remote/src/main/scala/org/apache/pekko/remote/RemoteActorRefProvider.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemoteActorRefProvider.scala
@@ -33,6 +33,7 @@ import pekko.dispatch.sysmsg._
 import pekko.event.EventStream
 import pekko.event.Logging
 import pekko.event.Logging.Error
+import pekko.event.LogMarker
 import pekko.event.LoggingAdapter
 import pekko.pattern.pipe
 import pekko.remote.artery.ArterySettings
@@ -267,6 +268,7 @@ private[pekko] class RemoteActorRefProvider(
 
     warnIfDirectUse()
     warnIfUseUnsafeWithoutCluster()
+    warnIfNoTls()
 
     // this enables reception of remote requests
     transport.start()
@@ -350,6 +352,43 @@ private[pekko] class RemoteActorRefProvider(
         log.warning(
           "Pekko Cluster not in use - Using Pekko Cluster is recommended if you need remote watch and deploy.")
     }
+
+  // Log on `init` to warn about non-TLS remote transports.
+  private def warnIfNoTls(): Unit = {
+    if (remoteSettings.Artery.Enabled) {
+      remoteSettings.Artery.Transport match {
+        case ArterySettings.Tcp =>
+          log.warning(
+            LogMarker.Security,
+            "Artery remote is configured without TLS (transport = tcp), " +
+            "messages are not encrypted in transit. " +
+            "Use 'tls-tcp' transport to enable TLS. " +
+            "See https://pekko.apache.org/docs/pekko/current/remoting-artery.html#configuring-ssl-tls-for-artery")
+        case AeronUpd =>
+          log.warning(
+            LogMarker.Security,
+            "Artery remote is configured without TLS (transport = aeron-udp), " +
+            "messages are not encrypted in transit. " +
+            "Use 'tls-tcp' transport if encryption is required. " +
+            "See https://pekko.apache.org/docs/pekko/current/remoting-artery.html#configuring-ssl-tls-for-artery")
+        case _ => // TlsTcp, no warning needed
+      }
+    } else {
+      remoteSettings.Transports.foreach {
+        case (transportClass, _, transportConfig) =>
+          val enableSsl = transportConfig.hasPath("enable-ssl") && transportConfig.getBoolean("enable-ssl")
+          if (!enableSsl) {
+            log.warning(
+              LogMarker.Security,
+              "Classic Netty remote is configured without TLS (enable-ssl = false for transport [{}]), " +
+              "messages are not encrypted in transit. " +
+              "Enable SSL or use Artery with 'tls-tcp' transport. " +
+              "See https://pekko.apache.org/docs/pekko/current/remoting.html",
+              transportClass)
+          }
+      }
+    }
+  }
 
   protected def warnOnUnsafe(message: String): Unit =
     if (warnOnUnsafeRemote) log.warning(message)

--- a/remote/src/test/scala/org/apache/pekko/remote/NonTlsWarningSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/NonTlsWarningSpec.scala
@@ -17,10 +17,12 @@
 
 package org.apache.pekko.remote
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.actor.ActorSystem
+import pekko.remote.artery.ArterySettings
 import pekko.testkit.PekkoSpec
 
 import org.scalatest.BeforeAndAfterAll
@@ -41,8 +43,7 @@ class NonTlsWarningSpec extends AnyWordSpecLike with Matchers with BeforeAndAfte
 
   override def afterAll(): Unit = {
     systems.foreach { sys =>
-      sys.terminate()
-      sys.whenTerminated.await(10.seconds)
+      Await.result(sys.terminate(), 10.seconds)
     }
     super.afterAll()
   }
@@ -58,7 +59,7 @@ class NonTlsWarningSpec extends AnyWordSpecLike with Matchers with BeforeAndAfte
         .withFallback(ConfigFactory.load())
 
       val system = createSystem("artery-tcp-test", config)
-      val settings = RemoteSettings(system.settings.config)
+      val settings = new RemoteSettings(system.settings.config)
       settings.Artery.Enabled should be(true)
       settings.Artery.Transport should be(ArterySettings.Tcp)
     }
@@ -72,7 +73,7 @@ class NonTlsWarningSpec extends AnyWordSpecLike with Matchers with BeforeAndAfte
         .withFallback(ConfigFactory.load())
 
       val system = createSystem("artery-aeron-test", config)
-      val settings = RemoteSettings(system.settings.config)
+      val settings = new RemoteSettings(system.settings.config)
       settings.Artery.Enabled should be(true)
       settings.Artery.Transport should be(ArterySettings.AeronUpd)
     }
@@ -86,7 +87,7 @@ class NonTlsWarningSpec extends AnyWordSpecLike with Matchers with BeforeAndAfte
         .withFallback(ConfigFactory.load())
 
       val system = createSystem("classic-netty-test", config)
-      val settings = RemoteSettings(system.settings.config)
+      val settings = new RemoteSettings(system.settings.config)
       settings.Artery.Enabled should be(false)
       settings.Transports should not be empty
       // Default classic transport (pekko.remote.classic.netty.tcp) has no enable-ssl key
@@ -106,7 +107,7 @@ class NonTlsWarningSpec extends AnyWordSpecLike with Matchers with BeforeAndAfte
         .withFallback(ConfigFactory.load())
 
       val system = createSystem("artery-tls-tcp-test", config)
-      val settings = RemoteSettings(system.settings.config)
+      val settings = new RemoteSettings(system.settings.config)
       settings.Artery.Enabled should be(true)
       settings.Artery.Transport should be(ArterySettings.TlsTcp)
     }
@@ -121,7 +122,7 @@ class NonTlsWarningSpec extends AnyWordSpecLike with Matchers with BeforeAndAfte
         .withFallback(ConfigFactory.load())
 
       val system = createSystem("classic-netty-ssl-test", config)
-      val settings = RemoteSettings(system.settings.config)
+      val settings = new RemoteSettings(system.settings.config)
       settings.Artery.Enabled should be(false)
       settings.Transports should not be empty
       settings.Transports.exists {

--- a/remote/src/test/scala/org/apache/pekko/remote/NonTlsWarningSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/NonTlsWarningSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.remote
+
+import scala.concurrent.duration._
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.testkit.PekkoSpec
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.typesafe.config.ConfigFactory
+
+class NonTlsWarningSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll {
+
+  private var systems: List[ActorSystem] = Nil
+
+  private def createSystem(name: String, config: com.typesafe.config.Config): ActorSystem = {
+    val sys = ActorSystem(name, config)
+    systems = systems :+ sys
+    sys
+  }
+
+  override def afterAll(): Unit = {
+    systems.foreach { sys =>
+      sys.terminate()
+      sys.whenTerminated.await(10.seconds)
+    }
+    super.afterAll()
+  }
+
+  "RemoteActorRefProvider" must {
+
+    "detect Artery TCP transport as non-TLS" in {
+      val config = ConfigFactory
+        .parseString("""
+          pekko.remote.artery.transport = tcp
+        """)
+        .withFallback(PekkoSpec.testConf)
+        .withFallback(ConfigFactory.load())
+
+      val system = createSystem("artery-tcp-test", config)
+      val settings = RemoteSettings(system.settings.config)
+      settings.Artery.Enabled should be(true)
+      settings.Artery.Transport should be(ArterySettings.Tcp)
+    }
+
+    "detect Artery Aeron UDP transport as non-TLS" in {
+      val config = ConfigFactory
+        .parseString("""
+          pekko.remote.artery.transport = aeron-udp
+        """)
+        .withFallback(PekkoSpec.testConf)
+        .withFallback(ConfigFactory.load())
+
+      val system = createSystem("artery-aeron-test", config)
+      val settings = RemoteSettings(system.settings.config)
+      settings.Artery.Enabled should be(true)
+      settings.Artery.Transport should be(ArterySettings.AeronUpd)
+    }
+
+    "detect Classic Netty transport as non-TLS by default" in {
+      val config = ConfigFactory
+        .parseString("""
+          pekko.remote.artery.enabled = off
+        """)
+        .withFallback(PekkoSpec.testConf)
+        .withFallback(ConfigFactory.load())
+
+      val system = createSystem("classic-netty-test", config)
+      val settings = RemoteSettings(system.settings.config)
+      settings.Artery.Enabled should be(false)
+      settings.Transports should not be empty
+      // Default classic transport (pekko.remote.classic.netty.tcp) has no enable-ssl key
+      settings.Transports.foreach {
+        case (_, _, transportConfig) =>
+          val hasSsl = transportConfig.hasPath("enable-ssl") && transportConfig.getBoolean("enable-ssl")
+          hasSsl should be(false)
+      }
+    }
+
+    "not warn for Artery TLS-TCP transport" in {
+      val config = ConfigFactory
+        .parseString("""
+          pekko.remote.artery.transport = tls-tcp
+        """)
+        .withFallback(PekkoSpec.testConf)
+        .withFallback(ConfigFactory.load())
+
+      val system = createSystem("artery-tls-tcp-test", config)
+      val settings = RemoteSettings(system.settings.config)
+      settings.Artery.Enabled should be(true)
+      settings.Artery.Transport should be(ArterySettings.TlsTcp)
+    }
+
+    "detect Classic Netty SSL transport as TLS-enabled" in {
+      val config = ConfigFactory
+        .parseString("""
+          pekko.remote.artery.enabled = off
+          pekko.remote.classic.enabled-transports = ["pekko.remote.classic.netty.ssl"]
+        """)
+        .withFallback(PekkoSpec.testConf)
+        .withFallback(ConfigFactory.load())
+
+      val system = createSystem("classic-netty-ssl-test", config)
+      val settings = RemoteSettings(system.settings.config)
+      settings.Artery.Enabled should be(false)
+      settings.Transports should not be empty
+      settings.Transports.exists {
+        case (_, _, transportConfig) =>
+          transportConfig.hasPath("enable-ssl") && transportConfig.getBoolean("enable-ssl")
+      } should be(true)
+    }
+
+  }
+
+}


### PR DESCRIPTION
pekko 2.0.0 should maybe become a bit more pushy about people using TLS - still optional though