### PR TITLE
fix: ignore FilteredPayload in replay of persisted events

### DIFF
--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -46,6 +46,9 @@ import pekko.persistence.query.Sequence
 import pekko.persistence.snapshot.SnapshotStore
 import pekko.persistence.testkit.PersistenceTestKitPlugin
 import pekko.persistence.testkit.query.scaladsl.PersistenceTestKitReadJournal
+import pekko.persistence.FilteredPayload
+import pekko.persistence.typed.EventAdapter
+import pekko.persistence.typed.EventSeq
 import pekko.persistence.typed.PersistenceId
 import pekko.persistence.typed.RecoveryCompleted
 import pekko.persistence.typed.SnapshotCompleted
@@ -330,6 +333,64 @@ class EventSourcedBehaviorSpec
       c2 ! Increment
       c2 ! GetValue(probe.ref)
       probe.expectMessage(State(4, Vector(0, 1, 2, 3)))
+    }
+
+    "exclude FilteredPayload in replay of persisted events" in {
+      sealed trait Cmd
+      case object Incr extends Cmd
+      case object PersistFiltered extends Cmd
+      final case class GetVal(replyTo: ActorRef[Int]) extends Cmd
+
+      sealed trait Evt
+      case object Incremented extends Evt
+      case object FilteredEvent extends Evt
+
+      def behavior(pid: PersistenceId): EventSourcedBehavior[Cmd, Evt, Int] =
+        EventSourcedBehavior[Cmd, Evt, Int](
+          pid,
+          emptyState = 0,
+          commandHandler = (_, cmd) =>
+            cmd match {
+              case Incr             => Effect.persist(Incremented)
+              case PersistFiltered  => Effect.persist(FilteredEvent)
+              case GetVal(replyTo)  =>
+                Effect.none.thenRun(state => replyTo ! state)
+            },
+          eventHandler = (state, evt) =>
+            evt match {
+              case Incremented   => state + 1
+              case FilteredEvent => state
+            })
+          .eventAdapter(new EventAdapter[Evt, Any] {
+            override def toJournal(e: Evt): Any = e match {
+              case FilteredEvent => FilteredPayload
+              case other         => other
+            }
+            override def manifest(event: Evt): String = ""
+            override def fromJournal(p: Any, manifest: String): EventSeq[Evt] = p match {
+              case FilteredPayload =>
+                throw new IllegalStateException("Unexpected FilteredPayload")
+              case e: Evt => EventSeq.single(e)
+              case other =>
+                throw new IllegalStateException(s"Unexpected event type $other")
+            }
+          })
+
+      val pid = nextPid()
+      val c = spawn(behavior(pid))
+      val probe = TestProbe[Int]()
+
+      c ! Incr
+      c ! PersistFiltered
+      c ! Incr
+      c ! GetVal(probe.ref)
+      probe.expectMessage(2)
+
+      // restart — recovery should skip the FilteredPayload entry
+      val c2 = spawn(behavior(pid))
+      c2 ! Incr
+      c2 ! GetVal(probe.ref)
+      probe.expectMessage(3)
     }
 
     "handle Terminated signal" in {

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -351,9 +351,9 @@ class EventSourcedBehaviorSpec
           emptyState = 0,
           commandHandler = (_, cmd) =>
             cmd match {
-              case Incr             => Effect.persist(Incremented)
-              case PersistFiltered  => Effect.persist(FilteredEvent)
-              case GetVal(replyTo)  =>
+              case Incr            => Effect.persist(Incremented)
+              case PersistFiltered => Effect.persist(FilteredEvent)
+              case GetVal(replyTo) =>
                 Effect.none.thenRun(state => replyTo ! state)
             },
           eventHandler = (state, evt) =>
@@ -371,7 +371,7 @@ class EventSourcedBehaviorSpec
               case FilteredPayload =>
                 throw new IllegalStateException("Unexpected FilteredPayload")
               case e: Evt => EventSeq.single(e)
-              case other =>
+              case other  =>
                 throw new IllegalStateException(s"Unexpected event type $other")
             }
           })

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -131,6 +131,15 @@ object EventSourcedBehaviorSpec {
 
   case object Tick
 
+  sealed trait FilteredCmd extends pekko.testkit.JavaSerializable
+  case object Incr extends FilteredCmd
+  case object PersistFiltered extends FilteredCmd
+  final case class GetFilteredVal(replyTo: ActorRef[Int]) extends FilteredCmd
+
+  sealed trait FilteredEvt extends pekko.testkit.JavaSerializable
+  case object FilteredIncremented extends FilteredEvt
+  case object FilteredEvent extends FilteredEvt
+
   val firstLogging = "first logging"
   val secondLogging = "second logging"
 
@@ -336,42 +345,33 @@ class EventSourcedBehaviorSpec
     }
 
     "exclude FilteredPayload in replay of persisted events" in {
-      sealed trait Cmd
-      case object Incr extends Cmd
-      case object PersistFiltered extends Cmd
-      final case class GetVal(replyTo: ActorRef[Int]) extends Cmd
-
-      sealed trait Evt
-      case object Incremented extends Evt
-      case object FilteredEvent extends Evt
-
-      def behavior(pid: PersistenceId): EventSourcedBehavior[Cmd, Evt, Int] =
-        EventSourcedBehavior[Cmd, Evt, Int](
+      def behavior(pid: PersistenceId): EventSourcedBehavior[FilteredCmd, FilteredEvt, Int] =
+        EventSourcedBehavior[FilteredCmd, FilteredEvt, Int](
           pid,
           emptyState = 0,
           commandHandler = (_, cmd) =>
             cmd match {
-              case Incr            => Effect.persist(Incremented)
-              case PersistFiltered => Effect.persist(FilteredEvent)
-              case GetVal(replyTo) =>
+              case Incr                    => Effect.persist(FilteredIncremented)
+              case PersistFiltered         => Effect.persist(FilteredEvent)
+              case GetFilteredVal(replyTo) =>
                 Effect.none.thenRun(state => replyTo ! state)
             },
           eventHandler = (state, evt) =>
             evt match {
-              case Incremented   => state + 1
-              case FilteredEvent => state
+              case FilteredIncremented => state + 1
+              case FilteredEvent       => state
             })
-          .eventAdapter(new EventAdapter[Evt, Any] {
-            override def toJournal(e: Evt): Any = e match {
+          .eventAdapter(new EventAdapter[FilteredEvt, Any] {
+            override def toJournal(e: FilteredEvt): Any = e match {
               case FilteredEvent => FilteredPayload
               case other         => other
             }
-            override def manifest(event: Evt): String = ""
-            override def fromJournal(p: Any, manifest: String): EventSeq[Evt] = p match {
+            override def manifest(event: FilteredEvt): String = ""
+            override def fromJournal(p: Any, manifest: String): EventSeq[FilteredEvt] = p match {
               case FilteredPayload =>
                 throw new IllegalStateException("Unexpected FilteredPayload")
-              case e: Evt => EventSeq.single(e)
-              case other  =>
+              case e: FilteredEvt => EventSeq.single(e)
+              case other          =>
                 throw new IllegalStateException(s"Unexpected event type $other")
             }
           })
@@ -383,13 +383,13 @@ class EventSourcedBehaviorSpec
       c ! Incr
       c ! PersistFiltered
       c ! Incr
-      c ! GetVal(probe.ref)
+      c ! GetFilteredVal(probe.ref)
       probe.expectMessage(2)
 
       // restart — recovery should skip the FilteredPayload entry
       val c2 = spawn(behavior(pid))
       c2 ! Incr
-      c2 ! GetVal(probe.ref)
+      c2 ! GetFilteredVal(probe.ref)
       probe.expectMessage(3)
     }
 

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ReplayingEvents.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ReplayingEvents.scala
@@ -138,7 +138,9 @@ private[pekko] final class ReplayingEvents[C, E, S](
         case ReplayedMessage(repr) =>
           var eventForErrorReporting: OptionVal[Any] = OptionVal.None
           try {
-            val eventSeq = setup.eventAdapter.fromJournal(repr.payload, repr.manifest)
+            val eventSeq =
+              if (repr.payload == FilteredPayload) EmptyEventSeq
+              else setup.eventAdapter.fromJournal(repr.payload, repr.manifest)
             def handleEvent(event: E): Unit = {
               eventForErrorReporting = OptionVal.Some(event)
               state = state.copy(seqNr = repr.sequenceNr, eventsReplayed = state.eventsReplayed + 1)

--- a/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
@@ -653,6 +653,7 @@ private[persistence] trait Eventsourced
         }
 
       {
+        case PersistentRepr(FilteredPayload, _) => // ignore
         case PersistentRepr(payload, _) if recoveryRunning && _receiveRecover.isDefinedAt(payload) =>
           _receiveRecover(payload)
         case s: SnapshotOffer if _receiveRecover.isDefinedAt(s) =>

--- a/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
@@ -653,7 +653,7 @@ private[persistence] trait Eventsourced
         }
 
       {
-        case PersistentRepr(FilteredPayload, _) => // ignore
+        case PersistentRepr(FilteredPayload, _)                                                    => // ignore
         case PersistentRepr(payload, _) if recoveryRunning && _receiveRecover.isDefinedAt(payload) =>
           _receiveRecover(payload)
         case s: SnapshotOffer if _receiveRecover.isDefinedAt(s) =>

--- a/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorSpec.scala
@@ -127,6 +127,24 @@ object PersistentActorSpec {
       extends Behavior3PersistentActor(name)
       with InmemRuntimePluginConfig
 
+  class Behavior4PersistentActor(name: String) extends ExamplePersistentActor(name) {
+    val receiveCommand: Receive = commonBehavior.orElse {
+      case FilteredPayload =>
+        persist(FilteredPayload)(_ => ())
+      case Cmd(data) =>
+        persist(Evt(s"$data-${lastSequenceNr + 1}"))(updateState)
+    }
+
+    override def receiveRecover: Receive = super.receiveRecover.orElse {
+      case FilteredPayload =>
+        throw new IllegalStateException("Unexpected FilteredPayload")
+    }
+  }
+
+  class Behavior4PersistentActorWithInmemRuntimePluginConfig(name: String, val providedConfig: Config)
+      extends Behavior4PersistentActor(name)
+      with InmemRuntimePluginConfig
+
   class ChangeBehaviorInLastEventHandlerPersistentActor(name: String) extends ExamplePersistentActor(name) {
     val newBehavior: Receive = {
       case Cmd(data) =>
@@ -975,6 +993,8 @@ abstract class PersistentActorSpec(config: Config) extends PersistenceSpec(confi
 
   protected def behavior3PersistentActor: ActorRef = namedPersistentActor[Behavior3PersistentActor]
 
+  protected def behavior4PersistentActor: ActorRef = namedPersistentActor[Behavior4PersistentActor]
+
   protected def changeBehaviorInFirstEventHandlerPersistentActor: ActorRef =
     namedPersistentActor[ChangeBehaviorInFirstEventHandlerPersistentActor]
 
@@ -1145,6 +1165,17 @@ abstract class PersistentActorSpec(config: Config) extends PersistenceSpec(confi
       persistentActor ! GetState
       // cmd that was added to state before failure (b-10) is not replayed ...
       expectMsg(List("a-1", "a-2", "b-11", "b-12", "c-10", "c-11", "c-12"))
+    }
+    "exclude FilteredPayload in replay of persisted events" in {
+      val persistentActor = behavior4PersistentActor
+      persistentActor ! GetState
+      expectMsg(List("a-1", "a-2"))
+      persistentActor ! FilteredPayload
+      persistentActor ! Cmd("b")
+      persistentActor ! "boom"
+      persistentActor ! Cmd("c")
+      persistentActor ! GetState
+      expectMsg(List("a-1", "a-2", "b-4", "c-5")) // seqNr 3 was for FilteredPayload
     }
     "allow behavior changes in event handler (when handling first event)" in {
       val persistentActor = changeBehaviorInFirstEventHandlerPersistentActor
@@ -1692,6 +1723,9 @@ class InmemPersistentActorWithRuntimePluginConfigSpec
 
   override protected def behavior3PersistentActor: ActorRef =
     namedPersistentActorWithProvidedConfig[Behavior3PersistentActorWithInmemRuntimePluginConfig](providedActorConfig)
+
+  override protected def behavior4PersistentActor: ActorRef =
+    namedPersistentActorWithProvidedConfig[Behavior4PersistentActorWithInmemRuntimePluginConfig](providedActorConfig)
 
   override protected def changeBehaviorInFirstEventHandlerPersistentActor: ActorRef =
     namedPersistentActorWithProvidedConfig[


### PR DESCRIPTION
### Motivation
When `FilteredPayload` is stored in the journal (e.g. via an `EventAdapter` that maps certain events to `FilteredPayload`), replaying those events would pass `FilteredPayload` to the user's `eventAdapter.fromJournal` or `receiveRecover` handler, which is unexpected and can cause failures.

### Modification
- In `ReplayingEvents` (typed persistence), skip `FilteredPayload` by returning `EmptyEventSeq` before calling `eventAdapter.fromJournal`.
- In `Eventsourced` (classic persistence), add a case to ignore `FilteredPayload` before it reaches the user's `receiveRecover` handler.
- Add directional tests for both classic and typed persistence that fail before the fix.

### Result
`FilteredPayload` entries in the journal are silently skipped during recovery. Sequence numbers are still correctly advanced.

### License
This PR ports a bug fix from Akka (https://github.com/akka/akka-core/pull/32000). The Apache License 2.0 is applicable.

### Tests
- `sbt "persistence / Test / testOnly org.apache.pekko.persistence.PersistentActorSpec"`
- `sbt "persistence-typed-tests / Test / testOnly org.apache.pekko.persistence.typed.scaladsl.EventSourcedBehaviorSpec"`

### References
Refs akka/akka-core#32000