### PR TITLE
docs: document post-handshake session verification for TLS

### DIFF
--- a/docs/src/main/paradox/remote-security.md
+++ b/docs/src/main/paradox/remote-security.md
@@ -121,6 +121,58 @@ You have a few choices how to set up certificates and hostname verification:
     * If keys/certificates are stolen, only the same node can access the cluster (unless DNS is tampered with as well).
       You can revoke single certificates.
 
+### Custom post-handshake session verification
+
+After every successful TLS handshake, Pekko calls back into the configured `SSLEngineProvider` to allow additional
+verification of the session:
+
+```
+def verifyClientSession(hostname: String, session: SSLSession): Option[Throwable]
+def verifyServerSession(hostname: String, session: SSLSession): Option[Throwable]
+```
+
+Returning `None` accepts the session. Returning `Some(cause)` rejects it and the connection is failed with that cause.
+`verifyClientSession` is called on the side that initiated the connection, `verifyServerSession` on the side that
+accepted it.
+
+The default `ConfigSSLEngineProvider` accepts every session that completed the handshake, because the certificate chain
+has already been validated against the configured trust-store, and `hostname-verification` covers the usual case of
+checking that you reached the host you expected. Prefer `hostname-verification=on` over a custom verifier whenever the
+peer hostnames are known up front.
+
+A verifier is useful for authorization checks the trust-store cannot express. A common example is a shared internal CA:
+every node in the organisation holds a certificate signed by the same CA, so the trust-store accepts all of them, but
+only a subset should be allowed into this particular cluster. Subclass `ConfigSSLEngineProvider` and inspect the peer
+certificate:
+
+@@snip [SSLEngineProviderDocSpec.scala](/docs/src/test/scala/docs/remoting/SSLEngineProviderDocSpec.scala) { #ssl-engine-provider-session-verification }
+
+The provider is selected by class name, and the constructor taking a single `ActorSystem` is the one Pekko uses:
+
+```
+pekko.remote.artery {
+  transport = tls-tcp
+  ssl.ssl-engine-provider = "docs.remoting.ClusterScopedSSLEngineProvider"
+}
+```
+
+Requiring mutual authentication is what makes these checks meaningful on the accepting side. With
+`require-mutual-authentication = on` (the default) the accepting side requests a certificate from the connecting peer,
+so the peer certificates are available in `verifyServerSession`. If mutual authentication is disabled, the connecting
+peer presents no certificate and `getPeerCertificates` throws `SSLPeerUnverifiedException`.
+
+@@@ note
+
+Both methods are invoked on every handshake, so keep them cheap and non-blocking. Inspect only the already-parsed
+`SSLSession`; do not perform I/O such as CRL or OCSP lookups inline.
+
+@@@
+
+The built-in `RotatingKeysSSLEngineProvider` uses this same mechanism: it deliberately does not use
+`hostname-verification`, and instead verifies after the handshake that the peer certificate shares at least one subject
+name (CN or SAN) with its own certificate. See
+@ref:[mTLS with rotated certificates in Kubernetes](#mtls-with-rotated-certificates-in-kubernetes).
+
 See also a description of the settings in the @ref:[Remote Configuration](remoting-artery.md#remote-configuration-artery)
 section.
 

--- a/docs/src/test/scala/docs/remoting/SSLEngineProviderDocSpec.scala
+++ b/docs/src/test/scala/docs/remoting/SSLEngineProviderDocSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package docs.remoting
+
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLSession
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.event.Logging
+import pekko.event.MarkerLoggingAdapter
+import pekko.remote.artery.tcp.ConfigSSLEngineProvider
+
+import com.typesafe.config.Config
+
+// #ssl-engine-provider-session-verification
+class ClusterScopedSSLEngineProvider(config: Config, log: MarkerLoggingAdapter)
+    extends ConfigSSLEngineProvider(config, log) {
+
+  def this(system: ActorSystem) =
+    this(
+      system.settings.config.getConfig("pekko.remote.artery.ssl.config-ssl-engine"),
+      Logging.withMarker(system, classOf[ClusterScopedSSLEngineProvider].getName))
+
+  private val allowedNames = Set("my-service")
+
+  private def verify(session: SSLSession): Option[Throwable] =
+    session.getPeerCertificates.headOption match {
+      case Some(x509: X509Certificate) =>
+        val subject = x509.getSubjectX500Principal.getName
+        if (allowedNames.exists(subject.contains)) None
+        else Some(new IllegalArgumentException(s"Peer [$subject] is not allowed to join this cluster"))
+      case _ =>
+        Some(new IllegalArgumentException("No X.509 peer certificate presented"))
+    }
+
+  override def verifyClientSession(hostname: String, session: SSLSession): Option[Throwable] =
+    verify(session)
+
+  override def verifyServerSession(hostname: String, session: SSLSession): Option[Throwable] =
+    verify(session)
+}
+// #ssl-engine-provider-session-verification


### PR DESCRIPTION
## Motivation

The Artery `SSLEngineProvider` trait exposes `verifyClientSession` and `verifyServerSession`. `ArteryTcpTransport` invokes them after every successful TLS handshake and fails the connection when they return `Some(cause)`:

https://github.com/apache/pekko/blob/main/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ArteryTcpTransport.scala#L145
https://github.com/apache/pekko/blob/main/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ArteryTcpTransport.scala#L261

The mechanism works and needs no code change, but it was only described in the `RotatingKeysSSLEngineProvider` section of the docs. Users on the default JKS-based `ConfigSSLEngineProvider` (whose `verify*` methods return `None`) had no indication that overriding them is a supported extension point.

## Changes

Adds a "Custom post-handshake session verification" subsection to `remote-security.md`, under the existing SSL/TLS configuration section:

- Documents both callbacks and their return contract.
- States that `hostname-verification=on` is preferred when peer hostnames are known, so the verifier is not presented as a substitute for it.
- Explains the dependency on `require-mutual-authentication` — with it off, the accepting side gets no peer certificate and `getPeerCertificates` throws `SSLPeerUnverifiedException`.
- Notes the callbacks run on every handshake and should avoid blocking I/O such as CRL/OCSP lookups.
- Cross-references `RotatingKeysSSLEngineProvider` as the built-in user of the same mechanism.

The example is a compiled snippet (`docs/src/test/scala/docs/remoting/SSLEngineProviderDocSpec.scala`) pulled in with `@@snip`, following the convention used elsewhere in the docs, so it cannot silently rot. It covers the shared-internal-CA case: every node's certificate is signed by the same CA and therefore accepted by the trust-store, but only a subset should be allowed into a given cluster.

Docs only — no production code or configuration is changed.

## Tests

- `sbt docs/Test/compile` passes; the snippet compiles against the real `ConfigSSLEngineProvider` API.
- `sbt docs/scalafmt` run; the snippet is unchanged by it.
- `sbt docs/headerCreateAll` generated the license header on the new file.
- `sbt docs/paradox` was not run locally; relying on CI to validate the `@@snip` reference and link rendering.
- No MiMa run: no public API, binary shape, or serialization change.

## References

- `SSLEngineProvider` trait: `remote/src/main/scala/org/apache/pekko/remote/artery/tcp/SSLEngineProvider.scala`
- Existing no-op implementations: `remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ConfigSSLEngineProvider.scala`
- Reference implementation using the hook: `remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ssl/RotatingKeysSSLEngineProvider.scala`