### PR TITLE
Update workflow to use Pekko 1.7.x

### DIFF
--- a/.github/workflows/nightly-1.7-builds.yml
+++ b/.github/workflows/nightly-1.7-builds.yml
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
-          ref: 1.6.x
+          ref: 1.7.x
 
       - name: Setup Java 11
         uses: actions/setup-java@v5
@@ -135,7 +135,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
-          ref: 1.6.x
+          ref: 1.7.x
 
       - name: Setup Java ${{ matrix.javaVersion }}
         uses: actions/setup-java@v5


### PR DESCRIPTION
Job is testing wrong branch. There are 3 checkouts in this workflow and last 2 are wrong.
Probably explains at leat some of the issues causing nightly tests to fail. 1.7.x has some backported test fixes.