### PR TITLE
feat: add ByteString slice-free copyToArray and decodeString overloads

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ByteStringSpec.scala
@@ -1744,6 +1744,185 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
     }
   }
 
+  "ByteString.copyToArray with a source offset" must {
+    // Same content in every internal representation, so the new overload is exercised against
+    // the compacted, sliced, two-fragment and multi-fragment layouts.
+    def representations(bytes: Array[Byte]): List[(String, ByteString)] = {
+      val n = bytes.length
+      val whole = ByteString(bytes)
+      var result = List("compact" -> whole.compact, "whole" -> whole)
+      if (n >= 1) {
+        val padded = ByteString(Array[Byte](0x7F, 0x7F)) ++ whole ++ ByteString(Array[Byte](0x7F))
+        result ::= "sliced" -> padded.drop(2).dropRight(1)
+        result ::= "per-byte rope" -> bytes.map(b => ByteString(Array(b))).reduce(_ ++ _)
+      }
+      if (n >= 2) result ::= "two fragments" -> (ByteString(bytes.take(1)) ++ ByteString(bytes.drop(1)))
+      if (n >= 4) {
+        val q = n / 4
+        result ::= "four fragments" -> (ByteString(bytes.slice(0, q)) ++ ByteString(bytes.slice(q, 2 * q)) ++
+        ByteString(bytes.slice(2 * q, 3 * q)) ++ ByteString(bytes.slice(3 * q, n)))
+      }
+      result
+    }
+
+    def sample(n: Int): Array[Byte] = Array.tabulate[Byte](n)(i => ((i * 31 + 7) % 251).toByte)
+
+    "copy the same bytes as slice(...).copyToArray, for every offset and length" in {
+      for (n <- List(0, 1, 2, 3, 8, 16, 17, 64)) {
+        val bytes = sample(n)
+        for {
+          (name, bs) <- representations(bytes)
+          srcOffset <- -1 to n
+          destOffset <- List(0, 1, 3)
+          len <- List(0, 1, 3, n, n + 5)
+        } withClue(s"size $n, $name, srcOffset $srcOffset, destOffset $destOffset, len $len: ") {
+          val destSize = n + 8
+          val actual = Array.fill[Byte](destSize)(0x7F.toByte)
+          val expected = Array.fill[Byte](destSize)(0x7F.toByte)
+          val expectedCopied =
+            if (srcOffset < 0 || len <= 0 || srcOffset >= n) 0
+            else math.max(0, math.min(math.min(len, n - srcOffset), destSize - destOffset))
+          if (expectedCopied > 0) System.arraycopy(bytes, srcOffset, expected, destOffset, expectedCopied)
+
+          bs.copyToArray(srcOffset, actual, destOffset, len) should ===(expectedCopied)
+          actual should ===(expected)
+        }
+      }
+    }
+
+    "clamp out of range arguments instead of throwing" in {
+      val bs = ByteString(sample(8))
+      val dest = new Array[Byte](8)
+      bs.copyToArray(-1, dest, 0, 4) should ===(0)
+      bs.copyToArray(0, dest, -1, 4) should ===(0)
+      bs.copyToArray(8, dest, 0, 4) should ===(0)
+      bs.copyToArray(100, dest, 0, 4) should ===(0)
+      bs.copyToArray(0, dest, 0, 0) should ===(0)
+      bs.copyToArray(0, dest, 0, -1) should ===(0)
+      bs.copyToArray(0, dest, 8, 4) should ===(0)
+    }
+
+    "not write past the end of the destination" in {
+      val bs = ByteString(sample(64))
+      val dest = Array.fill[Byte](10)(0x7F.toByte)
+      bs.copyToArray(0, dest, 6, 64) should ===(4)
+      dest.take(6) should ===(Array.fill[Byte](6)(0x7F.toByte))
+    }
+
+    "leave an empty ByteString as a no-op" in {
+      val dest = Array.fill[Byte](4)(0x7F.toByte)
+      ByteString.empty.copyToArray(0, dest, 0, 4) should ===(0)
+      dest should ===(Array.fill[Byte](4)(0x7F.toByte))
+    }
+
+    // A fragmented ByteString locates the starting fragment through a cached hint, which is only
+    // a shortcut when the next call lands on or after the remembered fragment. These walk a rope
+    // forwards, backwards and in a scattered order so the hit, resume-forward and rescan paths
+    // are all taken, and each result is checked against the same copy made from the flat bytes.
+    "copy correctly under repeated access on a fragmented ByteString" in {
+      val bytes = sample(200)
+      val rope = (0 until 200 by 7).map(i => ByteString(bytes.slice(i, math.min(i + 7, 200)))).reduce(_ ++ _)
+      val forwards = 0 until 200 by 3
+      val orders =
+        List("forwards" -> forwards, "backwards" -> forwards.reverse,
+          "scattered" -> forwards.sortBy(i => (i * 71) % 97))
+      for {
+        (orderName, offsets) <- orders
+        len <- List(1, 5, 20)
+        srcOffset <- offsets
+      } withClue(s"$orderName, srcOffset $srcOffset, len $len: ") {
+        val actual = Array.fill[Byte](len)(0x7F.toByte)
+        val expected = Array.fill[Byte](len)(0x7F.toByte)
+        val copied = math.min(len, 200 - srcOffset)
+        System.arraycopy(bytes, srcOffset, expected, 0, copied)
+
+        rope.copyToArray(srcOffset, actual, 0, len) should ===(copied)
+        actual should ===(expected)
+      }
+    }
+  }
+
+  "ByteString.decodeString over a range" must {
+    def representations(bytes: Array[Byte]): List[(String, ByteString)] = {
+      val n = bytes.length
+      val whole = ByteString(bytes)
+      var result = List("compact" -> whole.compact, "whole" -> whole)
+      if (n >= 1) {
+        val padded = ByteString(Array[Byte](0x7F, 0x7F)) ++ whole ++ ByteString(Array[Byte](0x7F))
+        result ::= "sliced" -> padded.drop(2).dropRight(1)
+        result ::= "per-byte rope" -> bytes.map(b => ByteString(Array(b))).reduce(_ ++ _)
+      }
+      if (n >= 2) result ::= "two fragments" -> (ByteString(bytes.take(1)) ++ ByteString(bytes.drop(1)))
+      result
+    }
+
+    val texts = List("", "a", "hello world", "Content-Type: application/json", "héllo wörld", "\u00e9\u00e8\u00ea")
+
+    "decode the same string as slice(...).decodeString" in {
+      for (text <- texts) {
+        val bytes = text.getBytes(StandardCharsets.UTF_8)
+        val n = bytes.length
+        for {
+          (name, bs) <- representations(bytes)
+          from <- -1 to n
+          until <- -1 to n + 1
+        } withClue(s"[$text], $name, from $from, until $until: ") {
+          val start = math.max(0, from)
+          val end = math.min(n, until)
+          val expected = if (start >= end) "" else new String(bytes, start, end - start, StandardCharsets.UTF_8)
+          bs.decodeString(StandardCharsets.UTF_8, from, until) should ===(expected)
+          bs.decodeString(StandardCharsets.UTF_8, from, until) should ===(bs.slice(start, end).decodeString(
+            StandardCharsets.UTF_8))
+        }
+      }
+    }
+
+    "return the empty string for an empty or inverted range" in {
+      val bs = ByteString("hello".getBytes(StandardCharsets.UTF_8))
+      bs.decodeString(StandardCharsets.UTF_8, 2, 2) should ===("")
+      bs.decodeString(StandardCharsets.UTF_8, 3, 1) should ===("")
+      bs.decodeString(StandardCharsets.UTF_8, 10, 20) should ===("")
+      bs.decodeString(StandardCharsets.UTF_8, -5, -1) should ===("")
+      ByteString.empty.decodeString(StandardCharsets.UTF_8, 0, 1) should ===("")
+    }
+
+    "clamp a range that runs past the end" in {
+      val bs = ByteString("hello".getBytes(StandardCharsets.UTF_8))
+      bs.decodeString(StandardCharsets.UTF_8, 3, 99) should ===("lo")
+      bs.decodeString(StandardCharsets.UTF_8, -3, 2) should ===("he")
+    }
+
+    "decode a multi-byte character that spans two fragments" in {
+      // 'é' is two bytes in UTF-8; split the ByteString between them
+      val bytes = "aéb".getBytes(StandardCharsets.UTF_8)
+      val split = ByteString(bytes.take(2)) ++ ByteString(bytes.drop(2))
+      split.decodeString(StandardCharsets.UTF_8, 0, bytes.length) should ===("aéb")
+      split.decodeString(StandardCharsets.UTF_8, 1, 3) should ===("é")
+    }
+
+    // A range that stays inside one fragment is decoded from that fragment's array directly,
+    // while one that straddles fragments has to gather the bytes first. Walk every range of a
+    // rope whose fragment boundaries fall inside multi-byte characters, so both paths are taken
+    // and are checked against decoding the same range out of the flat bytes.
+    "decode every range of a fragmented ByteString, within and across fragments" in {
+      val text = "Content-Type: application/json; charset=utf-8 \u00e9\u00e8\u00ea \u4f60\u597d"
+      val bytes = text.getBytes(StandardCharsets.UTF_8)
+      val n = bytes.length
+      for (fragSize <- List(1, 2, 3, 5, 16)) {
+        val rope = (0 until n by fragSize)
+          .map(i => ByteString(bytes.slice(i, math.min(i + fragSize, n))))
+          .reduce(_ ++ _)
+        for {
+          from <- 0 to n
+          until <- from to n
+        } withClue(s"fragSize $fragSize, from $from, until $until: ") {
+          rope.decodeString(StandardCharsets.UTF_8, from, until) should ===(
+            new String(bytes, from, until - from, StandardCharsets.UTF_8))
+        }
+      }
+    }
+  }
+
   "ByteString equality" must {
     // Builds the same content in every internal representation: compacted (ByteString1C),
     // a slice of a larger array (ByteString1), a two-fragment pair (ByteString2) and a

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -472,6 +472,15 @@ object ByteString {
       toCopy
     }
 
+    override def copyToArray(srcOffset: Int, dest: Array[Byte], destOffset: Int, len: Int): Int = {
+      val toCopy = copyableBytes(srcOffset, dest.length, destOffset, len)
+      if (toCopy > 0) System.arraycopy(bytes, srcOffset, dest, destOffset, toCopy)
+      toCopy
+    }
+
+    private[pekko] override def decodeStringUnchecked(charset: Charset, offset: Int, len: Int): String =
+      new String(bytes, offset, len, charset)
+
     override def toArrayUnsafe(): Array[Byte] = bytes
 
     override def asInputStream: InputStream = new UnsynchronizedByteArrayInputStream(bytes)
@@ -870,6 +879,15 @@ object ByteString {
       }
       toCopy
     }
