### PR TITLE
Add LeaseHealthCheck

### DIFF
--- a/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
+++ b/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
@@ -17,15 +17,17 @@
 
 package org.apache.pekko.coordination.lease
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.coordination.lease.scaladsl.{ Lease, LeaseProvider }
-import org.apache.pekko.event.Logging
-import org.apache.pekko.pattern.AskTimeoutException
+import java.util.UUID
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
-import java.util.UUID
 import scala.annotation.nowarn
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.coordination.lease.scaladsl.{ Lease, LeaseProvider }
+import pekko.event.Logging
+import pekko.pattern.AskTimeoutException
 
 /**
  * Performs a lease health check by attempting to acquire and immediately release a test lease.

--- a/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
+++ b/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.coordination.lease
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.coordination.lease.scaladsl.{ Lease, LeaseProvider }
+import org.apache.pekko.event.Logging
+import org.apache.pekko.pattern.AskTimeoutException
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
+import java.util.UUID
+import scala.annotation.nowarn
+
+/**
+ * Performs a lease health check by attempting to acquire and immediately release a test lease.
+ *
+ * Once the first check succeeds, subsequent checks return true without contacting the API.
+ * This is a quick connectivity test to verify the lease API is accessible.
+ *
+ * Returns true if:
+ * - Lease is successfully acquired (true)
+ * - Lease cannot be acquired due to conflict (another owner has it, but the API is reachable) (false)
+ *
+ * Returns false if:
+ * - Any exception occurs (LeaseException, AskTimeoutException, etc.)
+ */
+class LeaseHealthCheck(system: ActorSystem, leaseProviderName: String) extends (() => Future[Boolean]) {
+
+  implicit val executionContext: ExecutionContext = system.dispatcher
+
+  private val log = Logging(system, classOf[LeaseHealthCheck])
+
+  @volatile private var healthCheckPassed = false
+
+  private val leaseName = s"lease-${UUID.randomUUID().toString}"
+  private val ownerName = s"owner-${UUID.randomUUID().toString}"
+
+  protected val lease: Lease = LeaseProvider(system).getLease(leaseName, leaseProviderName, ownerName)
+
+  override def apply(): Future[Boolean] = check()
+
+  @nowarn("msg=match may not be exhaustive")
+  def check(): Future[Boolean] = {
+    if (healthCheckPassed) {
+      Future.successful(true)
+    } else {
+      lease.acquire().transform {
+        case Success(true) =>
+          healthCheckPassed = true
+          log.info(s"lease $leaseName from $ownerName returned true")
+          lease.release()
+          Success(true)
+        case Success(false) =>
+          log.info(s"lease $leaseName from $ownerName returned false")
+          healthCheckPassed = true
+          Success(true)
+        case Failure(e: LeaseException) =>
+          log.warning(s"lease $leaseName from $ownerName returned a LeaseException ${e.getMessage}")
+          Success(false)
+        case Failure(e: AskTimeoutException) =>
+          log.warning(s"lease $leaseName from $ownerName returned an AskTimeoutException ${e.getMessage}")
+          Success(false)
+        case Failure(e: Exception) =>
+          log.warning(s"lease $leaseName from $ownerName returned an Exception ${e.getMessage}")
+          Success(false)
+      }
+    }
+  }
+}

--- a/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
+++ b/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
@@ -41,6 +41,8 @@ import pekko.pattern.AskTimeoutException
  *
  * Returns false if:
  * - Any exception occurs (LeaseException, AskTimeoutException, etc.)
