### PR TITLE
fix: preserve StageActor demand across fused streams

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/FusingSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/FusingSpec.scala
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.stream
 
-import scala.concurrent.{ duration, Await, Promise }
+import scala.concurrent.{ duration, Await, Future, Promise }
 
 import duration._
 
@@ -23,7 +23,7 @@ import pekko.stream.QueueOfferResult
 import pekko.stream.impl.UnfoldResourceSource
 import pekko.stream.impl.fusing.GraphInterpreter
 import pekko.stream.scaladsl._
-import pekko.stream.stage.GraphStage
+import pekko.stream.stage.{ GraphStage, GraphStageLogic, GraphStageWithMaterializedValue, OutHandler }
 import pekko.stream.testkit.TestPublisher
 import pekko.stream.testkit.StreamSpec
 import pekko.stream.testkit.Utils.TE
@@ -247,6 +247,168 @@ class FusingSpec extends StreamSpec {
         .request(5)
         .expectNext(1, 2)
         .expectError(ex)
+    }
+
+    // Regression tests for https://github.com/apache/pekko/issues/3459
+    // Matches the UDP connector pattern: getStageActor receives messages from an external
+    // actor, pushes only when isAvailable(out) is true, drops otherwise.
+    def externalActorSource(
+        dropped: java.util.concurrent.atomic.AtomicInteger,
+        ready: Promise[Done],
+        beforePush: GraphStageLogic => Unit = (_: GraphStageLogic) => ()): Source[Int, Future[pekko.actor.ActorRef]] = {
+      val stageActorPromise = Promise[pekko.actor.ActorRef]()
+      Source.fromGraph(new GraphStageWithMaterializedValue[SourceShape[Int], Future[pekko.actor.ActorRef]] {
+        val out = Outlet[Int]("external.out")
+        override val shape = SourceShape(out)
+        override def createLogicAndMaterializedValue(
+            inheritedAttributes: Attributes): (GraphStageLogic, Future[pekko.actor.ActorRef]) = {
+          val logic = new GraphStageLogic(shape) {
+            override def preStart(): Unit =
+              stageActorPromise.success(getStageActor {
+                case (_, elem: Int) =>
+                  beforePush(this)
+                  if (isAvailable(out)) push(out, elem)
+                  else dropped.incrementAndGet()
+                case _ => // ignore non-Int messages
+              }.ref)
+            setHandler(out,
+              new OutHandler {
+                // Let tests wait until initial demand reaches the source port before sending a burst.
+                override def onPull(): Unit = ready.trySuccess(Done)
+              })
+          }
+          (logic, stageActorPromise.future)
+        }
+      })
+    }
+
+    def sendBurst(
+        stageActorFuture: Future[pekko.actor.ActorRef],
+        ready: Promise[Done],
+        downstream: pekko.stream.testkit.TestSubscriber.Probe[Int],
+        elementCount: Int): Unit = {
+      downstream.request(elementCount)
+      val stageActor = Await.result(stageActorFuture, 3.seconds)
+      Await.result(ready.future, 3.seconds)
+      (1 to elementCount).foreach(stageActor ! _)
+      within(5.seconds) {
+        downstream.expectNextN(elementCount.toLong)
+      }
+      downstream.cancel()
+    }
+
+    "replenish demand per-element for external async sources across an async boundary" in {
+      val elementCount = 100
+      val dropped = new java.util.concurrent.atomic.AtomicInteger(0)
+      val ready = Promise[Done]()
+
+      val (stageActorFuture, downstream) = externalActorSource(dropped, ready)
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .toMat(TestSink[Int]())(Keep.both)
+        .run()
+
+      sendBurst(stageActorFuture, ready, downstream, elementCount)
+      dropped.get() should ===(0)
+    }
+
+    "replenish demand independently of fused topology depth" in {
+      val elementCount = 8
+      val dropped = new java.util.concurrent.atomic.AtomicInteger(0)
+      val ready = Promise[Done]()
+      val deepSource = (1 to 256).foldLeft(externalActorSource(dropped, ready)) {
+        case (source, _) => source.map(identity)
+      }
+
+      val (stageActorFuture, downstream) = deepSource
+        .async
+        .addAttributes(asyncBoundaryInputBuffer)
+        .toMat(TestSink[Int]())(Keep.both)
+        .run()
+
+      sendBurst(stageActorFuture, ready, downstream, elementCount)
+      dropped.get() should ===(0)
+    }
+
+    "replenish demand when the shell sync processing limit is one" in {
+      val elementCount = 8
+      val dropped = new java.util.concurrent.atomic.AtomicInteger(0)
+      val ready = Promise[Done]()
+      val deepSource = (1 to 32).foldLeft(externalActorSource(dropped, ready)) {
+        case (source, _) => source.map(identity)
+      }
+
+      val (stageActorFuture, downstream) = deepSource
+        .async
+        .addAttributes(ActorAttributes.syncProcessingLimit(1) and asyncBoundaryInputBuffer)
+        .toMat(TestSink[Int]())(Keep.both)
+        .run()
+
+      sendBurst(stageActorFuture, ready, downstream, elementCount)
+      dropped.get() should ===(0)
+    }
+
+    "leave activeStage cleared when a stage actor callback completes its stage" in {
+      val interpreterPromise = Promise[GraphInterpreter]()
+      val stageActorPromise = Promise[pekko.actor.ActorRef]()
+      val ready = Promise[Done]()
+
+      val source =
+        Source.fromGraph(new GraphStageWithMaterializedValue[SourceShape[Int], Future[pekko.actor.ActorRef]] {
+          val out = Outlet[Int]("completion.out")
+          override val shape = SourceShape(out)
+          override def createLogicAndMaterializedValue(
+              inheritedAttributes: Attributes): (GraphStageLogic, Future[pekko.actor.ActorRef]) = {
+            val logic = new GraphStageLogic(shape) {
+              override def preStart(): Unit = {
+                interpreterPromise.success(interpreter)
+                stageActorPromise.success(getStageActor { case _ => completeStage() }.ref)
+              }
+              setHandler(out,
+                new OutHandler {
+                  override def onPull(): Unit = ready.trySuccess(Done)
+                })
+            }
+            (logic, stageActorPromise.future)
+          }
+        })
+
+      val (stageActorFuture, done) = source.toMat(Sink.ignore)(Keep.both).run()
+      Await.result(ready.future, 3.seconds)
+      Await.result(stageActorFuture, 3.seconds) ! "complete"
+      Await.result(done, 3.seconds) should ===(Done)
+      Await.result(interpreterPromise.future, 3.seconds).activeStage should be(null)
+    }
+
+    "stop a lazy stage actor dispatch after its handler fails" in {
+      val failure = TE("stage actor handler failed")
+      val invocations = new java.util.concurrent.atomic.AtomicInteger(0)
+      val entered = new java.util.concurrent.CountDownLatch(1)
+      val release = new java.util.concurrent.CountDownLatch(1)
+      val ready = Promise[Done]()
+      val dropped = new java.util.concurrent.atomic.AtomicInteger(0)
+      val source = externalActorSource(
+        dropped,
+        ready,
+        _ => {
+          invocations.incrementAndGet()
+          entered.countDown()
+          release.await(3, java.util.concurrent.TimeUnit.SECONDS)
+          throw failure
+        })
+
+      val (stageActorFuture, done) = source.toMat(Sink.ignore)(Keep.both).run()
+      Await.result(ready.future, 3.seconds)
+      val stageActor = Await.result(stageActorFuture, 3.seconds)
+      stageActor ! 1
+      try {
+        entered.await(3, java.util.concurrent.TimeUnit.SECONDS) should be(true)
+        (2 to 100).foreach(stageActor ! _)
+      } finally release.countDown()
+
+      Await.result(done.failed, 3.seconds) should ===(failure)
+      invocations.get() should ===(1)
+      dropped.get() should ===(0)
     }
 
     "use multiple actors when there are asynchronous boundaries in the subflows (manual)" in {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -629,12 +629,17 @@ import org.reactivestreams.Subscription
     @InternalStableApi
     override def execute(eventLimit: Int): Int = {
       if (!shell.waitingForShutdown) {
-        shell.interpreter.runAsyncInput(logic, evt, promise, handler)
-        if (eventLimit == 1 && shell.interpreter.isSuspended) {
-          shell.flushOutputs()
-          shell.sendResume(true)
-          0
-        } else shell.runBatch(eventLimit - 1)
+        handler match {
+          case eventLimitHandler: GraphInterpreter.EventLimitHandler =>
+            shell.runEventLimitHandler(logic, evt, promise, eventLimitHandler, eventLimit)
+          case _ =>
+            shell.interpreter.runAsyncInput(logic, evt, promise, handler)
+            if (eventLimit == 1 && shell.interpreter.isSuspended) {
+              shell.flushOutputs()
+              shell.sendResume(true)
+              0
+            } else shell.runBatch(eventLimit - 1)
+        }
       } else {
         eventLimit
       }
@@ -719,6 +724,7 @@ import org.reactivestreams.Subscription
   // TODO: Better heuristic here
   private val abortLimit = shellEventLimit * 2
   private var resumeScheduled = false
+  private var waitingEventLimitHandlers: util.ArrayDeque[GraphInterpreter.EventLimitHandler] = _
 
   def isInitialized: Boolean = self != null
   def init(
@@ -798,27 +804,65 @@ import org.reactivestreams.Subscription
     else enqueueToShortCircuit(resume)
   }
 
-  def runBatch(actorEventLimit: Int): Int = {
+  def runEventLimitHandler(
+      logic: GraphStageLogic,
+      evt: Any,
+      promise: Promise[Done],
+      handler: GraphInterpreter.EventLimitHandler,
+      actorEventLimit: Int): Int = {
     try {
-      val usingShellLimit = shellEventLimit < actorEventLimit
-      val remainingQuota = interpreter.execute(Math.min(actorEventLimit, shellEventLimit))
-      flushOutputs()
-      if (interpreter.isCompleted) {
-        // Cannot stop right away if not completely subscribed
-        if (canShutDown) interpreterCompleted = true
-        else {
-          waitingForShutdown = true
-          val subscriptionTimeout = attributes.mandatoryAttribute[ActorAttributes.StreamSubscriptionTimeout].timeout
-          mat.scheduleOnce(subscriptionTimeout, () => self ! new Abort(GraphInterpreterShell.this))
-        }
-      } else if (interpreter.isSuspended && !resumeScheduled) sendResume(!usingShellLimit)
+      val actorLimitAfterAsyncInput = actorEventLimit - 1
+      val interpreterLimit = Math.min(actorLimitAfterAsyncInput, shellEventLimit)
+      val handlerRemaining = interpreter.runAsyncInput(logic, evt, promise, handler, interpreterLimit)
+      val remaining = interpreter.execute(handlerRemaining)
 
-      if (usingShellLimit) actorEventLimit - shellEventLimit + remainingQuota else remainingQuota
+      if (handler.isWaitingForInterpreter) {
+        if (interpreter.isSuspended) {
+          if (waitingEventLimitHandlers eq null)
+            waitingEventLimitHandlers = new util.ArrayDeque[GraphInterpreter.EventLimitHandler]()
+          waitingEventLimitHandlers.addLast(handler)
+        } else handler.onInterpreterIdle()
+      }
+
+      finishBatch(actorLimitAfterAsyncInput - interpreterLimit + remaining)
     } catch {
       case NonFatal(e) =>
         tryAbort(e)
         actorEventLimit - 1
     }
+  }
+
+  def runBatch(actorEventLimit: Int): Int = {
+    try {
+      val interpreterLimit = Math.min(actorEventLimit, shellEventLimit)
+      val remaining = interpreter.execute(interpreterLimit)
+      finishBatch(actorEventLimit - interpreterLimit + remaining)
+    } catch {
+      case NonFatal(e) =>
+        tryAbort(e)
+        actorEventLimit - 1
+    }
+  }
+
+  private def finishBatch(remainingQuota: Int): Int = {
+    flushOutputs()
+    if (interpreter.isCompleted) {
+      // Cannot stop right away if not completely subscribed
+      if (canShutDown) interpreterCompleted = true
+      else {
+        waitingForShutdown = true
+        val subscriptionTimeout = attributes.mandatoryAttribute[ActorAttributes.StreamSubscriptionTimeout].timeout
+        mat.scheduleOnce(subscriptionTimeout, () => self ! new Abort(GraphInterpreterShell.this))
+      }
+    } else if (interpreter.isSuspended && !resumeScheduled) sendResume(remainingQuota == 0)
+
+    if (!interpreter.isSuspended && (waitingEventLimitHandlers ne null)) {
+      val handlers = waitingEventLimitHandlers
+      waitingEventLimitHandlers = null
+      while (!handlers.isEmpty) handlers.removeFirst().onInterpreterIdle()
+    }
+
+    remainingQuota
   }
 
   private def flushOutputs(): Unit = {

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphInterpreter.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GraphInterpreter.scala
@@ -61,6 +61,19 @@ import pekko.stream.stage._
   final val KeepGoingMask = 0x3FFFFFF
 
   /**
+   * INTERNAL API
+   *
+   * An async input handler that shares the interpreter event budget of the enclosing shell. The handler returns the
+   * unused part of `eventLimit`. If it has to stop while interpreter events are still pending, the shell invokes
+   * `onInterpreterIdle` after those events have been processed.
+   */
+  @InternalApi private[stream] trait EventLimitHandler extends (Any => Unit) {
+    def apply(event: Any, eventLimit: Int): Int
+    def isWaitingForInterpreter: Boolean
+    def onInterpreterIdle(): Unit
+  }
+
+  /**
    * Marker object that indicates that a port holds no element since it was already grabbed. The port is still pullable,
    * but there is no more element to grab.
    */
@@ -592,6 +605,41 @@ import pekko.stream.stage._
         afterStageHasRun(logic)
       } finally currentInterpreterHolder(0) = previousInterpreter
     }
+
+  /** INTERNAL API */
+  @InternalApi private[stream] def runAsyncInput(
+      logic: GraphStageLogic,
+      evt: Any,
+      promise: Promise[Done],
+      handler: EventLimitHandler,
+      eventLimit: Int): Int = {
+    var eventsRemaining = eventLimit
+    if (!isStageCompleted(logic)) {
+      if (GraphInterpreter.Debug) println(s"$Name ASYNC $evt ($handler) [$logic]")
+      val currentInterpreterHolder = _currentInterpreter.get()
+      val previousInterpreter = currentInterpreterHolder(0)
+      currentInterpreterHolder(0) = this
+      try {
+        activeStage = logic
+        try {
+          eventsRemaining = handler(evt, eventLimit)
+          if (promise ne GraphStageLogic.NoPromise) {
+            promise.success(Done)
+            logic.onFeedbackDispatched(promise)
+          }
+        } catch {
+          case NonFatal(ex) =>
+            if (promise ne GraphStageLogic.NoPromise) {
+              promise.failure(ex)
+              logic.onFeedbackDispatched(promise)
+            }
+            logic.failStage(ex)
+        }
+        afterStageHasRun(logic)
+      } finally currentInterpreterHolder(0) = previousInterpreter
+    }
+    eventsRemaining
+  }
 
   // Decodes and processes a single event for the given connection
   @InternalStableApi

--- a/stream/src/main/scala/org/apache/pekko/stream/stage/GraphStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/stage/GraphStage.scala
@@ -344,6 +344,7 @@ object GraphStageLogic {
 
     private final val SchedStateIdle: Int = 0
     private final val SchedStateScheduled: Int = 1
+    private final val SchedStateStopped: Int = 2
 
     /**
      * Lazy-path dispatch: producers enqueue into a Vyukov MPSC queue and elect a single drain via
@@ -375,7 +376,7 @@ object GraphStageLogic {
         handler: Any => Unit,
         drainBatchSize: Int)
         extends AbstractNodeQueue[(ActorRef, Any)]
-        with (Any => Unit) {
+        with GraphInterpreter.EventLimitHandler {
 
       // IDLE/SCHEDULED election state. VarHandle avoids per-instance AtomicInteger.
       @volatile var state: Int = SchedStateIdle
@@ -388,12 +389,13 @@ object GraphStageLogic {
       private def casState(expect: Int, update: Int): Boolean =
         LazyDispatch.stateHandle.compareAndSet(this, expect, update)
 
+      private var waitingForInterpreter = false
+
       // null msg = drain signal from onAsyncInput; non-null = (ActorRef, Any) tuple from FunctionRef.
       override def apply(msg: Any): Unit =
-        if (msg == null) drain()
-        else {
+        if (msg != null) {
           val pair = msg.asInstanceOf[(ActorRef, Any)]
-          if (!interpreter.isStageCompleted(logic)) {
+          if (!interpreter.isStageCompleted(logic) && getState() != SchedStateStopped) {
             add(pair)
             if (getState() == SchedStateIdle && casState(SchedStateIdle, SchedStateScheduled)) {
               if (interpreter.isStageCompleted(logic)) setState(SchedStateIdle)
@@ -404,36 +406,92 @@ object GraphStageLogic {
 
       private def scheduleDrain(): Unit =
         // 1 AsyncInput + 1 Envelope per drain batch (amortized across up to drainBatchSize tells).
-        // `this` serves as the drain callback (Any => Unit); onAsyncInput calls apply(null).
+        // `this` serves as both the producer callback and the event-limit-aware drain callback.
         interpreter.onAsyncInput(logic, null, NoPromise, this)
 
-      private def drain(): Unit = {
-        val limit = drainBatchSize
-        var processed = 0
-        while (processed < limit) {
-          if (interpreter.isStageCompleted(logic)) {
-            while (poll() ne null) ()
-            setState(SchedStateIdle)
-            return
+      override def apply(event: Any, eventLimit: Int): Int = {
+        require(event == null, "LazyDispatch drain event must be null")
+        drain(eventLimit)
+      }
+
+      override def isWaitingForInterpreter: Boolean = waitingForInterpreter
+
+      override def onInterpreterIdle(): Unit = {
+        waitingForInterpreter = false
+        if (interpreter.isStageCompleted(logic)) stopDispatch()
+        else publishIdleOrSchedule()
+      }
+
+      private def drain(eventLimit: Int): Int = {
+        var eventsRemaining = eventLimit
+        waitingForInterpreter = false
+        try {
+          // BoundaryEvents can overtake a shell resume when the shell-specific limit is reached. Finish any
+          // previously queued interpreter work before dispatching another StageActor message.
+          if (interpreter.isSuspended) {
+            eventsRemaining = interpreter.execute(eventsRemaining)
+            if (interpreter.isSuspended) {
+              waitingForInterpreter = true
+              return eventsRemaining
+            }
           }
-          val item = poll()
-          if (item eq null) {
-            setState(SchedStateIdle)
-            // Recheck race: a producer may have added between `poll == null` and the IDLE publish above.
-            if (!isEmpty && casState(SchedStateIdle, SchedStateScheduled))
-              scheduleDrain()
-            return
+
+          val limit = drainBatchSize
+          var processed = 0
+          // The AsyncInput itself accounts for the first callback. Even when it consumed the last actor quota,
+          // dispatch one message and defer any interpreter work it creates to the next shell resume.
+          while (processed < limit && (eventsRemaining > 0 || processed == 0)) {
+            if (interpreter.isStageCompleted(logic)) {
+              stopDispatch()
+              return eventsRemaining
+            }
+            val item = poll()
+            if (item eq null) {
+              publishIdleOrSchedule()
+              return eventsRemaining
+            }
+
+            // execute() changes activeStage while propagating the element. Set it explicitly for every
+            // StageActor callback; never restore a logic that execute() may have finalized and released.
+            interpreter.activeStage = logic
+            handler(item)
+            // Most StageActor callbacks only update local stage state. Avoid entering execute() unless the
+            // callback actually enqueued interpreter work; demand-producing callbacks still drain that work
+            // before another message is dispatched.
+            if (interpreter.isSuspended) eventsRemaining = interpreter.execute(eventsRemaining)
+            processed += 1
+
+            if (interpreter.isStageCompleted(logic)) {
+              stopDispatch()
+              return eventsRemaining
+            }
+            if (interpreter.isSuspended) {
+              waitingForInterpreter = true
+              return eventsRemaining
+            }
           }
-          handler(item)
-          processed += 1
+
+          publishIdleOrSchedule()
+          eventsRemaining
+        } catch {
+          case ex: Throwable =>
+            stopDispatch()
+            throw ex
         }
-        // The last handler(item) may have completed the stage; check before re-scheduling.
-        if (interpreter.isStageCompleted(logic)) {
-          while (poll() ne null) ()
+      }
+
+      private def publishIdleOrSchedule(): Unit = {
+        if (isEmpty) {
           setState(SchedStateIdle)
-          return
-        }
-        scheduleDrain()
+          // Recheck race: a producer may have added between observing empty and publishing IDLE above.
+          if (!isEmpty && casState(SchedStateIdle, SchedStateScheduled)) scheduleDrain()
+        } else scheduleDrain()
+      }
+
+      private def stopDispatch(): Unit = {
+        waitingForInterpreter = false
+        setState(SchedStateStopped)
+        while (poll() ne null) ()
       }
     }
 


### PR DESCRIPTION
### Motivation

`StageActor` lazy dispatch coalesces a burst into one async callback. A callback can enqueue interpreter work that replenishes downstream demand; dispatching the next message before that work runs makes it observe stale demand and can drop data, as reported in #3459.

Fixed nested calls such as `interpreter.execute(2)` or `execute(16)` are not a general fix: the required work depends on the fused topology depth, and the nested work is not charged to the actor shell's processing quota. Restoring a saved `activeStage` is also unsafe when interpreter execution may have completed and released that stage.

### Modification

- Add an internal event-limit-aware async handler contract so lazy `StageActor` dispatch and the graph interpreter share the enclosing shell's event budget.
- Drain callback-generated interpreter work before dispatching the next `StageActor` message. If the budget is exhausted, park the dispatcher and resume it only after the interpreter queue becomes idle; this has no topology-dependent event limit.
- Avoid entering `GraphInterpreter.execute` when a callback enqueues no interpreter work, preserving the common no-graph-work hot path.
- Set `activeStage` before every callback without restoring a potentially finalized stage.
- Stop and clear queued dispatch after stage completion or callback failure.
- Add directional tests for per-element demand replenishment, a 256-stage fused topology, `sync-processing-limit = 1`, stage completion, and callback failure.

### Result

Demand is replenished before the next `StageActor` message independently of fused topology depth. Actor/interpreter fairness remains bounded by the existing shell quota, lazy dispatch still coalesces mailbox traffic, and completed or failed stages are not dispatched again.

The original `pekko-connectors` UDP reproduction was run from connector commit `1c15f3b6f`; only `PekkoCoreDependency.currentVersion` changed:

| Pekko Core | `sbt "udp/test"` |
| --- | --- |
| `2.0.0-M4` | 1/5 passed; all four Scala/Java 100-datagram send/receive tests timed out |
| `2.0.0-M4+14-3f07c449-SNAPSHOT` | 5/5 passed |

This directly verifies the connector regression, not only the reduced Core reproducer.

The direct `StageActorRefBenchmark.lazy_stage_actor_ref_tell_10k` JMH benchmark was run on the same machine and OpenJDK 25.0.2 with `-wi 3 -i 5 -w 2s -r 2s -f 3`:

| Revision | Throughput (ops/s, JMH 99.9% error) |
| --- | ---: |
| `origin/main` (`6be39c658f`) | 26,285,866 ± 6,002,205 |
| This PR | 27,987,687 ± 3,124,268 |

The PR point estimate is 6.5% higher, but the confidence intervals overlap. The supported conclusion is that this run found no measurable throughput regression, not that the change is statistically faster.

### Tests

- `pekko-connectors`: `sbt "udp/test"` — 2.0.0-M4 failed 4/5; PR snapshot passed 5/5.
- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.FusingSpec org.apache.pekko.stream.scaladsl.StageActorRefSpec org.apache.pekko.stream.scaladsl.ActorRefSourceSpec org.apache.pekko.stream.scaladsl.StreamRefsSpec"` — 80/80 passed.
- `sbt -Dpekko.stream.fuzzing-mode=on "stream-tests / Test / testOnly org.apache.pekko.stream.FusingSpec"` — 24/24 passed with randomized event ordering and chasing disabled.
- `sbt "stream-tests / Test / testOnly org.apache.pekko.stream.impl.fusing.LifecycleInterpreterSpec"` — 13/13 passed.
- `sbt validatePullRequest` — Streams suite passed 3,418/3,418. The aggregate command failed outside this change: LevelDB JNI is unavailable on this ARM64 host; two Remote tests failed on local bind/TLS timing; `IntegrationDocTest` failed while instantiating `UnboundedMailbox`.
- `sbt "stream / mimaReportBinaryIssues" "++3.3.8" "stream / mimaReportBinaryIssues"` — passed.
- `sbt headerCreateAll "+headerCheckAll" checkCodeStyle`, native scalafmt, and `git diff --check` — passed.
- `sbt "bench-jmh / Jmh / run -wi 3 -i 5 -w 2s -r 2s -f 3 .*StageActorRefBenchmark.lazy_stage_actor_ref_tell_10k.*"` — results shown above.

### References

Fixes #3459
