### PR TITLE
perf: skip drainQueue buffer snapshot when all parallelism slots are full

### DIFF
--- a/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/MapAsyncPartitioned.scala
@@ -281,7 +281,7 @@ private[stream] final class MapAsyncPartitioned[In, Out, Partition](
       }
 
       private def drainQueue(): Unit = {
-        if (buffer.nonEmpty) {
+        if (buffer.nonEmpty && partitionsInProgress.size < parallelism) {
           // Snapshot the buffer because processElement may complete a Future synchronously
           // (the #20217 optimization), which re-enters pushNextIfPossible and either
           // dequeues from the buffer (ordered) or rebuilds it via filter (unordered),


### PR DESCRIPTION
### Motivation
`drainQueue()` is called on every future completion and performs an O(n) `buffer.toList` snapshot plus iteration. When all parallelism slots are occupied (`partitionsInProgress.size >= parallelism`), `canStartNextElement` returns false for every element, making the entire snapshot and iteration wasted work. This is the common steady-state case under backpressure.

### Modification
Add a guard `partitionsInProgress.size < parallelism` to the `drainQueue` condition, skipping the O(n) allocation and traversal when no new element can possibly be started.

### Result
In steady state (all parallelism slots busy), each future completion avoids an unnecessary O(n) buffer snapshot. The benefit scales with buffer size and parallelism.

### License
This change is inspired by Akka (https://github.com/akka/akka-core/pull/32031) but independently implemented for Pekko's different `MapAsyncPartitioned` architecture. The Apache License 2.0 is applicable.

### Tests
- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.scaladsl.FlowMapAsyncPartitionedSpec"`
- `sbt "stream-typed-tests / Test / testOnly org.apache.pekko.stream.MapAsyncPartitionedSpec"`

### References
Refs akka/akka-core#32031