### PR TITLE
docs: fix typos and punctuation in io-dns and split-brain-resolver

### DIFF
--- a/docs/src/main/paradox/io-dns.md
+++ b/docs/src/main/paradox/io-dns.md
@@ -27,7 +27,7 @@ Users should pick one of the built in extensions.
 
 @@@
 
-Pekko DNS is a pluggable way to interact with DNS. Implementations much implement `org.apache.pekko.io.DnsProvider` and provide a configuration
+Pekko DNS is a pluggable way to interact with DNS. Implementations must implement `org.apache.pekko.io.DnsProvider` and provide a configuration
 block that specifies the implementation via `provider-object`.
 
 @@@ note { title="DNS via Pekko Discovery" }

--- a/docs/src/main/paradox/split-brain-resolver.md
+++ b/docs/src/main/paradox/split-brain-resolver.md
@@ -227,22 +227,22 @@ of 4 and 5 nodes the side with 5 nodes will survive and the other 4 nodes will b
 in the 5 node cluster, no more failures can be handled, because the remaining cluster size would be
 less than 5. In the case of another failure in that 5 node cluster all nodes will be downed.
 
-Therefore it is important that you join new nodes when old nodes have been removed.
+Therefore, it is important that you join new nodes when old nodes have been removed.
 
 Another consequence of this is that if there are unreachable nodes when starting up the cluster,
 before reaching this limit, the cluster may shut itself down immediately. This is not an issue
 if you start all nodes at approximately the same time or use the `pekko.cluster.min-nr-of-members`
-to define required number of members before the leader changes member status of 'Joining' members to 'Up'
+to define required number of members before the leader changes member status of 'Joining' members to 'Up'.
 You can tune the timeout after which downing decisions are made using the `stable-after` setting.
 
 You should not add more members to the cluster than **quorum-size * 2 - 1**. A warning is logged
-if this recommendation is violated. If the exceeded cluster size remains when a SBR decision is
+if this recommendation is violated. If the exceeded cluster size remains when an SBR decision is
 needed it will down all nodes because otherwise there is a risk that both sides may down each
 other and thereby form two separate clusters.
 
-For rolling updates it's best to leave the cluster gracefully via
+For rolling updates, it's best to leave the cluster gracefully via
 @ref:[Coordinated Shutdown](coordinated-shutdown.md) (SIGTERM).
-For successful leaving SBR will not be used (no downing) but if there is an unreachability problem
+For successful leaving, SBR will not be used (no downing) but if there is an unreachability problem
 at the same time as the rolling update is in progress there could be an SBR decision. To avoid that
 the total number of members limit is not exceeded during the rolling update it's recommended to
 leave and fully remove one node before adding a new one, when using `static-quorum`.
@@ -380,8 +380,8 @@ See also configuration and additional dependency in [Kubernetes Lease]($pekko.do
 
 ## Indirectly connected nodes
 
-In a malfunctional network there can be situations where nodes are observed as unreachable via some network
-links but they are still indirectly connected via other nodes, i.e. it's not a clean network partition (or node crash).
+In a malfunctioning network there can be situations where nodes are observed as unreachable via some network
+links, but they are still indirectly connected via other nodes, i.e. it's not a clean network partition (or node crash).
 
 When this situation is detected the Split Brain Resolvers will keep fully connected nodes and down all the indirectly
 connected nodes.


### PR DESCRIPTION
### Motivation
Several typos and punctuation issues exist in the documentation that were fixed upstream in Akka but not yet ported to Pekko.

### Modification
- `io-dns.md`: "much implement" → "must implement"
- `split-brain-resolver.md`: add comma after "Therefore"
- `split-brain-resolver.md`: add period after "to 'Up'"
- `split-brain-resolver.md`: "a SBR" → "an SBR"
- `split-brain-resolver.md`: add comma after "For rolling updates"
- `split-brain-resolver.md`: add comma after "For successful leaving"
- `split-brain-resolver.md`: "malfunctional" → "malfunctioning"
- `split-brain-resolver.md`: add comma after "links"

### Result
Documentation reads correctly with proper grammar and punctuation.

### License
These documentation fixes are ported from Akka (https://github.com/akka/akka-core/pull/32019). The Apache License 2.0 is applicable.

### Tests
Not run - docs only

### References
Refs akka/akka-core#32019