### PR TITLE
test: add Java test for retry short-circuit with Predicate2

### DIFF
--- a/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
+++ b/actor-tests/src/test/java/org/apache/pekko/pattern/PatternsTest.java
@@ -339,6 +339,38 @@ public class PatternsTest {
   }
 
   @Test
+  public void testShortCircuitRetry() throws Exception {
+    AtomicInteger failureCounter = new AtomicInteger();
+
+    final CompletableFuture<Object> ise = new CompletableFuture<>();
+    final CompletableFuture<Object> iae = new CompletableFuture<>();
+    ise.completeExceptionally(new IllegalStateException());
+    iae.completeExceptionally(new IllegalArgumentException());
+
+    CompletionStage<Object> retriedAttempts =
+        Patterns.retry(
+            () -> {
+              if ((failureCounter.getAndIncrement() % 3) < 2) {
+                return ise;
+              } else {
+                return iae;
+              }
+            },
+            (result, ex) -> !(ex instanceof IllegalArgumentException),
+            10,
+            ec);
+
+    try {
+      retriedAttempts.toCompletableFuture().get(3, SECONDS);
+      throw new AssertionError("future should have failed!");
+    } catch (java.util.concurrent.ExecutionException e) {
+      assertEquals(IllegalArgumentException.class, e.getCause().getClass());
+    }
+
+    assertEquals(3, failureCounter.get());
+  }
+
+  @Test
   public void testAfterFailedCallable() throws Exception {
     Callable<CompletionStage<String>> failedCallable =
         () -> CompletableFuture.failedStage(new IllegalStateException("Illegal!"));


### PR DESCRIPTION
### Motivation
The Java DSL `Patterns.retry` with `Predicate2` (shouldRetry) has been available since 1.1.0 but lacks a directional test exercising the short-circuit behavior from Java. The Scala DSL has coverage in `RetrySpec` but the Java path is untested.

### Modification
Add `testShortCircuitRetry` to `PatternsTest.java` that verifies:
- Retry continues when predicate returns true (`IllegalStateException`)
- Retry stops immediately when predicate returns false (`IllegalArgumentException`)
- Exactly 3 attempts are made (2 retriable + 1 non-retriable)

### Result
Java DSL retry short-circuit behavior is now covered by a directional test that would fail if the `Predicate2` wiring were broken.

### Tests
- `sbt "actor-tests / Test / testOnly org.apache.pekko.pattern.PatternsTest"`

### References
Refs akka/akka-core#32035