+
+    override def copyToArray(srcOffset: Int, dest: Array[Byte], destOffset: Int, len: Int): Int = {
+      val toCopy = copyableBytes(srcOffset, dest.length, destOffset, len)
+      if (toCopy > 0) System.arraycopy(bytes, startIndex + srcOffset, dest, destOffset, toCopy)
+      toCopy
+    }
+
+    private[pekko] override def decodeStringUnchecked(charset: Charset, offset: Int, len: Int): String =
+      new String(bytes, startIndex + offset, len, charset)
 
     protected def writeReplace(): AnyRef = new SerializationProxy(this)
 
@@ -1307,6 +1325,32 @@ object ByteString {
       totalToCopy
     }
 
+    override def copyToArray(srcOffset: Int, dest: Array[Byte], destOffset: Int, len: Int): Int = {
+      val toCopy = copyableBytes(srcOffset, dest.length, destOffset, len)
+      if (toCopy <= 0) 0
+      else {
+        val firstLength = first.length
+        var copied = 0
+        if (srcOffset < firstLength) {
+          copied = first.copyToArray(srcOffset, dest, destOffset, toCopy)
+        }
+        if (copied < toCopy) {
+          val secondOffset = math.max(0, srcOffset - firstLength)
+          second.copyToArray(secondOffset, dest, destOffset + copied, toCopy - copied)
+        }
+        toCopy
+      }
+    }
+
+    private[pekko] override def decodeStringUnchecked(charset: Charset, offset: Int, len: Int): String = {
+      // A range that stays on one side decodes straight from that fragment's backing array, with
+      // no intermediate array; only a range straddling the two needs the bytes gathered first.
+      val firstLength = first.length
+      if (offset >= firstLength) second.decodeStringUnchecked(charset, offset - firstLength, len)
+      else if (len <= firstLength - offset) first.decodeStringUnchecked(charset, offset, len)
+      else super.decodeStringUnchecked(charset, offset, len)
+    }
+
     override def foreach[@specialized U](f: Byte => U): Unit = {
       first.foreach(f)
       second.foreach(f)
@@ -1517,10 +1561,29 @@ object ByteString {
         if (offset >= hintStart && offset - hintStart < frag.length)
           return frag.byteAtUnchecked(offset - hintStart)
       }
-      resolveAndRead(offset, hintIdx, hintStart)
+      val located = resolveFragment(offset, hintIdx, hintStart)
+      bytestrings((located >>> 32).toInt).byteAtUnchecked(offset - located.toInt)
     }
 
