### PR TITLE
fix(stream): undeprecate getFirst/getFirstAttribute methods

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
@@ -304,28 +304,28 @@ final class Attributes private[pekko] (
   }
 
   /**
-    *  INTERNAL API
-    * 
-    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
-    * If no such attribute exists the `default` value is returned.
-    */
+   *  INTERNAL API
+   *
+   * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
+   * If no such attribute exists the `default` value is returned.
+   */
   @InternalStableApi
   def getFirstAttribute[T <: Attribute](c: Class[T], default: T): T =
     getFirstAttribute(c).orElse(default)
 
   /**
-    *  INTERNAL API
-    * 
-    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
-    */
+   *  INTERNAL API
+   *
+   * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
+   */
   @InternalStableApi
   def getFirstAttribute[T <: Attribute](c: Class[T]): Optional[T] =
     attributeList.reverseIterator.collectFirst { case attr if c.isInstance(attr) => c.cast(attr) }.toJava
 
   /**
-    *  INTERNAL API
-    * 
-    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
+   *  INTERNAL API
+   *
+   * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
    * If no such attribute exists the `default` value is returned.
    */
   @InternalStableApi
@@ -337,10 +337,10 @@ final class Attributes private[pekko] (
   }
 
   /**
-    * INTERNAL API
-    * 
-    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
-    */
+   * INTERNAL API
+   *
+   * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
+   */
   @InternalStableApi
   def getFirst[T <: Attribute: ClassTag]: Option[T] = {
     val c = classTag[T].runtimeClass.asInstanceOf[Class[T]]

--- a/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
@@ -31,7 +31,7 @@ import pekko.actor.ActorSystem
 import pekko.annotation.ApiMayChange
 import pekko.annotation.DoNotInherit
 import pekko.annotation.InternalApi
-import pekko.anotation.InternalStableApi
+import pekko.annotation.InternalStableApi
 import pekko.event.Logging
 import pekko.japi.function
 import pekko.stream.impl.TraversalBuilder

--- a/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
@@ -306,14 +306,14 @@ final class Attributes private[pekko] (
    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
    * If no such attribute exists the `default` value is returned.
    */
-  @deprecated("Attributes should always be most specific, use getAttribute[T]", "Akka 2.5.7")
+  // Maintained active: required to retrieve the least specific attribute without breaking precedence. See apache/pekko-http#345
   def getFirstAttribute[T <: Attribute](c: Class[T], default: T): T =
     getFirstAttribute(c).orElse(default)
 
   /**
    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
    */
-  @deprecated("Attributes should always be most specific, use get[T]", "Akka 2.5.7")
+  // Maintained active: required to retrieve the least specific attribute without breaking precedence. See apache/pekko-http#345
   def getFirstAttribute[T <: Attribute](c: Class[T]): Optional[T] =
     attributeList.reverseIterator.collectFirst { case attr if c.isInstance(attr) => c.cast(attr) }.toJava
 
@@ -321,7 +321,7 @@ final class Attributes private[pekko] (
    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
    * If no such attribute exists the `default` value is returned.
    */
-  @deprecated("Attributes should always be most specific, use get[T]", "Akka 2.5.7")
+  // Maintained active: required to retrieve the least specific attribute without breaking precedence. See apache/pekko-http#345
   def getFirst[T <: Attribute: ClassTag](default: T): T = {
     getFirst[T] match {
       case Some(a) => a
@@ -331,8 +331,8 @@ final class Attributes private[pekko] (
 
   /**
    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
-   */
-  @deprecated("Attributes should always be most specific, use get[T]", "Akka 2.5.7")
+    */
+  // Maintained active: required to retrieve the least specific attribute without breaking precedence. See apache/pekko-http#345
   def getFirst[T <: Attribute: ClassTag]: Option[T] = {
     val c = classTag[T].runtimeClass.asInstanceOf[Class[T]]
     attributeList.reverseIterator.collectFirst { case attr if c.isInstance(attr) => c.cast(attr) }

--- a/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Attributes.scala
@@ -31,6 +31,7 @@ import pekko.actor.ActorSystem
 import pekko.annotation.ApiMayChange
 import pekko.annotation.DoNotInherit
 import pekko.annotation.InternalApi
+import pekko.anotation.InternalStableApi
 import pekko.event.Logging
 import pekko.japi.function
 import pekko.stream.impl.TraversalBuilder
@@ -303,25 +304,31 @@ final class Attributes private[pekko] (
   }
 
   /**
-   * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
-   * If no such attribute exists the `default` value is returned.
-   */
-  // Maintained active: required to retrieve the least specific attribute without breaking precedence. See apache/pekko-http#345
+    *  INTERNAL API
+    * 
+    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
+    * If no such attribute exists the `default` value is returned.
+    */
+  @InternalStableApi
   def getFirstAttribute[T <: Attribute](c: Class[T], default: T): T =
     getFirstAttribute(c).orElse(default)
 
   /**
-   * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
-   */
-  // Maintained active: required to retrieve the least specific attribute without breaking precedence. See apache/pekko-http#345
+    *  INTERNAL API
+    * 
+    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
+    */
+  @InternalStableApi
   def getFirstAttribute[T <: Attribute](c: Class[T]): Optional[T] =
     attributeList.reverseIterator.collectFirst { case attr if c.isInstance(attr) => c.cast(attr) }.toJava
 
   /**
-   * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
+    *  INTERNAL API
+    * 
+    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
    * If no such attribute exists the `default` value is returned.
    */
-  // Maintained active: required to retrieve the least specific attribute without breaking precedence. See apache/pekko-http#345
+  @InternalStableApi
   def getFirst[T <: Attribute: ClassTag](default: T): T = {
     getFirst[T] match {
       case Some(a) => a
@@ -330,9 +337,11 @@ final class Attributes private[pekko] (
   }
 
   /**
-   * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
+    * INTERNAL API
+    * 
+    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
     */
-  // Maintained active: required to retrieve the least specific attribute without breaking precedence. See apache/pekko-http#345
+  @InternalStableApi
   def getFirst[T <: Attribute: ClassTag]: Option[T] = {
     val c = classTag[T].runtimeClass.asInstanceOf[Class[T]]
     attributeList.reverseIterator.collectFirst { case attr if c.isInstance(attr) => c.cast(attr) }


### PR DESCRIPTION
This PR removes the @deprecated annotation from getFirst and getFirstAttribute in the Attributes class.

As discussed in apache/pekko-http#345, migrating away from getFirst to get reverses the attribute precedence logic (since getFirst uses reverseIterator to find the least specific attribute, while get finds the most specific one). ¡¡Keeping these methods active and undeprecated is necessary to maintain correct precedence in the HTTP layer!!.

Related Issue:
Resolves apache/pekko-http#345