### PR TITLE
refactor: replace immutable.Traversable in the public io and stream APIs

### DIFF
--- a/actor/src/main/scala/org/apache/pekko/io/Tcp.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/Tcp.scala
@@ -18,7 +18,6 @@ import java.net.InetSocketAddress
 import java.net.Socket
 import java.nio.file.{ Path, Paths }
 
-import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -131,11 +130,10 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    * @param localAddress optionally specifies a specific address to bind to
    * @param options Please refer to the `Tcp.SO` object for a list of all supported options.
    */
-  @nowarn("msg=deprecated")
   final case class Connect(
       remoteAddress: InetSocketAddress,
       localAddress: Option[InetSocketAddress] = None,
-      options: immutable.Traversable[SocketOption] = Nil,
+      options: immutable.Iterable[SocketOption] = Nil,
       timeout: Option[FiniteDuration] = None,
       pullMode: Boolean = false)
       extends Command
@@ -159,12 +157,11 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    *
    * @param options Please refer to the `Tcp.SO` object for a list of all supported options.
    */
-  @nowarn("msg=deprecated")
   final case class Bind(
       handler: ActorRef,
       localAddress: InetSocketAddress,
       backlog: Int = 100,
-      options: immutable.Traversable[SocketOption] = Nil,
+      options: immutable.Iterable[SocketOption] = Nil,
       pullMode: Boolean = false)
       extends Command
 

--- a/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/TcpConnection.scala
@@ -20,7 +20,6 @@ import java.nio.channels.{ FileChannel, SocketChannel }
 import java.nio.channels.SelectionKey._
 import java.nio.file.Path
 
-import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
@@ -219,11 +218,10 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   // AUXILIARIES and IMPLEMENTATION
 
   /** used in subclasses to start the common machinery above once a channel is connected */
-  @nowarn("msg=deprecated")
   def completeConnect(
       registration: ChannelRegistration,
       commander: ActorRef,
-      options: immutable.Traversable[SocketOption]): Unit = {
+      options: immutable.Iterable[SocketOption]): Unit = {
     this.registration = Some(registration)
 
     // Turn off Nagle's algorithm by default

--- a/actor/src/main/scala/org/apache/pekko/io/TcpIncomingConnection.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/TcpIncomingConnection.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.io
 
 import java.nio.channels.SocketChannel
 
-import scala.annotation.nowarn
 import scala.collection.immutable
 
 import org.apache.pekko
@@ -28,13 +27,12 @@ import pekko.io.Inet.SocketOption
  *
  * INTERNAL API
  */
-@nowarn("msg=deprecated")
 private[io] class TcpIncomingConnection(
     _tcp: TcpExt,
     _channel: SocketChannel,
     registry: ChannelRegistry,
     bindHandler: ActorRef,
-    options: immutable.Traversable[SocketOption],
+    options: immutable.Iterable[SocketOption],
     readThrottling: Boolean)
     extends TcpConnection(_tcp, _channel, readThrottling) {
 

--- a/actor/src/main/scala/org/apache/pekko/io/Udp.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/Udp.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.io
 import java.net.DatagramSocket
 import java.net.InetSocketAddress
 
-import scala.annotation.nowarn
 import scala.collection.immutable
 
 import org.apache.pekko
@@ -111,11 +110,10 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
    * The listener actor for the newly bound port will reply with a [[Bound]]
    * message, or the manager will reply with a [[CommandFailed]] message.
    */
-  @nowarn("msg=deprecated")
   final case class Bind(
       handler: ActorRef,
       localAddress: InetSocketAddress,
-      options: immutable.Traversable[SocketOption] = Nil)
+      options: immutable.Iterable[SocketOption] = Nil)
       extends Command
 
   /**
@@ -135,8 +133,7 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
    * The “simple sender” will not stop itself, you will have to send it a [[pekko.actor.PoisonPill]]
    * when you want to close the socket.
    */
-  @nowarn("msg=deprecated")
-  case class SimpleSender(options: immutable.Traversable[SocketOption] = Nil) extends Command
+  case class SimpleSender(options: immutable.Iterable[SocketOption] = Nil) extends Command
   object SimpleSender extends SimpleSender(Nil)
 
   /**

--- a/actor/src/main/scala/org/apache/pekko/io/UdpConnected.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/UdpConnected.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.io
 import java.lang.{ Iterable => JIterable }
 import java.net.InetSocketAddress
 
-import scala.annotation.nowarn
 import scala.collection.immutable
 
 import org.apache.pekko
@@ -104,12 +103,11 @@ object UdpConnected extends ExtensionId[UdpConnectedExt] with ExtensionIdProvide
    * which is restricted to sending to and receiving from the given `remoteAddress`.
    * All received datagrams will be sent to the designated `handler` actor.
    */
-  @nowarn("msg=deprecated")
   final case class Connect(
       handler: ActorRef,
       remoteAddress: InetSocketAddress,
       localAddress: Option[InetSocketAddress] = None,
-      options: immutable.Traversable[SocketOption] = Nil)
+      options: immutable.Iterable[SocketOption] = Nil)
       extends Command
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
@@ -140,8 +140,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
       interface: String,
       port: Int,
       backlog: Int = defaultBacklog,