-    private def resolveAndRead(offset: Int, hintIdx: Int, hintStart: Int): Byte = {
+    /**
+     * Locates the fragment containing `offset`, consulting and updating the hint. Returns the
+     * fragment index in the high 32 bits and its start offset in the low 32, in the same packing
+     * the hint uses. `offset` must be within this ByteString.
+     */
+    private def locateFragment(offset: Int): Long = {
+      val hint = fragmentHint // single read: index and start below are mutually consistent
+      val hintIdx = (hint >>> 32).toInt
+      val hintStart = hint.toInt
+      if (hintIdx >= 0 && offset >= hintStart && offset - hintStart < bytestrings(hintIdx).length) hint
+      else resolveFragment(offset, hintIdx, hintStart)
+    }
+
+    /**
+     * Scans for the fragment containing `offset` and records it as the hint. `hintIdx` and
+     * `hintStart` are a previously read hint that missed, used to resume the scan from that
+     * fragment rather than from the start.
+     */
+    private def resolveFragment(offset: Int, hintIdx: Int, hintStart: Int): Long = {
       var pos = 0
       var seen = 0
       if (hintIdx >= 0) {
@@ -1537,8 +1600,9 @@ object ByteString {
         pos += 1
         frag = bytestrings(pos)
       }
-      fragmentHint = (pos.toLong << 32) | (seen.toLong & 0xFFFFFFFFL)
-      frag.byteAtUnchecked(offset - seen)
+      val located = (pos.toLong << 32) | (seen.toLong & 0xFFFFFFFFL)
+      fragmentHint = located
+      located
     }
 
     private[pekko] override def compareBytesTo(that: ByteString, thatOffset: Int): Boolean =
@@ -1986,6 +2050,41 @@ object ByteString {
         }
       }
       ByteString1C(result)
+    }
+
+    override def copyToArray(srcOffset: Int, dest: Array[Byte], destOffset: Int, len: Int): Int = {
+      val toCopy = copyableBytes(srcOffset, dest.length, destOffset, len)
+      if (toCopy <= 0) 0
+      else {
+        // Locate the fragment holding srcOffset through the same hint byteAtUnchecked uses, so a
+        // caller walking forward through a rope does not rescan the fragment vector on every call,
+        // then copy whole runs out of consecutive fragments. Indexing rather than iterating keeps
+        // this allocation free.
+        val located = locateFragment(srcOffset)
+        var fragIdx = (located >>> 32).toInt
+        var fragOffset = srcOffset - located.toInt
+        var copied = 0
+        while (copied < toCopy) {
+          val frag = bytestrings(fragIdx)
+          val fromFrag = math.min(toCopy - copied, frag.length - fragOffset)
+          frag.copyToArray(fragOffset, dest, destOffset + copied, fromFrag)
+          copied += fromFrag
+          fragIdx += 1
+          fragOffset = 0
+        }
+        toCopy
+      }
+    }
+
+    private[pekko] override def decodeStringUnchecked(charset: Charset, offset: Int, len: Int): String = {
+      // A range lying inside a single fragment -- the common case when a caller decodes a small
+      // field out of a large rope -- decodes straight from that fragment's backing array, with no
+      // intermediate array. Ranges spanning fragments fall back to gathering the bytes first.
+      val located = locateFragment(offset)
+      val frag = bytestrings((located >>> 32).toInt)
+      val fragOffset = offset - located.toInt
+      if (len <= frag.length - fragOffset) frag.decodeStringUnchecked(charset, fragOffset, len)
+      else super.decodeStringUnchecked(charset, offset, len)
     }
 
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
@@ -2576,6 +2675,45 @@ object ByteString {
     throw new UnsupportedOperationException("Method copyToArray is not implemented in ByteString")
 
   /**
+   * Copies `len` bytes of this ByteString, starting at `srcOffset`, into `dest` starting at
+   * `destOffset`.
+   *
+   * `copyToArray(dest, destOffset, len)` can only copy from the start of this ByteString, so
+   * copying from an offset otherwise requires slicing first, which allocates. This overload
+   * copies directly out of the backing array(s).
+   *
+   * Out of range values are clamped: the number of bytes copied is the largest value that fits in
+   * both this ByteString from `srcOffset` and `dest` from `destOffset`, and is never negative.
+   *
+   * @param srcOffset  the index in this ByteString to start copying from
+   * @param dest       the array to copy into
+   * @param destOffset the index in `dest` to start copying to
+   * @param len        the maximum number of bytes to copy
+   * @return the number of bytes actually copied
+   * @since 2.0.0
+   */
+  def copyToArray(srcOffset: Int, dest: Array[Byte], destOffset: Int, len: Int): Int = {
+    val toCopy = copyableBytes(srcOffset, dest.length, destOffset, len)
+    if (toCopy <= 0) 0
+    else {
+      var i = 0
+      while (i < toCopy) {
+        dest(destOffset + i) = byteAtUnchecked(srcOffset + i)
+        i += 1
+      }
+      toCopy
+    }
+  }
+
+  /**
+   * INTERNAL API: the number of bytes `copyToArray(srcOffset, dest, destOffset, len)` may copy,
+   * clamped to what is available in this ByteString and what fits in the destination.
+   */
+  private[pekko] final def copyableBytes(srcOffset: Int, destLength: Int, destOffset: Int, len: Int): Int =
+    if (srcOffset < 0 || destOffset < 0 || len <= 0 || srcOffset >= length) 0
+    else math.max(0, math.min(math.min(len, length - srcOffset), destLength - destOffset))
+
+  /**
    * Unsafe API: Use only in situations you are completely confident that this is what
    * you need, and that you understand the implications documented below.
    *
@@ -2697,6 +2835,38 @@ object ByteString {
    * Avoids Charset.forName lookup in String internals, thus is preferable to `decodeString(charset: String)`.
    */
   def decodeString(charset: Charset): String
+
+  /**
+   * Decodes the bytes in `[from, until)` using the given charset.
+   *
+   * Equivalent to `slice(from, until).decodeString(charset)` but without allocating the
+   * intermediate ByteString, which matters for parsers that repeatedly decode small ranges of a
+   * larger buffer.
+   *
+   * The range is clamped to the bounds of this ByteString, so an empty or inverted range decodes
+   * to the empty string rather than throwing.
+   *
+   * @param charset the charset to decode with
+   * @param from    the index to start decoding at, inclusive
+   * @param until   the index to stop decoding at, exclusive
+   * @since 2.0.0
+   */
+  def decodeString(charset: Charset, from: Int, until: Int): String = {
+    val start = math.max(0, from)
+    val end = math.min(length, until)
+    if (start >= end) ""
+    else decodeStringUnchecked(charset, start, end - start)
+  }
+
+  /**
+   * INTERNAL API: decode `len` bytes starting at `offset`, with the range already validated.
+   * Overridden by the array-backed layouts so no intermediate ByteString or array is allocated.
+   */
+  private[pekko] def decodeStringUnchecked(charset: Charset, offset: Int, len: Int): String = {
+    val bytes = new Array[Byte](len)
+    copyToArray(offset, bytes, 0, len)
+    new String(bytes, charset)
+  }
 
   /**
    * Returns a ByteString which is the binary representation of this ByteString


### PR DESCRIPTION
Adds two `ByteString` APIs for callers that repeatedly read sub-ranges of a larger buffer. Both come from an analysis of the pekko-http parsers, where the slice-then-use pattern is common in header and line parsing.

## `copyToArray(srcOffset, dest, destOffset, len)`

The existing `copyToArray(dest, destOffset, len)` can only copy from index 0, so copying from an offset means `drop(n)` or `slice(...)` first — which allocates a new ByteString, and for a fragmented one a new fragment vector too.

## `decodeString(charset, from, until)`

Decodes a sub-range directly. The array-backed layouts pass the offset and length straight to `new String(bytes, offset, len, charset)`, so neither an intermediate ByteString nor an intermediate array is created.

## Implementation

Both are defined on `ByteString` with a correct generic fallback and overridden in `ByteString1C`, `ByteString1`, `ByteString2` and `ByteStrings`. The single-array layouts use `System.arraycopy` and the offset-taking `String` constructor; `ByteStrings` locates the starting fragment and copies whole runs out of consecutive fragments.

Out of range arguments are **clamped rather than throwing**, matching the existing `copyToArray` overloads: the copy is reduced to what is available in the source and what fits in the destination, and an empty or inverted range decodes to `""`. This is a deliberate choice for consistency — worth a reviewer's opinion if you would rather they threw.

## Measurements

Allocation is the reliable signal here and is the point of both APIs. Copying 4096 bytes from offset 2048 of an 8192-byte ByteString:

| layout | `drop(n).copyToArray` | `copyToArray(srcOffset, …)` |
|---|---|---|
| 128 × 64B fragments | 202 B/op | **0 B/op** |
| 16 × 512B fragments | 144 B/op | **0 B/op** |

Decoding a 45-byte header out of a fragmented buffer: `slice(…).decodeString` 328 B/op → `decodeString(cs, from, until)` 152 B/op.

**One case where the new API is slower**, which I want to flag rather than bury: with very small fragments (1024 × 8B), `copyToArray(srcOffset, …)` runs slower than `drop(n).copyToArray` (~15µs vs ~11µs) even though it allocates nothing. The reason is that `drop` produces a ByteString whose existing `copyToArray` walks `bytestrings.iterator` once, whereas the new implementation indexes `bytestrings(fragIdx)` per fragment, and `Vector.apply` is O(log n). I tried an iterator-based walk; it fixed the timing but reintroduced allocation, which defeats the purpose, so I kept the allocation-free version. 8-byte fragments are also not a realistic shape for the parser use case this targets. Happy to revisit if a reviewer disagrees with that trade.

Timings on this machine were noisy run to run; the allocation figures are stable and reproducible, so I would treat the timing numbers as indicative only.

## Relationship to the other ByteString PRs

Independent of #3463. I stacked this branch on top of it to check: the two merge cleanly, all tests pass, and the small-fragment gap above persists, because `copyToArray` copies via `Array.copy` per fragment and never goes through the memoised `byteAtUnchecked` that #3463 adds. The one place they do interact is the generic `copyToArray` fallback on the abstract class, which reads `byteAtUnchecked` per byte — that path gets faster if #3463 lands, but no built-in layout uses it. Neither PR needs the other, and they can merge in either order.

## Tests

8 new tests in `ByteStringSpec`:

- both APIs compared against the `slice(...)`-based expression they replace, across compacted, sliced, two-fragment and multi-fragment representations, over all combinations of in and out of range offsets and lengths
- clamping of every out of range argument
- not writing past the end of the destination
- empty ByteString and empty/inverted ranges
- a multi-byte UTF-8 character split across two fragments

`actor-tests/testOnly org.apache.pekko.util.ByteStringSpec` passes (221 tests). `sbt actor/mimaReportBinaryIssues` is clean — both APIs are additive. `scalafmt` run on both modules.

I did not add a JMH benchmark here, since the win is allocation rather than throughput and the existing ByteString benchmarks are throughput oriented. Happy to add one if preferred.