### PR TITLE
feat: add EventWriter for batching journal writes

### DIFF
--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/internal/EventWriterSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/internal/EventWriterSpec.scala
@@ -1,18 +1,14 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * license agreements; and to You under the Apache License, version 2.0:
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package org.apache.pekko.persistence.typed.internal
@@ -169,7 +165,7 @@ class EventWriterSpec extends ScalaTestWithActorTestKit(EventWriterSpec.config) 
     }
     def journalAckWrite(pid: String = pid1): Int = {
       val write = fakeJournal.expectMessageType[JournalProtocol.WriteMessages]
-      write.messages should have size (1)
+      write.messages should have size 1
       val atomicWrite = write.messages.head.asInstanceOf[AtomicWrite]
       atomicWrite.payload.foreach { repr =>
         repr.persistenceId should ===(pid)
@@ -181,7 +177,7 @@ class EventWriterSpec extends ScalaTestWithActorTestKit(EventWriterSpec.config) 
 
     def journalFailWrite(reason: String, pid: String = pid1): Int = {
       val write = fakeJournal.expectMessageType[JournalProtocol.WriteMessages]
-      write.messages should have size (1)
+      write.messages should have size 1
       val atomicWrite = write.messages.head.asInstanceOf[AtomicWrite]
       atomicWrite.payload.foreach { repr =>
         repr.persistenceId should ===(pid)

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/internal/EventWriterSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/internal/EventWriterSpec.scala
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.typed.internal
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.LogCapturing
+import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import pekko.pattern.StatusReply
+import pekko.persistence.AtomicWrite
+import pekko.persistence.JournalProtocol
+
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.typesafe.config.ConfigFactory
+
+object EventWriterSpec {
+  def config =
+    ConfigFactory.parseString(s"""
+      pekko.persistence.journal.inmem.delay-writes=10ms
+    """).withFallback(ConfigFactory.load()).resolve()
+}
+
+class EventWriterSpec extends ScalaTestWithActorTestKit(EventWriterSpec.config) with AnyWordSpecLike with LogCapturing {
+
+  private val settings = EventWriter.EventWriterSettings(10, 5.seconds)
+  implicit val ec: ExecutionContext = testKit.system.executionContext
+
+  "The event writer" should {
+
+    "handle duplicates" in new TestSetup {
+      sendWrite(1)
+      journalAckWrite()
+      clientExpectSuccess(1)
+
+      // should also be ack:ed
+      sendWrite(1)
+      journalAckWrite()
+      clientExpectSuccess(1)
+    }
+
+    "handle batched duplicates" in new TestSetup {
+      // first write
+      sendWrite(1)
+      // first batch
+      for (n <- 2L to 10L) {
+        sendWrite(n)
+      }
+      // 0 will be written directly
+      journalAckWrite() should ===(1)
+      clientExpectSuccess(1)
+
+      // completing 1 triggers write of batch with 0-9
+      // second
+      for (n <- 1L to 10L) {
+        sendWrite(n)
+      }
+      // batch 0-9 in flight, writes in the meanwhile go in a new batch
+      journalAckWrite() should ===(9)
+      journalFailWrite("duplicate") should ===(10)
+      journalHighestSeqNr(10L)
+
+      clientExpectSuccess(19)
+    }
+
+    "handle batches with half duplicates" in new TestSetup {
+      for (n <- 1L to 10L) {
+        sendWrite(n)
+      }
+      journalAckWrite() should ===(1)
+      journalAckWrite() should ===(9)
+      clientExpectSuccess(10)
+
+      for (n <- 5L until 15L) {
+        sendWrite(n)
+      }
+      journalFailWrite("duplicate") should ===(1) // seq nr 5
+      journalHighestSeqNr(10L)
+      journalFailWrite("duplicate") should ===(9) // batch of 6-15
+      journalHighestSeqNr(10L)
+      journalAckWrite() should ===(4) // new write of 11-15 (non duplicates)
+
+      // all writes succeeded
+      clientExpectSuccess(10)
+    }
+
+    "pass real errors from journal back" in new TestSetup {
+      sendWrite(1L)
+      journalFailWrite("error error")
+      // duplicate handling will ask for highest seq nr, can't know it is an actual error
+      journalHighestSeqNr(0L)
+      val response = clientProbe.receiveMessage()
+      response.isError should ===(true)
+      response.getError.getMessage should ===("Journal write failed")
+    }
+
+    "ignores old failures when replay triggered" in new TestSetup {
+      sendWrite(1L) // triggers write
+
+      sendWrite(1L) // goes into batch
+      sendWrite(2L)
+      journalAckWrite()
+
+      val firstWrite = fakeJournal.expectMessageType[JournalProtocol.WriteMessages]
+      val payloads = firstWrite.messages.head.asInstanceOf[AtomicWrite].payload
+      // signal first failure, triggers HighestSeq
+      firstWrite.persistentActor ! JournalProtocol.WriteMessageFailure(
+        payloads.head,
+        new RuntimeException("duplicate"),
+        firstWrite.actorInstanceId)
+
+      // replay response triggers partial rewrite, seq nr 2
+      val replayRequest = fakeJournal.expectMessageType[JournalProtocol.ReplayMessages]
+      replayRequest.persistentActor ! JournalProtocol.RecoverySuccess(1L)
+
+      // but then original write failure arrives for seq nr 2 after sequence number lookup succeeded
+      firstWrite.persistentActor ! JournalProtocol.WriteMessageFailure(
+        payloads.tail.head,
+        new RuntimeException("duplicate"),
+        firstWrite.actorInstanceId)
+      firstWrite.persistentActor ! JournalProtocol.WriteMessagesFailed
+
+      // ack the partial retry
+      journalAckWrite() should ===(1)
+
+      clientExpectSuccess(3)
+
+    }
+
+    "handle writes to many pids" in {
+      val writer = spawn(EventWriter("pekko.persistence.journal.inmem", settings))
+      val probe = createTestProbe[StatusReply[EventWriter.WriteAck]]()
+      (0 to 1000).map { pidN =>
+        Future {
+          for (n <- 0 until 20) {
+            writer ! EventWriter.Write(s"pid$pidN", n.toLong, n.toString, None, Set.empty, probe.ref)
+          }
+        }
+      }
+      probe.receiveMessages(20 * 1000, 20.seconds)
+    }
+  }
+
+  trait TestSetup {
+    def pid1 = "pid1"
+    val fakeJournal = createTestProbe[JournalProtocol.Message]()
+    val writer = spawn(EventWriter(fakeJournal.ref, settings))
+    val clientProbe = createTestProbe[StatusReply[EventWriter.WriteAck]]()
+    def sendWrite(seqNr: Long, pid: String = pid1): Unit = {
+      writer ! EventWriter.Write(pid, seqNr, seqNr.toString, None, Set.empty, clientProbe.ref)
+    }
+    def journalAckWrite(pid: String = pid1): Int = {
+      val write = fakeJournal.expectMessageType[JournalProtocol.WriteMessages]
+      write.messages should have size (1)
+      val atomicWrite = write.messages.head.asInstanceOf[AtomicWrite]
+      atomicWrite.payload.foreach { repr =>
+        repr.persistenceId should ===(pid)
+        write.persistentActor ! JournalProtocol.WriteMessageSuccess(repr, write.actorInstanceId)
+      }
+      write.persistentActor ! JournalProtocol.WriteMessagesSuccessful
+      atomicWrite.payload.size
+    }
+
+    def journalFailWrite(reason: String, pid: String = pid1): Int = {
+      val write = fakeJournal.expectMessageType[JournalProtocol.WriteMessages]
+      write.messages should have size (1)
+      val atomicWrite = write.messages.head.asInstanceOf[AtomicWrite]
+      atomicWrite.payload.foreach { repr =>
+        repr.persistenceId should ===(pid)
+        write.persistentActor ! JournalProtocol.WriteMessageFailure(
+          repr,
+          new RuntimeException(reason),
+          write.actorInstanceId)
+      }
+      write.persistentActor ! JournalProtocol.WriteMessagesFailed
+      atomicWrite.payload.size
+    }
+
+    def journalHighestSeqNr(highestSeqNr: Long): Unit = {
+      val replay = fakeJournal.expectMessageType[JournalProtocol.ReplayMessages]
+      replay.persistentActor ! JournalProtocol.RecoverySuccess(highestSeqNr)
+    }
+
+    def clientExpectSuccess(n: Int) = {
+      clientProbe.receiveMessages(n).foreach { reply =>
+        reply.isSuccess should be(true)
+      }
+    }
+  }
+
+}

--- a/persistence-typed/src/main/resources/reference.conf
+++ b/persistence-typed/src/main/resources/reference.conf
@@ -48,6 +48,14 @@ pekko.persistence.typed {
   # the actor context logger.
   use-context-logger-for-internal-logging = false
 
+  event-writer {
+    # The maximum number of events to batch together when writing to the journal through the event writer
+    max-batch-size = 10
+    # The event-writer occasionally needs to ask the journal about highest sequence number to handle duplicate
+    # writes, this timeout is for that interaction
+    ask-timeout = 20s
+  }
+
   # Commands get stashed during persistence and un-stashed afterward. Normally, when many read-only
   # (i.e. that do not cause any persistence) commands are present in the stash, the functions are called
   # in a loop to unstash all of them. Setting this to true, will cause functions to be called

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventWriter.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventWriter.scala
@@ -1,18 +1,14 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * license agreements; and to You under the Apache License, version 2.0:
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package org.apache.pekko.persistence.typed.internal
@@ -51,23 +47,24 @@ import pekko.util.Timeout
  */
 @InternalStableApi
 private[pekko] object EventWriterExtension extends ExtensionId[EventWriterExtension] {
-  def createExtension(system: ActorSystem[_]): EventWriterExtension = new EventWriterExtension(system)
+  def createExtension(system: ActorSystem[?]): EventWriterExtension = new EventWriterExtension(system)
 
-  def get(system: ActorSystem[_]): EventWriterExtension = apply(system)
+  def get(system: ActorSystem[?]): EventWriterExtension = apply(system)
 }
 
 /**
  * INTERNAL API
  */
 @InternalStableApi
-private[pekko] class EventWriterExtension(system: ActorSystem[_]) extends Extension {
+private[pekko] class EventWriterExtension(system: ActorSystem[?]) extends Extension {
 
   private val settings = EventWriter.EventWriterSettings(system)
   private val writersPerJournalId = new ConcurrentHashMap[String, ActorRef[EventWriter.Command]]()
 
   def writerForJournal(journalId: Option[String]): ActorRef[EventWriter.Command] =
     writersPerJournalId.computeIfAbsent(
-      journalId.getOrElse(""), { _ =>
+      journalId.getOrElse(""),
+      { _ =>
         system.systemActorOf(
           EventWriter(journalId.getOrElse(""), settings),
           s"EventWriter-${URLEncoder.encode(journalId.getOrElse("default"), "UTF-8")}")
@@ -85,7 +82,7 @@ private[pekko] object EventWriter {
   type Pid = String
 
   object EventWriterSettings {
-    def apply(system: ActorSystem[_]): EventWriterSettings =
+    def apply(system: ActorSystem[?]): EventWriterSettings =
       EventWriterSettings(
         maxBatchSize = system.settings.config.getInt("pekko.persistence.typed.event-writer.max-batch-size"),
         askTimeout = system.settings.config.getDuration("pekko.persistence.typed.event-writer.ask-timeout").asScala)

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventWriter.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EventWriter.scala
@@ -1,0 +1,381 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.persistence.typed.internal
+
+import java.net.URLEncoder
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Failure
+import scala.util.Success
+
+import org.apache.pekko
+import pekko.actor.typed.ActorRef
+import pekko.actor.typed.ActorSystem
+import pekko.actor.typed.Behavior
+import pekko.actor.typed.Extension
+import pekko.actor.typed.ExtensionId
+import pekko.actor.typed.SupervisorStrategy
+import pekko.actor.typed.scaladsl.Behaviors
+import pekko.actor.typed.scaladsl.LoggerOps
+import pekko.actor.typed.scaladsl.adapter.ClassicActorRefOps
+import pekko.actor.typed.scaladsl.adapter.TypedActorRefOps
+import pekko.annotation.InternalStableApi
+import pekko.pattern.StatusReply
+import pekko.persistence.AtomicWrite
+import pekko.persistence.JournalProtocol
+import pekko.persistence.Persistence
+import pekko.persistence.PersistentRepr
+import pekko.persistence.journal.Tagged
+import pekko.util.JavaDurationConverters.JavaDurationOps
+import pekko.util.Timeout
+
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+private[pekko] object EventWriterExtension extends ExtensionId[EventWriterExtension] {
+  def createExtension(system: ActorSystem[_]): EventWriterExtension = new EventWriterExtension(system)
+
+  def get(system: ActorSystem[_]): EventWriterExtension = apply(system)
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+private[pekko] class EventWriterExtension(system: ActorSystem[_]) extends Extension {
+
+  private val settings = EventWriter.EventWriterSettings(system)
+  private val writersPerJournalId = new ConcurrentHashMap[String, ActorRef[EventWriter.Command]]()
+
+  def writerForJournal(journalId: Option[String]): ActorRef[EventWriter.Command] =
+    writersPerJournalId.computeIfAbsent(
+      journalId.getOrElse(""), { _ =>
+        system.systemActorOf(
+          EventWriter(journalId.getOrElse(""), settings),
+          s"EventWriter-${URLEncoder.encode(journalId.getOrElse("default"), "UTF-8")}")
+      })
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+private[pekko] object EventWriter {
+
+  type SeqNr = Long
+  type Pid = String
+
+  object EventWriterSettings {
+    def apply(system: ActorSystem[_]): EventWriterSettings =
+      EventWriterSettings(
+        maxBatchSize = system.settings.config.getInt("pekko.persistence.typed.event-writer.max-batch-size"),
+        askTimeout = system.settings.config.getDuration("pekko.persistence.typed.event-writer.ask-timeout").asScala)
+
+  }
+  final case class EventWriterSettings(maxBatchSize: Int, askTimeout: FiniteDuration)
+
+  sealed trait Command
+  final case class Write(
+      persistenceId: Pid,
+      sequenceNumber: SeqNr,
+      event: Any,
+      metadata: Option[Any],
+      tags: Set[String],
+      replyTo: ActorRef[StatusReply[WriteAck]])
+      extends Command
+  final case class WriteAck(persistenceId: Pid, sequenceNumber: SeqNr)
+
+  private case class MaxSeqNrForPid(persistenceId: Pid, sequenceNumber: SeqNr, originalErrorDesc: String)
+      extends Command
+
+  private def emptyWaitingForWrite = Vector.empty[(PersistentRepr, ActorRef[StatusReply[WriteAck]])]
+  private case class StateForPid(
+      waitingForReply: Map[SeqNr, (PersistentRepr, ActorRef[StatusReply[WriteAck]])],
+      waitingForWrite: Vector[(PersistentRepr, ActorRef[StatusReply[WriteAck]])] = emptyWaitingForWrite,
+      writeErrorHandlingInProgress: Boolean = false,
+      currentTransactionId: Int = 0)
+
+  def apply(journalPluginId: String, eventWriterSettings: EventWriterSettings): Behavior[Command] =
+    Behaviors
+      .supervise(Behaviors.setup[Command] { context =>
+        val journal = Persistence(context.system).journalFor(journalPluginId)
+        context.log.debug("Event writer for journal [{}] starting up", journalPluginId)
+        apply(journal.toTyped, eventWriterSettings)
+      })
+      .onFailure[Exception](SupervisorStrategy.restart)
+
+  def apply(journal: ActorRef[JournalProtocol.Message], eventWriterSettings: EventWriterSettings): Behavior[Command] =
+    Behaviors
+      .setup[AnyRef] { context =>
+        val writerUuid = UUID.randomUUID().toString
+
+        var perPidWriteState = Map.empty[Pid, StateForPid]
+        implicit val askTimeout: Timeout = eventWriterSettings.askTimeout
+
+        def sendToJournal(transactionId: Int, reprs: Vector[PersistentRepr]) = {
+          journal ! JournalProtocol.WriteMessages(
+            AtomicWrite(reprs) :: Nil,
+            context.self.toClassic,
+            // Note: we use actorInstanceId to correlate replies from one write request
+            actorInstanceId = transactionId)
+        }
+
+        def handleUpdatedStateForPid(pid: Pid, newStateForPid: StateForPid): Unit = {
+          if (newStateForPid.waitingForReply.nonEmpty) {
+            perPidWriteState = perPidWriteState.updated(pid, newStateForPid)
+          } else {
+            if (newStateForPid.waitingForWrite.isEmpty) {
+              perPidWriteState = perPidWriteState - pid
+            } else {
+              val newReplyTo = newStateForPid.waitingForWrite.map {
+                case (repr, replyTo) => (repr.sequenceNr, (repr, replyTo))
+              }.toMap
+              val updatedState =
+                newStateForPid.copy(
+                  newReplyTo,
+                  emptyWaitingForWrite,
+                  currentTransactionId = newStateForPid.currentTransactionId + 1)
+
+              if (context.log.isTraceEnabled())
+                context.log.traceN(
+                  "Writing batch of {} events for pid [{}], seq nrs [{}-{}], tx id [{}]",
+                  newStateForPid.waitingForWrite.size,
+                  pid,
+                  newStateForPid.waitingForWrite.head._1.sequenceNr,
+                  newStateForPid.waitingForWrite.last._1.sequenceNr,
+                  updatedState.currentTransactionId)
+
+              val batch = newStateForPid.waitingForWrite.map { case (repr, _) => repr }
+              sendToJournal(updatedState.currentTransactionId, batch)
+              perPidWriteState = perPidWriteState.updated(pid, updatedState)
+
+            }
+          }
+        }
+
+        def handleJournalResponse(response: JournalProtocol.Response): Behavior[AnyRef] =
+          response match {
+            case JournalProtocol.WriteMessageSuccess(message, transactionId) =>
+              val pid = message.persistenceId
+              val sequenceNr = message.sequenceNr
+              perPidWriteState.get(pid) match {
+                case None =>
+                  context.log.debugN(
+                    "Got write success reply for event with no previous state for pid, ignoring (pid [{}], seq nr [{}], tx id [{}])",
+                    pid,
+                    sequenceNr,
+                    transactionId)
+                case Some(stateForPid) =>
+                  if (transactionId == stateForPid.currentTransactionId) {
+                    stateForPid.waitingForReply.get(sequenceNr) match {
+                      case None =>
+                        context.log.debugN(
+                          "Got write error reply for event with no waiting request for seq nr, ignoring (pid [{}], seq nr [{}], tx id [{}])",
+                          pid,
+                          sequenceNr,
+                          transactionId)
+                      case Some((_, waiting)) =>
+                        context.log.trace2(
+                          "Successfully wrote event persistence id [{}], sequence nr [{}]",
+                          pid,
+                          message.sequenceNr)
+                        waiting ! StatusReply.success(WriteAck(pid, sequenceNr))
+                        val newState = stateForPid.copy(waitingForReply = stateForPid.waitingForReply - sequenceNr)
+                        handleUpdatedStateForPid(pid, newState)
+                    }
+                  } else {
+                    if (context.log.isTraceEnabled) {
+                      context.log.traceN(
+                        "Got reply for old tx id [{}] (current [{}]) for pid [{}], ignoring",
+                        transactionId,
+                        stateForPid.currentTransactionId,
+                        pid)
+                    }
+                  }
+              }
+              Behaviors.same
+
+            case JournalProtocol.WriteMessageFailure(message, error, transactionId) =>
+              val pid = message.persistenceId
+              val sequenceNr = message.sequenceNr
+              perPidWriteState.get(pid) match {
+                case None =>
+                  context.log.debugN(
+                    "Got write error reply for event with no previous state for pid, ignoring (pid [{}], seq nr [{}], tx id [{}])",
+                    pid,
+                    sequenceNr,
+                    transactionId)
+                case Some(state) =>
+                  state.waitingForReply.get(sequenceNr) match {
+                    case None =>
+                      context.log.debugN(
+                        "Got write error reply for event with no waiting request for seq nr, ignoring (pid [{}], seq nr [{}], tx id [{}])",
+                        pid,
+                        sequenceNr,
+                        transactionId)
+                    case Some(_) =>
+                      if (!state.writeErrorHandlingInProgress && state.currentTransactionId == transactionId) {
+                        perPidWriteState =
+                          perPidWriteState.updated(pid, state.copy(writeErrorHandlingInProgress = true))
+                        context.ask(
+                          journal,
+                          (replyTo: ActorRef[JournalProtocol.Response]) =>
+                            JournalProtocol.ReplayMessages(0L, 0L, 1L, pid, replyTo.toClassic)) {
+                          case Success(JournalProtocol.RecoverySuccess(highestSequenceNr)) =>
+                            MaxSeqNrForPid(pid, highestSequenceNr, error.getMessage)
+                          case Success(unexpected) =>
+                            throw new IllegalArgumentException(
+                              s"Got unexpected reply from journal ${unexpected.getClass} for pid $pid")
+                          case Failure(exception) =>
+                            throw new RuntimeException(
+                              s"Error finding highest sequence number in journal for pid $pid",
+                              exception)
+                        }
+                      } else {
+                        context.log.traceN(
+                          "Ignoring failure for pid [{}], seq nr [{}], tx id [{}], since write error handling already in progress or old tx id (current tx id [{}])",
+                          pid,
+                          sequenceNr,
+                          transactionId,
+                          state.currentTransactionId)
+                      }
+                  }
+              }
+              Behaviors.same
+
+            case _ =>
+              Behaviors.same
+          }
+
+        Behaviors.receiveMessage {
+          case Write(persistenceId, sequenceNumber, event, metadata, tags, replyTo) =>
+            val payload = if (tags.isEmpty) event else Tagged(event, tags)
+            val repr = PersistentRepr(
+              payload,
+              persistenceId = persistenceId,
+              sequenceNr = sequenceNumber,
+              manifest = "",
+              writerUuid = writerUuid,
+              sender = pekko.actor.ActorRef.noSender)
+
+            val reprWithMeta = metadata match {
+              case Some(meta) => repr.withMetadata(meta)
+              case _          => repr
+            }
+
+            val newStateForPid =
+              perPidWriteState.get(persistenceId) match {
+                case None =>
+                  if (context.log.isTraceEnabled)
+                    context.log.traceN(
+                      "Writing event persistence id [{}], sequence nr [{}], payload {}",
+                      persistenceId,
+                      sequenceNumber,
+                      event)
+                  sendToJournal(1, Vector(reprWithMeta))
+                  StateForPid(
+                    Map((reprWithMeta.sequenceNr, (reprWithMeta, replyTo))),
+                    emptyWaitingForWrite,
+                    currentTransactionId = 1)
+                case Some(state) =>
+                  if (state.waitingForWrite.size == eventWriterSettings.maxBatchSize) {
+                    replyTo ! StatusReply.error(
+                      s"Max batch reached for pid $persistenceId, at most ${eventWriterSettings.maxBatchSize} writes for " +
+                      "the same pid may be in flight at the same time")
+                    state
+                  } else {
+                    if (context.log.isTraceEnabled)
+                      context.log.traceN(
+                        "Writing event in progress for persistence id [{}], adding sequence nr [{}], payload {} to batch",
+                        persistenceId,
+                        sequenceNumber,
+                        event)
+                    state.copy(waitingForWrite = state.waitingForWrite :+ ((reprWithMeta, replyTo)))
+                  }
+              }
+            perPidWriteState = perPidWriteState.updated(persistenceId, newStateForPid)
+            Behaviors.same
+
+          case MaxSeqNrForPid(pid, maxSeqNr, originalErrorDesc) =>
+            perPidWriteState.get(pid) match {
+              case None =>
+                context.log.debug2(
+                  "Got max seq nr with no waiting previous state for pid, ignoring (pid [{}], original error desc: {})",
+                  pid,
+                  originalErrorDesc)
+              case Some(state) =>
+                val sortedSeqs = state.waitingForReply.keys.toSeq.sorted
+                val (alreadyInJournal, needsWrite) = sortedSeqs.partition(seqNr => seqNr <= maxSeqNr)
+                if (alreadyInJournal.isEmpty) {
+                  state.waitingForReply.values.foreach {
+                    case (_, replyTo) =>
+                      replyTo ! StatusReply.error("Journal write failed")
+                  }
+                  context.log.warnN(
+                    "Failed writing event batch persistence id [{}], sequence nr [{}-{}]: {}",
+                    pid,
+                    sortedSeqs.head,
+                    sortedSeqs.last,
+                    originalErrorDesc)
+                  val newState = state.copy(waitingForReply = Map.empty, writeErrorHandlingInProgress = false)
+                  handleUpdatedStateForPid(pid, newState)
+                } else {
+                  val stateAfterWritten = alreadyInJournal
+                    .foldLeft(state) { (state, seqNr) =>
+                      val (_, replyTo) = state.waitingForReply(seqNr)
+                      replyTo ! StatusReply.success(WriteAck(pid, seqNr))
+                      state.copy(waitingForReply = state.waitingForReply - seqNr)
+                    }
+                    .copy(writeErrorHandlingInProgress = false)
+                  if (needsWrite.isEmpty) {
+                    handleUpdatedStateForPid(pid, stateAfterWritten)
+                  } else {
+                    val reprsToRewrite =
+                      stateAfterWritten.waitingForReply.values.map { case (repr, _) => repr }.toVector
+                    if (context.log.isDebugEnabled())
+                      context.log.debugN(
+                        "Partial batch was duplicates, re-triggering write of persistence id [{}], sequence nr [{}-{}]",
+                        pid,
+                        reprsToRewrite.head.sequenceNr,
+                        reprsToRewrite.last.sequenceNr)
+                    val partialRewriteState =
+                      stateAfterWritten.copy(currentTransactionId = stateAfterWritten.currentTransactionId + 1)
+                    sendToJournal(partialRewriteState.currentTransactionId, reprsToRewrite)
+                    handleUpdatedStateForPid(pid, partialRewriteState)
+                  }
+
+                }
+
+            }
+            Behaviors.same
+
+          case response: JournalProtocol.Response => handleJournalResponse(response)
+
+          case unexpected =>
+            context.log.warn("Unexpected message sent to EventWriter [{}], ignored", unexpected.getClass)
+            Behaviors.same
+
+        }
+      }
+      .narrow[Command]
+
+}

--- a/persistence/src/main/resources/reference.conf
+++ b/persistence/src/main/resources/reference.conf
@@ -266,6 +266,8 @@ pekko.persistence.journal.inmem {
 
     # Turn this on to test serialization of the events
     test-serialization = off
+    # Useful for tests, increase to make writes take time like an actual persistent journal
+    delay-writes = 0s
 }
 
 # Local file system snapshot store plugin.

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/inmem/InmemJournal.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/inmem/InmemJournal.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.persistence.journal.inmem
 
 import scala.collection.immutable
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -23,6 +24,7 @@ import pekko.actor.ActorRef
 import pekko.annotation.ApiMayChange
 import pekko.annotation.InternalApi
 import pekko.event.Logging
+import pekko.pattern.after
 import pekko.persistence.AtomicWrite
 import pekko.persistence.JournalProtocol.RecoverySuccess
 import pekko.persistence.PersistentRepr
@@ -30,6 +32,7 @@ import pekko.persistence.journal.{ AsyncWriteJournal, Tagged }
 import pekko.persistence.journal.inmem.InmemJournal.{ MessageWithMeta, ReplayWithMeta }
 import pekko.serialization.SerializationExtension
 import pekko.serialization.Serializers
+import pekko.util.JavaDurationConverters._
 import pekko.util.OptionVal
 
 import com.typesafe.config.Config
@@ -71,9 +74,14 @@ object InmemJournal {
 
   private val log = Logging(context.system, classOf[InmemJournal])
 
+  private val delayWrites = {
+    val key = "delay-writes"
+    if (cfg.hasPath(key)) cfg.getDuration(key).asScala
+    else Duration.Zero
+  }
   private val testSerialization = {
     val key = "test-serialization"
-    if (cfg.hasPath(key)) cfg.getBoolean("test-serialization")
+    if (cfg.hasPath(key)) cfg.getBoolean(key)
     else false
   }
 
@@ -92,7 +100,10 @@ object InmemJournal {
         add(p)
         eventStream.publish(InmemJournal.Write(p.payload, p.persistenceId, p.sequenceNr))
       }
-      Future.successful(Nil) // all good
+      if (delayWrites == Duration.Zero)
+        Future.successful(Nil) // all good
+      else
+        after(delayWrites)(Future.successful(Nil))(context.system)
     } catch {
       case NonFatal(e) =>
         // serialization problem

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/inmem/InmemJournal.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/inmem/InmemJournal.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.persistence.journal.inmem
 
 import scala.collection.immutable
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -32,7 +32,6 @@ import pekko.persistence.journal.{ AsyncWriteJournal, Tagged }
 import pekko.persistence.journal.inmem.InmemJournal.{ MessageWithMeta, ReplayWithMeta }
 import pekko.serialization.SerializationExtension
 import pekko.serialization.Serializers
-import pekko.util.JavaDurationConverters._
 import pekko.util.OptionVal
 
 import com.typesafe.config.Config
@@ -76,7 +75,7 @@ object InmemJournal {
 
   private val delayWrites = {
     val key = "delay-writes"
-    if (cfg.hasPath(key)) cfg.getDuration(key).asScala
+    if (cfg.hasPath(key)) cfg.getDuration(key, MILLISECONDS).millis
     else Duration.Zero
   }
   private val testSerialization = {


### PR DESCRIPTION
### Motivation
Writing events one at a time to the journal is inefficient when many actors are persisting concurrently. A shared event writer that batches writes per persistence id and handles duplicate detection improves throughput for write-heavy workloads.

### Modification
- Add `EventWriter` internal actor that batches journal writes per persistence id, handles duplicate detection via highest sequence number lookup, and supports partial batch rewrites.
- Add `EventWriterExtension` for per-journal writer instances.
- Add `event-writer` config (`max-batch-size`, `ask-timeout`) to persistence-typed `reference.conf`.
- Add `delay-writes` config to `InmemJournal` for testing write timing behavior.
- Add comprehensive `EventWriterSpec` covering duplicates, batching, partial duplicates, error propagation, and multi-pid writes.

### Result
Internal API available for batching journal writes with duplicate handling. InmemJournal supports configurable write delays for testing.

### License
This PR ports code from Akka (https://github.com/akka/akka-core/pull/32010). The Apache License 2.0 is applicable. New files carry the Akka-derived copyright header (Copyright (C) 2009-2023 Lightbend Inc.).

### Tests
- `sbt "persistence-typed-tests / Test / testOnly org.apache.pekko.persistence.typed.internal.EventWriterSpec"`

### References
Refs akka/akka-core#32010