-      @nowarn // Traversable deprecated in 2.13
-      options: immutable.Traversable[SocketOption] = Nil,
+      options: immutable.Iterable[SocketOption] = Nil,
       halfClose: Boolean = false,
       idleTimeout: Duration = Duration.Inf): Source[IncomingConnection, Future[ServerBinding]] =
     Source.fromGraph(
@@ -182,8 +181,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
       interface: String,
       port: Int,
       backlog: Int = defaultBacklog,
-      @nowarn // Traversable deprecated in 2.13
-      options: immutable.Traversable[SocketOption] = Nil,
+      options: immutable.Iterable[SocketOption] = Nil,
       halfClose: Boolean = false,
       idleTimeout: Duration = Duration.Inf)(implicit m: Materializer): Future[ServerBinding] = {
     bind(interface, port, backlog, options, halfClose, idleTimeout)
@@ -216,8 +214,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
   def outgoingConnection(
       remoteAddress: InetSocketAddress,
       localAddress: Option[InetSocketAddress] = None,
-      @nowarn // Traversable deprecated in 2.13
-      options: immutable.Traversable[SocketOption] = Nil,
+      options: immutable.Iterable[SocketOption] = Nil,
       halfClose: Boolean = true,
       connectTimeout: Duration = Duration.Inf,
       idleTimeout: Duration = Duration.Inf): Flow[ByteString, ByteString, Future[OutgoingConnection]] = {


### PR DESCRIPTION
### Motivation

`immutable.Traversable` is a deprecated alias for `immutable.Iterable`, kept around for the 2.12 migration. It survives in the `options` parameter of several public messages and methods:

| site | |
|---|---|
| `Tcp.scala:138,167` | `Tcp.Connect`, `Tcp.Bind` |
| `Udp.scala:118,139` | `Udp.Bind`, `Udp.SimpleSender` |
| `UdpConnected.scala:112` | `UdpConnected.Connect` |
| `stream/scaladsl/Tcp.scala:144,186,220` | `bind`, `bindWithTls`, `outgoingConnection` |
| `TcpConnection.scala:226`, `TcpIncomingConnection.scala:37` | `private[io]`, but share the signature |

### On the MiMa exclusions

You asked for exclusions with this. **None are needed, and I would rather not add empty ones.**

I had previously told you this change would move the Scala pickle signature and need filtering. That was wrong, and checking it is what changed the shape of this PR. `immutable.Traversable` is a *type alias*, so it is already erased **and written** as `immutable.Iterable` in the bytecode. `javap` on the pre-change build:

```
public scala.collection.immutable.Iterable<...Inet$SocketOption> options();
  descriptor: ()Lscala/collection/immutable/Iterable;
public org.apache.pekko.io.Tcp$Connect copy(java.net.InetSocketAddress, scala.Option<...>,
    scala.collection.immutable.Iterable<...Inet$SocketOption>, ...)
```

The generic signature already said `Iterable`, so `copy` and `unapply` are unchanged too — the case-class concern I raised earlier does not apply. `actor/mimaReportBinaryIssues` and `stream/mimaReportBinaryIssues` both pass **unmodified** against the `pekko-actor:1.0.0` baseline that MiMa resolves.

If a reviewer would still like a `.excludes` file added defensively, say so and I will add one — but it would exclude nothing, and I did not want to imply a compatibility risk that the bytecode says is not there.

### Also removed: eight stale suppressions

Five `@nowarn("msg=deprecated")` in the actor io sources and three `@nowarn // Traversable deprecated in 2.13` in stream's `Tcp`. I verified each was stale by deleting it and recompiling.

This is the part with real value. `@nowarn("msg=deprecated")` on a class or method silences **every** deprecation warning in its scope, not just the one it was added for — on `Udp.Bind` and `Tcp.Connect` it sits on the whole case class. Left in, they would keep hiding unrelated deprecations indefinitely. The `nowarn` import is kept in stream's `Tcp` only because line 402 still uses it for something else.

### Compatibility

- **Binary**: unchanged, as above.
- **Source**: unaffected for callers passing `Seq`, `List`, `Nil` or `immutable.Iterable`. A caller that has explicitly spelled `immutable.Traversable` at a call site still compiles, since the alias itself is not being removed.

### Tests

No new tests — this is a type-alias substitution with no behaviour change and no signature change.

`actor/compile`, `stream/compile`, `actor/mimaReportBinaryIssues` and `stream/mimaReportBinaryIssues` all pass locally, and `scalafmt` has been run on both modules. I have **not** run the full test suites locally and am relying on CI for those.

### Scope

Deliberately limited to `immutable.Traversable`. The `GenTraversableOnce` use in `DnsMessage` is in #3467 and is not touched here.