### PR TITLE
ByteString performance improvements (small)

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -1455,7 +1455,7 @@ object ByteString {
 
     /** Avoid `iterator` in performance sensitive code, call ops directly on ByteString instead */
     override def iterator: ByteIterator.MultiByteArrayIterator =
-      ByteIterator.MultiByteArrayIterator(bytestrings.to(LazyList).map { _.iterator })
+      ByteIterator.MultiByteArrayIterator(bytestrings.iterator.map(_.iterator).toList)
 
     def ++(that: ByteString): ByteString = {
       if (that.isEmpty) this
@@ -1802,7 +1802,7 @@ object ByteString {
       bytestrings.foreach { bs =>
         var i = 0
         while (i < bs.length) {
-          result(pos) = f(bs(i))
+          result(pos) = f(bs.byteAtUnchecked(i))
           pos += 1
           i += 1
         }


### PR DESCRIPTION
Assisted by Claude AI.

These 2 low impact changes should have a reasonable perf benefit.

1. ByteStrings.iterator uses LazyList — significant overhead

File: ByteString.scala:1458
override def iterator: ByteIterator.MultiByteArrayIterator =
  ByteIterator.MultiByteArrayIterator(bytestrings.to(LazyList).map { _.iterator })

LazyList has per-element thunk allocation and synchronization overhead. Since bytestrings is already a Vector (random-access), a plain Iterator is sufficient:

override def iterator: ByteIterator.MultiByteArrayIterator =
  ByteIterator.MultiByteArrayIterator(bytestrings.iterator.map(_.iterator))

This eliminates lazy evaluation machinery that buys nothing here — the fragments are already materialized in the Vector.

ByteStrings.iterator: Replaced bytestrings.to(LazyList).map(_.iterator) with bytestrings.iterator.map(_.iterator).toList. The LazyList allocated thunks for each element access despite the fragments already being materialized in the Vector. A plain List is a LinearSeq (which MultiByteArrayIterator requires) and avoids the per-element lazy evaluation overhead.

2. ByteStrings.map: Changed bs(i) to bs.byteAtUnchecked(i). Since the loop already constrains i to 0 until bs.length, the bounds check in ByteString1.apply was redundant. byteAtUnchecked skips the checkRangeConvert call (bounds check + offset arithmetic) on every byte.
