### PR TITLE
refactor: replace deprecated collection aliases in internal io code

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
@@ -20,7 +20,6 @@ import java.nio.channels.{ FileChannel, SocketChannel }
 import java.nio.channels.SelectionKey._
 import java.nio.file.Path
 
-import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
@@ -219,11 +218,10 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   // AUXILIARIES and IMPLEMENTATION
 
   /** used in subclasses to start the common machinery above once a channel is connected */
-  @nowarn("msg=deprecated")
   def completeConnect(
       registration: ChannelRegistration,
       commander: ActorRef,
-      options: immutable.Traversable[SocketOption]): Unit = {
+      options: immutable.Iterable[SocketOption]): Unit = {
     this.registration = Some(registration)
 
     // Turn off Nagle's algorithm by default

--- a/actor/src/main/scala/org/apache/pekko/io/TcpIncomingConnection.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/TcpIncomingConnection.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.io
 
 import java.nio.channels.SocketChannel
 
-import scala.annotation.nowarn
 import scala.collection.immutable
 
 import org.apache.pekko
@@ -28,13 +27,12 @@ import pekko.io.Inet.SocketOption
  *
  * INTERNAL API
  */
-@nowarn("msg=deprecated")
 private[io] class TcpIncomingConnection(
     _tcp: TcpExt,
     _channel: SocketChannel,
     registry: ChannelRegistry,
     bindHandler: ActorRef,
-    options: immutable.Traversable[SocketOption],
+    options: immutable.Iterable[SocketOption],
     readThrottling: Boolean)
     extends TcpConnection(_tcp, _channel, readThrottling) {
 

--- a/actor/src/main/scala/org/apache/pekko/io/dns/internal/DnsMessage.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/internal/DnsMessage.scala
@@ -13,8 +13,7 @@
 
 package org.apache.pekko.io.dns.internal
 
-import scala.annotation.nowarn
-import scala.collection.GenTraversableOnce
+import scala.collection.IterableOnce
 import scala.collection.immutable.Seq
 import scala.util.{ Failure, Success, Try }
 
@@ -166,8 +165,7 @@ private[internal] object Message {
     }
 
     import scala.language.implicitConversions
-    @nowarn("msg=deprecated")
-    implicit def flattener[T](tried: Try[T]): GenTraversableOnce[T] =
+    implicit def flattener[T](tried: Try[T]): IterableOnce[T] =
       if (flags.isTruncated) tried.toOption
       else
         tried match {


### PR DESCRIPTION
### Motivation

`scala.collection.GenTraversableOnce` and `scala.collection.immutable.Traversable` are deprecated aliases retained for the 2.12 migration — they resolve to `IterableOnce` and `immutable.Iterable`. Three internal sites still use them, and each carries a `@nowarn("msg=deprecated")` to silence the resulting warning:

| site | alias |
|---|---|
| `DnsMessage.scala:170` — `Message.parse`'s `flattener` implicit | `GenTraversableOnce` |
| `TcpConnection.scala:226` — `completeConnect` | `immutable.Traversable` |
| `TcpIncomingConnection.scala:33` — constructor | `immutable.Traversable` |

### Modification

Use the current names and drop the three `@nowarn` suppressions.

**The suppressions are the substantive part of this change.** `@nowarn("msg=deprecated")` on a class or method silences *every* deprecation warning in its scope, not just the one it was added for. I verified all three were stale by removing them and recompiling — the code builds clean without them. Left in place they would keep hiding unrelated deprecation warnings in those files indefinitely; in `TcpIncomingConnection` the annotation sits on the whole class.

### Scope and safety

All three sites are internal:

- `Message` is `private[internal]`
- `TcpConnection` and `TcpIncomingConnection` are `private[io]`, and the only two callers of `completeConnect` (`TcpIncomingConnection.scala:46`, `TcpOutgoingConnection.scala:112`) are in the same package

The aliases are identical types, so this is behaviour preserving — no erasure change, no signature change visible outside `io`.

### What is deliberately not in this PR

The **public** API still uses `immutable.Traversable`, in `Tcp.scala:138,167`, `Udp.scala:118,139`, `UdpConnected.scala:112` and `stream/scaladsl/Tcp.scala:144,186,220`. Those are left alone on purpose: the Scala pickle signature changes even though erasure does not, and `Udp.SimpleSender` is a case class so `copy` and `unapply` would change with it. That is a considered API change for a major release, gated on `+mimaReportBinaryIssues`, not a drive-by refactor. Their `@nowarn`s stay for the same reason.

### Tests

No new tests. This is a type-alias substitution with no behaviour change, and the affected paths already have coverage — `MessageSpec` exercises `Message.parse` and therefore the `flattener` implicit directly.

- `actor-tests/testOnly org.apache.pekko.io.dns.*` — 60 tests pass
- `actor-tests/testOnly org.apache.pekko.io.dns.internal.* org.apache.pekko.io.TcpConnectionSpec org.apache.pekko.io.TcpIntegrationSpec` — 94 pass
- `sbt actor/mimaReportBinaryIssues` — clean
- **`sbt ++3.3.8 actor/compile` — passes.** Worth calling out: `GenTraversableOnce` and `IterableOnce` differ in availability between Scala 2.13 and 3, and `DnsMessage.scala` is a single shared source file rather than a cross-version variant, so Scala 3 was the real risk in this change.
- `scalafmt` run

### References

Last of the items from the Java 8 / Scala 2.12 legacy sweep, following #3465 and #3466.