### PR TITLE
upgrade scala, typesafe-config, netty and jackson

### DIFF
--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/AskPattern.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/AskPattern.scala
@@ -118,8 +118,8 @@ object AskPattern {
       // We do not currently use the implicit scheduler, but want to require it
       // because it might be needed when we move to a 'native' typed runtime, see #24219
       ref match {
-        case a: InternalRecipientRef[Req] => askClassic[Req, Res](a, timeout, replyTo)
-        case a                            =>
+        case a: (InternalRecipientRef[Req] @unchecked) => askClassic[Req, Res](a, timeout, replyTo)
+        case a                                         =>
           throw new IllegalStateException(
             "Only expect references to be RecipientRef, ActorRefAdapter or ActorSystemAdapter until " +
             "native system is implemented: " + a.getClass)

--- a/actor/src/main/boilerplate/org/apache/pekko/japi/function/Functions.scala.template
+++ b/actor/src/main/boilerplate/org/apache/pekko/japi/function/Functions.scala.template
@@ -19,7 +19,7 @@ import scala.annotation.nowarn
  * A Function interface. Used to create 1-arg first-class-functions is Java.
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(##1L)
 @FunctionalInterface
 trait Function1[[#-T1#], +R] extends java.io.Serializable {
@@ -34,7 +34,7 @@ trait Function1[[#-T1#], +R] extends java.io.Serializable {
  * A Procedure is like a Function, but it doesn't produce a return value.
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(##1L)
 @FunctionalInterface
 trait Procedure1[[#-T1#]] extends java.io.Serializable {

--- a/actor/src/main/java/org/apache/pekko/util/Unsafe.java
+++ b/actor/src/main/java/org/apache/pekko/util/Unsafe.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /** INTERNAL API */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "sunapi"})
 @InternalApi
 public final class Unsafe {
   public static final sun.misc.Unsafe instance;

--- a/actor/src/main/java/org/apache/pekko/util/Unsafe.java
+++ b/actor/src/main/java/org/apache/pekko/util/Unsafe.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /** INTERNAL API */
+@SuppressWarnings("deprecation")
 @InternalApi
 public final class Unsafe {
   public static final sun.misc.Unsafe instance;

--- a/actor/src/main/scala-3/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala-3/org/apache/pekko/util/ByteString.scala
@@ -1356,7 +1356,7 @@ final class ByteStringBuilder extends Builder[Byte, ByteString] {
       case bs: ByteString          => addAll(bs)
       case xs: WrappedArray.ofByte =>
         if (xs.nonEmpty) putByteArrayUnsafe(xs.array.clone)
-      case seq: collection.IndexedSeq[Byte] if shouldResizeTempFor(seq.length) =>
+      case seq: (collection.IndexedSeq[Byte] @unchecked) if shouldResizeTempFor(seq.length) =>
         if (seq.nonEmpty) {
           val copied = Array.from(xs)
 
@@ -1364,7 +1364,7 @@ final class ByteStringBuilder extends Builder[Byte, ByteString] {
           _builder += ByteString.ByteString1(copied)
           _length += seq.length
         }
-      case seq: collection.IndexedSeq[Byte] =>
+      case seq: (collection.IndexedSeq[Byte] @unchecked) =>
         if (seq.nonEmpty) {
           ensureTempSize(_tempLength + seq.size)
           seq.copyToArray(_temp, _tempLength)

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorPath.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorPath.scala
@@ -167,7 +167,7 @@ object ActorPath {
  * references are compared the unique id of the actor is not taken into account
  * when comparing actor paths.
  */
-@nowarn("msg=@SerialVersionUID has no effect on traits")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing) on traits")
 @SerialVersionUID(1L)
 sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
 

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorSelection.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorSelection.scala
@@ -338,7 +338,7 @@ private[pekko] final case class ActorSelectionMessage(
 /**
  * INTERNAL API
  */
-@nowarn("msg=@SerialVersionUID has no effect on traits")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing) on traits")
 @SerialVersionUID(1L)
 private[pekko] sealed trait SelectionPathElement
 

--- a/actor/src/main/scala/org/apache/pekko/actor/Deployer.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Deployer.scala
@@ -182,7 +182,7 @@ trait Scope {
   def withFallback(other: Scope): Scope
 }
 
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 abstract class LocalScope extends Scope
 
@@ -191,7 +191,7 @@ abstract class LocalScope extends Scope
  * which do not set a different scope. It is also the only scope handled by
  * the LocalActorRefProvider.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 case object LocalScope extends LocalScope {
 
@@ -206,7 +206,7 @@ case object LocalScope extends LocalScope {
 /**
  * This is the default value and as such allows overrides.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 abstract class NoScopeGiven extends Scope
 @SerialVersionUID(1L)

--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -104,7 +104,7 @@ object Pair {
  *
  * This class is kept for compatibility, but for future API's please prefer [[pekko.japi.function.Creator]].
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 @deprecated("Will be removed in favor of pekko.japi.function.Creator in Pekko 2.0.0", "1.2.0")

--- a/actor/src/main/scala/org/apache/pekko/japi/function/Function.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/function/Function.scala
@@ -22,7 +22,7 @@ import scala.annotation.nowarn
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Function` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Function[-T, +R] extends java.io.Serializable {
@@ -44,7 +44,7 @@ object Function {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.BiFunction` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Function2[-T1, -T2, +R] extends java.io.Serializable {
@@ -57,7 +57,7 @@ trait Function2[-T1, -T2, +R] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Consumer` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Procedure[-T] extends java.io.Serializable {
@@ -70,7 +70,7 @@ trait Procedure[-T] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Effect` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Effect extends java.io.Serializable {
@@ -84,7 +84,7 @@ trait Effect extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Predicate` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Predicate[-T] extends java.io.Serializable {
@@ -95,7 +95,7 @@ trait Predicate[-T] extends java.io.Serializable {
  * A constructor/factory, takes no parameters but creates a new value of type T every call.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Supplier` counterpart does not.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @FunctionalInterface
 trait Creator[+T] extends Serializable {

--- a/actor/src/main/scala/org/apache/pekko/routing/Balancing.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/Balancing.scala
@@ -38,7 +38,7 @@ private[pekko] object BalancingRoutingLogic {
  * INTERNAL API
  * Selects the first routee, balancing will be done by the dispatcher.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 private[pekko] final class BalancingRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/actor/src/main/scala/org/apache/pekko/routing/Broadcast.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/Broadcast.scala
@@ -31,7 +31,7 @@ object BroadcastRoutingLogic {
 /**
  * Broadcasts a message to all its routees.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 final class BroadcastRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/actor/src/main/scala/org/apache/pekko/routing/Random.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/Random.scala
@@ -33,7 +33,7 @@ object RandomRoutingLogic {
 /**
  * Randomly selects one of the target routees to send a message to
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 final class RandomRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/actor/src/main/scala/org/apache/pekko/routing/RoundRobin.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/RoundRobin.scala
@@ -34,7 +34,7 @@ object RoundRobinRoutingLogic {
  * Uses round-robin to select a routee. For concurrent calls,
  * round robin is just a best effort.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 final class RoundRobinRoutingLogic extends RoutingLogic {
   val next = new AtomicLong

--- a/actor/src/main/scala/org/apache/pekko/routing/RouterConfig.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/RouterConfig.scala
@@ -49,7 +49,7 @@ import pekko.util.unused
  * someone tries sending a message to that reference before the constructor of
  * RoutedActorRef has returned, there will be a `NullPointerException`!
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 trait RouterConfig extends Serializable {
 
@@ -386,7 +386,7 @@ case object NoRouter extends NoRouter {
 /**
  * INTERNAL API
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 private[pekko] trait RouterManagementMesssage
 
@@ -395,7 +395,7 @@ private[pekko] trait RouterManagementMesssage
  * A [[Routees]] message is sent asynchronously to the "requester" containing information
  * about what routees the router is routing over.
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 abstract class GetRoutees extends RouterManagementMesssage
 

--- a/actor/src/main/scala/org/apache/pekko/routing/SmallestMailbox.scala
+++ b/actor/src/main/scala/org/apache/pekko/routing/SmallestMailbox.scala
@@ -43,7 +43,7 @@ object SmallestMailboxRoutingLogic {
  *     since their mailbox size is unknown</li>
  * </ul>
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 class SmallestMailboxRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =
@@ -191,7 +191,7 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
  * @param routerDispatcher dispatcher to use for the router head actor, which handles
  *   supervision, death watch and router management messages
  */
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 final case class SmallestMailboxPool(
     nrOfInstances: Int,

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterActorRefProvider.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterActorRefProvider.scala
@@ -137,7 +137,7 @@ private[pekko] class ClusterDeployer(_settings: ActorSystem.Settings, _pm: Dynam
 
 }
 
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 abstract class ClusterScope extends Scope
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
 
   val junitVersion = "4.13.2"
   val junit5Version = "5.13.4"
-  val slf4jVersion = "2.0.17"
+  val slf4jVersion = "2.0.18"
   // check agrona version when updating this
   val aeronVersion = "1.45.2"
   // needs to be inline with the aeron version, check
@@ -45,7 +45,7 @@ object Dependencies {
 
   val scala212Version = "2.12.21"
   val scala213Version = "2.13.18"
-  val scala3Version = "3.3.7"
+  val scala3Version = "3.3.8"
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val reactiveStreamsVersion = "1.0.4"

--- a/remote/src/main/scala/org/apache/pekko/remote/RemotingLifecycleEvent.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemotingLifecycleEvent.scala
@@ -22,14 +22,14 @@ import pekko.actor.{ ActorSystem, Address }
 import pekko.event.{ Logging, LoggingAdapter }
 import pekko.event.Logging.LogLevel
 
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 sealed trait RemotingLifecycleEvent extends Serializable {
   def logLevel: Logging.LogLevel
 }
 
-@nowarn("msg=@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID (has no effect|does nothing)")
 @SerialVersionUID(1L)
 @deprecated("Classic remoting is deprecated, use Artery", "Akka 2.6.0")
 sealed trait AssociationEvent extends RemotingLifecycleEvent {


### PR DESCRIPTION
* Scala 3.3.8 -- ByteString fix was also needed from #3297
* Config 1.4.9
* Jackson 2.21.5
* Netty 4.2.17

Patch level bumps but include CVE fixes