### PR TITLE
docs: fix image paths in substream docs

### DIFF
--- a/docs/src/main/paradox/stream/stream-substream.md
+++ b/docs/src/main/paradox/stream/stream-substream.md
@@ -35,7 +35,7 @@ Scala
 Java
 :   @@snip [SubstreamDocTest.java](/docs/src/test/java/jdocs/stream/SubstreamDocTest.java) { #groupBy1 }
 
-![stream-substream-groupBy1.png](../../images/stream-substream-groupBy1.png)
+![stream-substream-groupBy1.png](../images/stream-substream-groupBy1.png)
 
 This operation splits the incoming stream into separate output
 streams, one for each element key. The key is computed for each element
@@ -54,7 +54,7 @@ Scala
 Java
 :   @@snip [SubstreamDocTest.java](/docs/src/test/java/jdocs/stream/SubstreamDocTest.java) { #groupBy2 }
 
-![stream-substream-groupBy2.png](../../images/stream-substream-groupBy2.png)
+![stream-substream-groupBy2.png](../images/stream-substream-groupBy2.png)
 
 Also substreams, more precisely, @apidoc[stream.*.SubFlow] @java[and @javadoc[SubSource](pekko.stream.javadsl.SubSource)] have methods that allow you to
 merge or concat substreams into the main stream again.
@@ -67,7 +67,7 @@ Scala
 Java
 :   @@snip [SubstreamDocTest.java](/docs/src/test/java/jdocs/stream/SubstreamDocTest.java) { #groupBy3 }
 
-![stream-substream-groupBy3.png](../../images/stream-substream-groupBy3.png)
+![stream-substream-groupBy3.png](../images/stream-substream-groupBy3.png)
 
 You can limit the number of active substreams running and being merged at a time,
 with either the @apidoc[mergeSubstreamsWithParallelism](stream.*.SubFlow) {scala="#mergeSubstreamsWithParallelism(parallelism:Int):F[Out]" java="#mergeSubstreamsWithParallelism(int)"} or @apidoc[concatSubstreams](stream.*.SubFlow) {scala="#concatSubstreams:F[Out]" java="#concatSubstreams()"} method.
@@ -85,7 +85,7 @@ Element one and two leads to two created substreams, but since the number of sub
 when element 3 comes in it cannot lead to creation of a new substream until one of the previous two are completed 
 and this leads to the stream being deadlocked.
 
-![stream-substream-groupBy4.png](../../images/stream-substream-groupBy4.png)
+![stream-substream-groupBy4.png](../images/stream-substream-groupBy4.png)
 
 ### splitWhen and splitAfter
 
@@ -120,7 +120,7 @@ This prints out the following output.
 26
 ``` 
 
-![stream-substream-splitWhen-splitAfter.png](../../images/stream-substream-splitWhen-splitAfter.png)
+![stream-substream-splitWhen-splitAfter.png](../images/stream-substream-splitWhen-splitAfter.png)
 
 ## Flattening operators
 
@@ -138,7 +138,7 @@ Scala
 Java
 :   @@snip [SubstreamDocTest.java](/docs/src/test/java/jdocs/stream/SubstreamDocTest.java) { #flatMapConcat }
 
-![stream-substream-flatMapConcat1.png](../../images/stream-substream-flatMapConcat1.png)
+![stream-substream-flatMapConcat1.png](../images/stream-substream-flatMapConcat1.png)
 
 Like the `concat` operation on @apidoc[stream.*.Flow], it fully consumes one @apidoc[stream.*.Source] after the other.
 So, there is only one substream actively running at a given time.
@@ -146,7 +146,7 @@ So, there is only one substream actively running at a given time.
 Then once the active substream is fully consumed, the next substream can start running.
 Elements from all the substreams are concatenated to the sink.
 
-![stream-substream-flatMapConcat2.png](../../images/stream-substream-flatMapConcat2.png)
+![stream-substream-flatMapConcat2.png](../images/stream-substream-flatMapConcat2.png)
 
 ### flatMapMerge
 
@@ -159,4 +159,4 @@ Scala
 Java
 :   @@snip [SubstreamDocTest.java](/docs/src/test/java/jdocs/stream/SubstreamDocTest.java) { #flatMapMerge }
 
-![stream-substream-flatMapMerge.png](../../images/stream-substream-flatMapMerge.png)
+![stream-substream-flatMapMerge.png](../images/stream-substream-flatMapMerge.png)


### PR DESCRIPTION
### Motivation
Spotted that the image links in the [substreams documentation](https://pekko.apache.org/docs/pekko/1.1/stream/stream-substream.html) were incorrect. 

### Modification
Corrects the image links in `stream-substream.md` to the correct locations.

### Result
Images are now displayed correctly.

### Tests
Built the docs locally and confirmed that the images show. Also checked for missing images on other pages.