+ *
+ * @since 2.0.0
  */
 class LeaseHealthCheck(system: ActorSystem, leaseProviderName: String) extends (() => Future[Boolean]) {
 

--- a/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
+++ b/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
@@ -44,7 +44,7 @@ import pekko.pattern.AskTimeoutException
  */
 class LeaseHealthCheck(system: ActorSystem, leaseProviderName: String) extends (() => Future[Boolean]) {
 
-  implicit val executionContext: ExecutionContext = system.dispatcher
+  private implicit val executionContext: ExecutionContext = system.dispatcher
 
   private val log = Logging(system, classOf[LeaseHealthCheck])
 

--- a/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
+++ b/coordination/src/main/scala/org/apache/pekko/coordination/lease/LeaseHealthCheck.scala
@@ -50,8 +50,9 @@ class LeaseHealthCheck(system: ActorSystem, leaseProviderName: String) extends (
 
   @volatile private var healthCheckPassed = false
 
-  private val leaseName = s"lease-${UUID.randomUUID().toString}"
-  private val ownerName = s"owner-${UUID.randomUUID().toString}"
+  private val randomUUIDString = UUID.randomUUID().toString
+  private val leaseName = s"lease-$randomUUIDString"
+  private val ownerName = s"owner-$randomUUIDString"
 
   protected val lease: Lease = LeaseProvider(system).getLease(leaseName, leaseProviderName, ownerName)
 

--- a/coordination/src/test/scala/org/apache/pekko/coordination/lease/LeaseHealthCheckSpec.scala
+++ b/coordination/src/test/scala/org/apache/pekko/coordination/lease/LeaseHealthCheckSpec.scala
@@ -17,75 +17,103 @@
 
 package org.apache.pekko.coordination.lease
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import org.apache.pekko
+import pekko.coordination.lease.scaladsl.Lease
+import pekko.pattern.AskTimeoutException
+import pekko.testkit.PekkoSpec
+
 import com.typesafe.config.{ Config, ConfigFactory }
-import org.apache.pekko.coordination.lease.scaladsl.Lease
-import org.apache.pekko.pattern.AskTimeoutException
-import org.apache.pekko.testkit.PekkoSpec
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-
-import scala.concurrent.Future
-import scala.concurrent.duration._
 
 class LeaseHealthCheckSpec
     extends PekkoSpec(LeaseHealthCheckSpec.config)
     with ScalaFutures
     with AnyWordSpecLike
-    with BeforeAndAfterAll
     with Matchers {
+
+  import LeaseHealthCheckSpec._
 
   override implicit val patience: PatienceConfig = PatienceConfig(5.seconds)
 
-  "LeaseHealthCheckSpec" should {
+  private def newTestLease(): MockLease with MockLeaseState =
+    new MockLease(mockLeaseSettings) with MockLeaseState
 
+  private def healthCheckWith(testLease: Lease): LeaseHealthCheck =
+    new LeaseHealthCheck(system, "mock-lease") {
+      override protected val lease: Lease = testLease
+    }
+
+  "LeaseHealthCheckSpec" should {
     "return true and release lease on successful acquisition" in {
-      LeaseHealthCheckSpec.nextAcquire = () => Future.successful(true)
-      LeaseHealthCheckSpec.releaseCalled = false
-      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual true
-      LeaseHealthCheckSpec.releaseCalled shouldEqual true
+      val lease = newTestLease()
+      lease.nextAcquire = () => Future.successful(true)
+
+      healthCheckWith(lease).check().futureValue shouldEqual true
+      lease.releaseCalled shouldEqual true
     }
 
     "not call acquire again after healthCheckPassed is true" in {
-      LeaseHealthCheckSpec.nextAcquire = () => Future.successful(true)
-      LeaseHealthCheckSpec.acquireCalls = 0
-      val healthcheck = new LeaseHealthCheck(system, "mock-lease")
+      val lease = newTestLease()
+      lease.nextAcquire = () => Future.successful(true)
+
+      val healthcheck = healthCheckWith(lease)
       healthcheck.check().futureValue shouldEqual true
-      LeaseHealthCheckSpec.acquireCalls shouldEqual 1
+      lease.acquireCalls shouldEqual 1
 
       healthcheck.check().futureValue shouldEqual true
-      LeaseHealthCheckSpec.acquireCalls shouldEqual 1
+      lease.acquireCalls shouldEqual 1
     }
 
     "return true on lease conflict" in {
-      LeaseHealthCheckSpec.nextAcquire = () => Future.successful(false)
-      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual true
+      val lease = newTestLease()
+      lease.nextAcquire = () => Future.successful(false)
+      healthCheckWith(lease).check().futureValue shouldEqual true
     }
 
     "return false on LeaseException" in {
-      LeaseHealthCheckSpec.nextAcquire = () => Future.failed(new LeaseException("API error"))
-      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual false
+      val lease = newTestLease()
+      lease.nextAcquire = () => Future.failed(new LeaseException("API error"))
+      healthCheckWith(lease).check().futureValue shouldEqual false
     }
 
     "return false on AskTimeoutException" in {
-      LeaseHealthCheckSpec.nextAcquire = () => Future.failed(new AskTimeoutException("timeout"))
-      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual false
+      val lease = newTestLease()
+      lease.nextAcquire = () => Future.failed(new AskTimeoutException("timeout"))
+      healthCheckWith(lease).check().futureValue shouldEqual false
     }
 
     "return false on generic Exception" in {
-      LeaseHealthCheckSpec.nextAcquire = () => Future.failed(new RuntimeException("generic error"))
-      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual false
+      val lease = newTestLease()
+      lease.nextAcquire = () => Future.failed(new RuntimeException("generic error"))
+      healthCheckWith(lease).check().futureValue shouldEqual false
     }
   }
 }
 
 object LeaseHealthCheckSpec {
-  @volatile var nextAcquire: () => Future[Boolean] = () => Future.successful(true)
-  @volatile var releaseCalled = false
-  @volatile var acquireCalls = 0
+  val config: Config = ConfigFactory.parseString(s"""
+  mock-lease {
+    lease-class = "${classOf[LeaseHealthCheckSpec.MockLease].getName}"
+    heartbeat-timeout = 100s
+    heartbeat-interval = 1s
+    lease-operation-timeout = 2s
+  }
+  """)
 
-  class MockLease(settings: LeaseSettings) extends Lease(settings) {
+  private val mockLeaseSettings = LeaseSettings(config.getConfig("mock-lease"), "test-lease", "test-owner")
+
+  trait MockLeaseState {
+    @volatile var nextAcquire: () => Future[Boolean] = () => Future.successful(true)
+    @volatile var releaseCalled: Boolean = false
+    @volatile var acquireCalls: Int = 0
+  }
+
+  class MockLease(settings: LeaseSettings) extends Lease(settings) with MockLeaseState {
     override def acquire(): Future[Boolean] = {
       acquireCalls += 1
       nextAcquire()
@@ -97,13 +125,4 @@ object LeaseHealthCheckSpec {
     }
     override def checkLease(): Boolean = true
   }
-
-  val config: Config = ConfigFactory.parseString(s"""
-  mock-lease {
-    lease-class = "${classOf[LeaseHealthCheckSpec.MockLease].getName}"
-    heartbeat-timeout = 100s
-    heartbeat-interval = 1s
-    lease-operation-timeout = 2s
-  }
-  """)
 }

--- a/coordination/src/test/scala/org/apache/pekko/coordination/lease/LeaseHealthCheckSpec.scala
+++ b/coordination/src/test/scala/org/apache/pekko/coordination/lease/LeaseHealthCheckSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.coordination.lease
+
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.apache.pekko.coordination.lease.scaladsl.Lease
+import org.apache.pekko.pattern.AskTimeoutException
+import org.apache.pekko.testkit.PekkoSpec
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class LeaseHealthCheckSpec
+    extends PekkoSpec(LeaseHealthCheckSpec.config)
+    with ScalaFutures
+    with AnyWordSpecLike
+    with BeforeAndAfterAll
+    with Matchers {
+
+  override implicit val patience: PatienceConfig = PatienceConfig(5.seconds)
+
+  "LeaseHealthCheckSpec" should {
+
+    "return true and release lease on successful acquisition" in {
+      LeaseHealthCheckSpec.nextAcquire = () => Future.successful(true)
+      LeaseHealthCheckSpec.releaseCalled = false
+      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual true
+      LeaseHealthCheckSpec.releaseCalled shouldEqual true
+    }
+
+    "not call acquire again after healthCheckPassed is true" in {
+      LeaseHealthCheckSpec.nextAcquire = () => Future.successful(true)
+      LeaseHealthCheckSpec.acquireCalls = 0
+      val healthcheck = new LeaseHealthCheck(system, "mock-lease")
+      healthcheck.check().futureValue shouldEqual true
+      LeaseHealthCheckSpec.acquireCalls shouldEqual 1
+
+      healthcheck.check().futureValue shouldEqual true
+      LeaseHealthCheckSpec.acquireCalls shouldEqual 1
+    }
+
+    "return true on lease conflict" in {
+      LeaseHealthCheckSpec.nextAcquire = () => Future.successful(false)
+      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual true
+    }
+
+    "return false on LeaseException" in {
+      LeaseHealthCheckSpec.nextAcquire = () => Future.failed(new LeaseException("API error"))
+      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual false
+    }
+
+    "return false on AskTimeoutException" in {
+      LeaseHealthCheckSpec.nextAcquire = () => Future.failed(new AskTimeoutException("timeout"))
+      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual false
+    }
+
+    "return false on generic Exception" in {
+      LeaseHealthCheckSpec.nextAcquire = () => Future.failed(new RuntimeException("generic error"))
+      new LeaseHealthCheck(system, "mock-lease").check().futureValue shouldEqual false
+    }
+  }
+}
+
+object LeaseHealthCheckSpec {
+  @volatile var nextAcquire: () => Future[Boolean] = () => Future.successful(true)
+  @volatile var releaseCalled = false
+  @volatile var acquireCalls = 0
+
+  class MockLease(settings: LeaseSettings) extends Lease(settings) {
+    override def acquire(): Future[Boolean] = {
+      acquireCalls += 1
+      nextAcquire()
+    }
+    override def acquire(callback: Option[Throwable] => Unit): Future[Boolean] = acquire()
+    override def release(): Future[Boolean] = {
+      releaseCalled = true
+      Future.successful(true)
+    }
+    override def checkLease(): Boolean = true
+  }
+
+  val config: Config = ConfigFactory.parseString(s"""
+  mock-lease {
+    lease-class = "${classOf[LeaseHealthCheckSpec.MockLease].getName}"
+    heartbeat-timeout = 100s
+    heartbeat-interval = 1s
+    lease-operation-timeout = 2s
+  }
+  """)
+}


### PR DESCRIPTION
Applying this PR will add a `LeaseHealthCheck` class folks can use as one of their startup/liveness/readiness probes or as part of their home grown status check setup.
Rationale: a lease is often used for SBR (split brain resolution), but the lease is only created when a split-brain situation occurs. Finding out that it is actually impossible to acquire a lease because of, for example, a misconfiguration only then is undesirable.