### PR TITLE
build: stop CI switching the default SecureRandom away from NativePRNG

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -156,7 +156,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-1.0-builds.yml
+++ b/.github/workflows/nightly-1.0-builds.yml
@@ -48,7 +48,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
@@ -104,7 +104,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-1.1-builds.yml
+++ b/.github/workflows/nightly-1.1-builds.yml
@@ -48,7 +48,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
@@ -105,7 +105,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-1.2-builds.yml
+++ b/.github/workflows/nightly-1.2-builds.yml
@@ -48,7 +48,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
@@ -105,7 +105,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-1.3-builds.yml
+++ b/.github/workflows/nightly-1.3-builds.yml
@@ -47,7 +47,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
@@ -104,7 +104,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-1.4-builds.yml
+++ b/.github/workflows/nightly-1.4-builds.yml
@@ -47,7 +47,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
@@ -104,7 +104,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-1.5-builds.yml
+++ b/.github/workflows/nightly-1.5-builds.yml
@@ -47,7 +47,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
@@ -104,7 +104,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-1.6-builds.yml
+++ b/.github/workflows/nightly-1.6-builds.yml
@@ -47,7 +47,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
@@ -104,7 +104,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-1.7-builds.yml
+++ b/.github/workflows/nightly-1.7-builds.yml
@@ -49,7 +49,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
@@ -106,7 +106,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-builds-aeron.yml
+++ b/.github/workflows/nightly-builds-aeron.yml
@@ -57,7 +57,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.transport=aeron-udp \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -40,7 +40,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.test.sigar=true \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
@@ -96,7 +96,7 @@ jobs:
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
           sbt \
-          -Djava.security.egd=file:/dev/./urandom \
+          -Djava.security.egd=file:/dev/urandom \
           -Dpekko.remote.artery.enabled=off \
           -Dpekko.test.timefactor=2 \
           -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -50,7 +50,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |-
           sbt \
-            -Djava.security.egd=file:/dev/./urandom \
+            -Djava.security.egd=file:/dev/urandom \
             -Dpekko.cluster.assert=on \
             -Dpekko.test.timefactor=2 \
             -Dpekko.actor.testkit.typed.timefactor=2 \

--- a/.jvmopts-ci
+++ b/.jvmopts-ci
@@ -10,6 +10,8 @@
 -XX:+UseCompressedOops
 -XX:MetaspaceSize=512M
 -XX:-ClassUnloadingWithConcurrentMark
--Djava.security.egd=file:/dev/./urandom
+# Non-blocking seed source. Keep the plain path: `/dev/./urandom` switches the
+# default SecureRandom away from NativePRNG (to DRBG, or SHA1PRNG on JDK 8).
+-Djava.security.egd=file:/dev/urandom
 -Dpekko.ci-server=true
 -Dio.netty.leakDetection.level=PARANOID

--- a/project/PekkoBuild.scala
+++ b/project/PekkoBuild.scala
@@ -212,8 +212,11 @@ object PekkoBuild {
         "-XX:MaxGCPauseMillis=300",
         // nio direct memory limit for artery/aeron (probably)
         "-XX:MaxDirectMemorySize=256m",
-        // faster random source
-        "-Djava.security.egd=file:/dev/./urandom")
+        // Non-blocking seed source. Keep the plain path: `/dev/./urandom` does
+        // not match SunEntries.URL_DEV_URANDOM, which switches the default
+        // SecureRandom away from NativePRNG (to DRBG, or SHA1PRNG on JDK 8),
+        // so CI would stop exercising the algorithm users get.
+        "-Djava.security.egd=file:/dev/urandom")
 
       defaults ++
       CliOptions.runningOnCi


### PR DESCRIPTION
### Motivation

The build and every CI workflow pass `-Djava.security.egd=file:/dev/./urandom`. The `/./` is a long-standing workaround whose only effect today is to stop the string matching `SunEntries.URL_DEV_URANDOM`:

```java
DEF_SECURE_RANDOM_ALGO = (NativePRNG.isAvailable() &&
    (seedSource.equals(URL_DEV_URANDOM) || seedSource.equals(URL_DEV_RANDOM))
    ? "NativePRNG" : "DRBG");
```

So CI resolves `new SecureRandom` to something other than the algorithm users get. Measured on every JDK in the build matrix:

| JDK | unset | `file:/dev/./urandom` | `file:/dev/urandom` |
|-----|-------|-----------------------|---------------------|
| 8   | NativePRNG | **SHA1PRNG** | NativePRNG |
| 11  | NativePRNG | DRBG | NativePRNG |
| 17  | NativePRNG | DRBG | NativePRNG |
| 21  | NativePRNG | DRBG | NativePRNG |
| 25  | NativePRNG | DRBG | NativePRNG |

On the 1.x nightlies (`javaVersion: [8, 11, 17, 21]`) that means the JDK 8 jobs have been defaulting to `SHA1PRNG` — which seeds once at startup and never reseeds.

This reaches production code, not just the launcher: `SecureRandomFactory` maps `random-number-generator = ""` straight to `new SecureRandom`, so `TlsTcpSpec`, `Ticket1978CommunicationSpec` and friends have not been exercising the algorithm users actually run with.

The workaround is also no longer needed for its original purpose. On Unix, `NativeSeedGenerator extends SeedGenerator.URLSeedGenerator` and passes the seed file through unchanged — verified in both the JDK 8 and JDK 21 sources — so `file:/dev/urandom` reads `/dev/urandom` and does not block on any supported JDK. The special case only diverges on Windows.

### Modification

Use `file:/dev/urandom` in `project/PekkoBuild.scala`, `.jvmopts-ci` and the twelve workflow files.

Record why the plain path matters next to the two definitions that are hand-edited, so the `/./` is not reintroduced by someone recognising the old idiom.

### Result

CI seeds from a non-blocking source, exactly as before, and `new SecureRandom` resolves to `NativePRNG` on every JDK in the matrix — matching an unconfigured JVM, which is what users get.

No change to shipped defaults, to `reference.conf`, or to any published artifact. Build and CI configuration only.

### Tests

- `scalafmt project/PekkoBuild.scala` — reformatted, no further changes
- Measured the table above by running `new SecureRandom().getAlgorithm()` under each flag on Temurin 8.0.492, 11.0.31, 17.0.19, 21.0.11 and 25.0.3
- No directional test: this is build/CI configuration with no runtime code path of its own

### References

Refs #3481