### PR TITLE
Update jacksonCoreVersion to 2.21.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
   val logbackVersion = "1.3.15"
 
   val jacksonAnnotationsVersion = "2.21"
-  val jacksonCoreVersion = "2.21.5"
+  val jacksonCoreVersion = "2.21.6"
   val jacksonDatabindVersion = jacksonCoreVersion
 
   val scala212Version = "2.12.21"


### PR DESCRIPTION
contains security fixes - https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21.6

The main branch uses 2.22.x but I think it is best to keep 1.x on the same minor version as before.