### PR TITLE
refactor: use bit operations for the DNS over TCP length prefix

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/TcpDnsClientSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/TcpDnsClientSpec.scala
@@ -28,6 +28,38 @@ import pekko.testkit.{ EventFilter, ImplicitSender, PekkoSpec, TestProbe }
 class TcpDnsClientSpec extends PekkoSpec with ImplicitSender {
   import TcpDnsClient._
 
+  "The TCP DNS length prefix" should {
+    // RFC 1035 section 4.2.2: each message is prefixed by its length as two big endian bytes.
+
+    "round trip every representable length" in {
+      for (length <- 0 to 65535) withClue(s"length $length: ") {
+        val encoded = encodeLength(length)
+        encoded.length should ===(2)
+        decodeLength(encoded) should ===(length)
+      }
+    }
+
+    "encode the length as two big endian bytes" in {
+      encodeLength(0) should ===(pekko.util.ByteString(0, 0))
+      encodeLength(1) should ===(pekko.util.ByteString(0, 1))
+      encodeLength(255) should ===(pekko.util.ByteString(0, 255.toByte))
+      encodeLength(256) should ===(pekko.util.ByteString(1, 0))
+      encodeLength(65535) should ===(pekko.util.ByteString(255.toByte, 255.toByte))
+    }
+
+    "decode lengths whose bytes have the high bit set" in {
+      // the bytes are unsigned on the wire; a naive signed conversion gets these wrong
+      decodeLength(pekko.util.ByteString(0, 255.toByte)) should ===(255)
+      decodeLength(pekko.util.ByteString(255.toByte, 0)) should ===(65280)
+      decodeLength(pekko.util.ByteString(255.toByte, 255.toByte)) should ===(65535)
+      decodeLength(pekko.util.ByteString(128.toByte, 128.toByte)) should ===(32896)
+    }
+
+    "ignore any bytes after the two byte prefix" in {
+      decodeLength(pekko.util.ByteString(1, 2, 3, 4, 5)) should ===(258)
+    }
+  }
+
   "The async TCP DNS client" should {
     val exampleRequestMessage =
       Message(42, MessageFlags(), questions = Seq(Question("pekko.io", RecordType.A, RecordClass.IN)))

--- a/actor/src/main/scala/org/apache/pekko/io/dns/internal/TcpDnsClient.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/internal/TcpDnsClient.scala
@@ -99,10 +99,15 @@ import pekko.util.ByteString
   }
 }
 private[internal] object TcpDnsClient {
-  def encodeLength(length: Int): ByteString =
-    ByteString((length / 256).toByte, length.toByte)
 
-  def decodeLength(data: ByteString): Int = ((data(0).toInt + 256) % 256) * 256 + ((data(1) + 256) % 256)
+  /**
+   * DNS over TCP prefixes each message with its length as a two byte big endian value
+   * (RFC 1035 section 4.2.2).
+   */
+  def encodeLength(length: Int): ByteString =
+    ByteString(((length >> 8) & 0xFF).toByte, (length & 0xFF).toByte)
+
+  def decodeLength(data: ByteString): Int = ((data(0) & 0xFF) << 8) | (data(1) & 0xFF)
 
   def throwFailure(message: String, cause: Option[Throwable]): Unit =
     cause match {


### PR DESCRIPTION
### Motivation

RFC 1035 section 4.2.2 prefixes each DNS over TCP message with its length as two big endian bytes. Both directions in `TcpDnsClient` expressed this with arithmetic rather than bit operations:

```scala
def encodeLength(length: Int): ByteString =
  ByteString((length / 256).toByte, length.toByte)

def decodeLength(data: ByteString): Int =
  ((data(0).toInt + 256) % 256) * 256 + ((data(1) + 256) % 256)
```

The `+ 256) % 256` pairs are working around `Byte` being signed, which `& 0xFF` states directly, and the division and multiplication are a shift by 8.

### Modification

```scala
def encodeLength(length: Int): ByteString =
  ByteString(((length >> 8) & 0xFF).toByte, (length & 0xFF).toByte)

def decodeLength(data: ByteString): Int =
  ((data(0) & 0xFF) << 8) | (data(1) & 0xFF)
```

Plus a short comment naming the RFC section, since the two byte big endian framing is not obvious from the code alone.

### This is behaviour preserving, not a fix

I want to be clear that this fixes nothing — the original was correct. I verified equivalence exhaustively rather than by inspection:

- `decodeLength`: identical over **all 65,536 byte pairs** (every `(Byte, Byte)` combination), producing the full `[0, 65535]` range in both forms.
- `encodeLength`: identical over the **entire valid length range 0 to 65535**.

The two forms diverge in exactly one place: `encodeLength(-1)` gives `(0, -1)` under the old form and `(-1, -1)` under the new one. That cannot occur — the only caller is `encodeLength(bytes.length)` at `TcpDnsClient.scala:62`, where `bytes` is a `ByteString`, so the argument is never negative. I checked the call site rather than assuming.

So the case for merging is readability, and a small amount of work removed from the receive path (two divisions and a multiplication become a shift and two masks). If you would rather not take churn in working DNS framing code for that, this is a reasonable one to decline.

### Tests

Added a `"The TCP DNS length prefix"` block to `TcpDnsClientSpec` covering the helpers directly, which nothing previously did — they were only exercised indirectly through the client's receive loop:

- round trip over **every** representable length, 0 to 65535
- the expected big endian byte layout at the boundaries (0, 1, 255, 256, 65535)
- decoding of bytes with the high bit set (`0xFF 0xFF` → 65535, `0x80 0x80` → 32896) — the case the signed-byte workaround existed for
- trailing bytes after the two byte prefix are ignored

**These pass against both the old and the new implementation.** That is the correct outcome for a behaviour preserving change, and worth stating plainly: unlike a bug fix, these tests do not fail on the unmodified code. Their value is locking the contract down so a future change to this framing cannot silently break it.

`actor-tests/testOnly org.apache.pekko.io.dns.internal.TcpDnsClientSpec` — 8 tests, all pass. `sbt actor/mimaReportBinaryIssues` clean; `TcpDnsClient` is `private[internal]`, so no API surface is affected. `scalafmt` run on both modules.

### References

Found during a sweep for patterns left over from the Java 8 / Scala 2.12 baseline, alongside #3465.