### PR TITLE
docs: correct the stale SHA1PRNG entropy note

### DIFF
--- a/docs/src/main/paradox/remote-security.md
+++ b/docs/src/main/paradox/remote-security.md
@@ -126,8 +126,15 @@ section.
 
 @@@ note
 
-When using SHA1PRNG on Linux it's recommended to specify `-Djava.security.egd=file:/dev/urandom` as argument
-to the JVM to prevent blocking. It is NOT as secure because it reuses the seed.
+`random-number-generator` defaults to the platform `SecureRandom`, which is the recommended
+setting. `SHA1PRNG` is a legacy algorithm: it draws a single seed at startup and never reseeds,
+where the platform default mixes fresh kernel randomness into every request.
+
+On Linux the seed comes from `securerandom.source` (`file:/dev/random` by default), overridable
+with `-Djava.security.egd`. On older kernels `/dev/random` could block on hosts with little
+entropy, which is the origin of the frequently suggested
+`-Djava.security.egd=file:/dev/urandom`; current kernels do not block once the pool is seeded
+at boot.
 
 @@@
 

--- a/docs/src/main/paradox/remoting.md
+++ b/docs/src/main/paradox/remoting.md
@@ -510,8 +510,15 @@ See also a description of the settings in the @ref:[Remote Configuration](remoti
 
 @@@ note
 
-When using SHA1PRNG on Linux it's recommended specify `-Djava.security.egd=file:/dev/urandom` as argument
-to the JVM to prevent blocking. It is NOT as secure because it reuses the seed.
+`random-number-generator` defaults to the platform `SecureRandom`, which is the recommended
+setting. `SHA1PRNG` is a legacy algorithm: it draws a single seed at startup and never reseeds,
+where the platform default mixes fresh kernel randomness into every request.
+
+On Linux the seed comes from `securerandom.source` (`file:/dev/random` by default), overridable
+with `-Djava.security.egd`. On older kernels `/dev/random` could block on hosts with little
+entropy, which is the origin of the frequently suggested
+`-Djava.security.egd=file:/dev/urandom`; current kernels do not block once the pool is seeded
+at boot.
 
 @@@
 

--- a/remote/src/main/resources/reference.conf
+++ b/remote/src/main/resources/reference.conf
@@ -725,7 +725,8 @@ pekko {
 
           # There are two options, and the default SecureRandom is recommended:
           # "" or "SecureRandom" => (default)
-          # "SHA1PRNG" => Can be slow because of blocking issues on Linux
+          # "SHA1PRNG" => Legacy algorithm, seeded once at startup and never
+          #               reseeded. The default is preferred.
           #
           # Setting a value here may require you to supply the appropriate cipher
           # suite (see enabled-algorithms section above)
@@ -1233,7 +1234,8 @@ pekko {
 
           # There are two options, and the default SecureRandom is recommended:
           # "" or "SecureRandom" => (default)
-          # "SHA1PRNG" => Can be slow because of blocking issues on Linux
+          # "SHA1PRNG" => Legacy algorithm, seeded once at startup and never
+          #               reseeded. The default is preferred.
           #
           # Setting a value here may require you to supply the appropriate cipher
           # suite (see enabled-algorithms section above)
@@ -1290,7 +1292,8 @@ pekko {
 
           # There are two options, and the default SecureRandom is recommended:
           # "" or "SecureRandom" => (default)
-          # "SHA1PRNG" => Can be slow because of blocking issues on Linux
+          # "SHA1PRNG" => Legacy algorithm, seeded once at startup and never
+          #               reseeded. The default is preferred.
           #
           # Setting a value here may require you to supply the appropriate cipher
           # suite (see enabled-algorithms section)


### PR DESCRIPTION
### Motivation

The TLS docs told users that on Linux with `SHA1PRNG` they should set `-Djava.security.egd=file:/dev/urandom` *"to prevent blocking"*, and that doing so *"is NOT as secure because it reuses the seed"*. Both halves are wrong on any JDK Pekko supports.

**"It reuses the seed"** — nothing about `/dev/urandom` reuses a seed. Since Linux 4.8 both devices draw from the same CSPRNG. The note's instinct is sound but attached to the wrong cause: the real caveat belongs to the *algorithm*. In `sun.security.provider.SecureRandom`, `SHA1PRNG` seeds `state` once when it is null and then runs a deterministic SHA-1 chain forever, whereas the platform default `NativePRNG` mixes fresh kernel randomness into every `nextBytes` call. That holds whatever `java.security.egd` is set to, so the flag is irrelevant to the concern being raised.

**"To prevent blocking"** — close to inert. In `SeedGenerator`, `file:/dev/urandom` selects `NativeSeedGenerator`, which on Unix is just `URLSeedGenerator` reading that path; the special case only means something on Windows. The default `securerandom.source` is `file:/dev/random`, which since kernel 5.6 no longer blocks once the pool is seeded at boot. The advice mattered on old kernels in low-entropy VMs.

The same stale rationale is repeated in the `reference.conf` comments, which justify avoiding `SHA1PRNG` on the grounds of *"blocking issues on Linux"*.

### Modification

Rewrite the note in `remote-security.md` (artery) and `remoting.md` (classic) to:

- lead with the recommendation to keep the platform default `SecureRandom`;
- give the no-reseeding property as the reason to prefer it over `SHA1PRNG`;
- describe the entropy source accurately, with the blocking concern marked as historical.

Also fixes the missing "to" in the classic copy (*"it's recommended specify"*), and updates the three `reference.conf` comments to match.

### Result

The note states a caveat that is true and actionable, and no longer advises a JVM flag on grounds that have not applied for several kernel releases.

`reference.conf` changes are comment-only — no defaults, behaviour, or public API are affected.

### Tests

- Not run - docs only

### References

None - follow-up from the threat model review in #3478