### PR TITLE
feat: add javadsl Effect.delete() for durable state

### DIFF
--- a/persistence-typed-tests/src/test/java/org/apache/pekko/persistence/typed/state/javadsl/RuntimeDurableStateStoreTest.java
+++ b/persistence-typed-tests/src/test/java/org/apache/pekko/persistence/typed/state/javadsl/RuntimeDurableStateStoreTest.java
@@ -82,6 +82,14 @@ public class RuntimeDurableStateStoreTest {
     INSTANCE
   }
 
+  static final class Delete implements Command {
+    final ActorRef<Done> replyTo;
+
+    Delete(ActorRef<Done> replyTo) {
+      this.replyTo = replyTo;
+    }
+  }
+
   static final class Actor extends DurableStateBehavior<Command, String> {
     private final String store;
 
@@ -105,6 +113,7 @@ public class RuntimeDurableStateStoreTest {
           .forAnyState()
           .onCommand(Save.class, this::onSave)
           .onCommand(ShowMeWhatYouGot.class, this::onShow)
+          .onCommand(Delete.class, (state, cmd) -> Effect().<String>delete().thenRun(() -> cmd.replyTo.tell(Done.getInstance())))
           .onCommand(Stop.class, (state, cmd) -> Effect().stop())
           .build();
     }
@@ -145,6 +154,31 @@ public class RuntimeDurableStateStoreTest {
 
     assertStore("store1", "s1m1");
     assertStore("store2", "s2m1");
+  }
+
+  @Test
+  public void deleteState() throws Exception {
+    TestProbe<Done> probe = testKit.createTestProbe();
+
+    ActorRef<Command> s1 = testKit.spawn(Actor.create("id1", "store1"));
+    s1.tell(new Save("s1m1", probe.ref()));
+    probe.receiveMessage();
+    assertStore("store1", "s1m1");
+
+    s1.tell(new Delete(probe.ref()));
+    probe.receiveMessage();
+    assertStoreDeleted("store1");
+  }
+
+  private void assertStoreDeleted(String store) throws Exception {
+    @SuppressWarnings("unchecked")
+    DurableStateUpdateStore<String> durableStateStore =
+        DurableStateStoreRegistry.get(testKit.system())
+            .getDurableStateStoreFor(
+                DurableStateUpdateStore.class, store + ".state", config(store));
+    GetObjectResult<String> result =
+        durableStateStore.getObject("id1").toCompletableFuture().get(3, TimeUnit.SECONDS);
+    assertEquals(Optional.empty(), result.value());
   }
 
   private void assertStore(String store, String expectedState) throws Exception {

--- a/persistence-typed-tests/src/test/java/org/apache/pekko/persistence/typed/state/javadsl/RuntimeDurableStateStoreTest.java
+++ b/persistence-typed-tests/src/test/java/org/apache/pekko/persistence/typed/state/javadsl/RuntimeDurableStateStoreTest.java
@@ -113,7 +113,10 @@ public class RuntimeDurableStateStoreTest {
           .forAnyState()
           .onCommand(Save.class, this::onSave)
           .onCommand(ShowMeWhatYouGot.class, this::onShow)
-          .onCommand(Delete.class, (state, cmd) -> Effect().<String>delete().thenRun(() -> cmd.replyTo.tell(Done.getInstance())))
+          .onCommand(
+              Delete.class,
+              (state, cmd) ->
+                  Effect().<String>delete().thenRun(() -> cmd.replyTo.tell(Done.getInstance())))
           .onCommand(Stop.class, (state, cmd) -> Effect().stop())
           .build();
     }

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/Effect.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/javadsl/Effect.scala
@@ -44,7 +44,12 @@ import pekko.persistence.typed.state.internal.SideEffect
    */
   final def persist(state: State): EffectBuilder[State] = Persist(state)
 
-  // FIXME add delete effect
+  /**
+   * Delete the persisted state.
+   *
+   * Side effects can be chained with `thenRun`.
+   */
+  def delete(): EffectBuilder[State] = Delete().asInstanceOf[EffectBuilder[State]]
 
   /**
    * Do not persist anything


### PR DESCRIPTION
### Motivation
The scaladsl `DurableStateBehavior` already supports `Effect.delete()` but the javadsl was missing it (marked with a FIXME comment). Java users had no way to delete persisted state from a `DurableStateBehavior`.

### Modification
- Add `delete()` method to javadsl `EffectFactories`, delegating to the existing internal `Delete()` effect.
- Add a directional test exercising `Effect().delete()` from Java with a deterministic reply-after-delete pattern.

### Result
Java DSL users can now call `Effect().delete()` in their `DurableStateBehavior` command handlers, achieving API parity with the Scala DSL.

### License
This PR ports a feature from Akka (https://github.com/akka/akka-core/pull/32027). The Apache License 2.0 is applicable.

### Tests
- `sbt "persistence-typed-tests / Test / testOnly org.apache.pekko.persistence.typed.state.javadsl.RuntimeDurableStateStoreTest"`

### References
Refs akka/akka-core#32027