### PR TITLE
Remove Test Reports step from workflow

### DIFF
--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -62,12 +62,3 @@ jobs:
             -Dmultinode.Xmx256M \
             -Dmultinode.XX:+AlwaysActAsServerClassMachine \
             clean test
-
-      - name: Test Reports
-        # Makes it easier to spot failures instead of looking at the logs.
-        if: ${{ failure() }}
-        uses: scacap/action-surefire-report@c38a2d74b9840ae8950a4387ae02b637421d0f39 # v1.13.0
-        with:
-          report_paths: '**/target/test-reports/TEST-*.xml'
-          fail_if_no_tests: false
-          skip_publishing: true


### PR DESCRIPTION
Removed Test Reports step from timing-tests workflow.

Our timing tests plan is failing every night. https://github.com/apache/pekko/actions/workflows/timing-tests.yml

This action is now not allowed due to https://github.com/apache/infrastructure-actions/pull/828

Can't find any of the replacements in this allowed list:
https://github.com/apache/infrastructure-actions/blob/main/actions.yml

I don't think this action adds much anyway. When the tests fail, I just look at the logs to find the stacktraces and test reports.