### PR TITLE
docs: remove stale Java 8/11 framing now that JDK 17 is the minimum

### DIFF
--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -102,8 +102,8 @@ pekko {
   # by setting this property to `off`.
   fail-mixed-versions = on
 
-  # Some modules (remoting only right now) can emit custom events to the Java Flight Recorder if running
-  # on JDK 11 or later. If you for some reason do not want that, it can be disabled and switched to no-ops
+  # Some modules (remoting only right now) can emit custom events to the Java Flight Recorder.
+  # If you for some reason do not want that, it can be disabled and switched to no-ops
   # with this toggle.
   java-flight-recorder {
     enabled = true

--- a/docs/src/main/paradox/persistence.md
+++ b/docs/src/main/paradox/persistence.md
@@ -862,9 +862,10 @@ in your Pekko configuration. Also note that for the LevelDB Java port, you will 
   version="0.9"
 }
 
-@@@ note { title="Java 17" }
+@@@ note
 
-When using LevelDB with Java 17 you have to add JVM flag `--add-opens=java.base/java.nio=ALL-UNNAMED`.
+LevelDB requires the JVM flag `--add-opens=java.base/java.nio=ALL-UNNAMED` on the JDK 17+ runtimes required by
+this Pekko version.
 
 @@@
 

--- a/docs/src/main/paradox/remote-security.md
+++ b/docs/src/main/paradox/remote-security.md
@@ -65,7 +65,7 @@ For TLS 1.3, these are good options:
 
  * TLS_AES_128_GCM_SHA256
  * TLS_AES_256_GCM_SHA384
- * TLS_CHACHA20_POLY1305_SHA256 (may not be supported on Java 8 runtimes)
+ * TLS_CHACHA20_POLY1305_SHA256
 
 You should always check the latest information about security and algorithm recommendations before configuring your
 system.

--- a/docs/src/main/paradox/remoting-artery.md
+++ b/docs/src/main/paradox/remoting-artery.md
@@ -43,9 +43,10 @@ The Aeron dependency needs to be explicitly added if using the `aeron-udp` trans
   version2="$aeron_version$"
 }
 
-@@@ note { title="Java 17" }
+@@@ note
 
-When using Aeron with Java 17 you have to add JVM flag `--add-opens=java.base/sun.nio.ch=ALL-UNNAMED`.
+Aeron requires the JVM flag `--add-opens=java.base/sun.nio.ch=ALL-UNNAMED` on the JDK 17+ runtimes required by
+this Pekko version.
 
 @@@
 
@@ -754,8 +755,9 @@ Any space used in the mount will count towards your container's memory usage.
 
 ### Flight Recorder
 
-When running on JDK 11 Artery specific flight recording is available through the [Java Flight Recorder (JFR)](https://openjdk.java.net/jeps/328).
-The flight recorder is automatically enabled by detecting JDK 11 but can be disabled if needed by setting `pekko.java-flight-recorder.enabled = false`.
+Artery specific flight recording is available through the [Java Flight Recorder (JFR)](https://openjdk.java.net/jeps/328),
+which is included in all JDK versions supported by Pekko. It is automatically enabled but can be disabled if needed
+by setting `pekko.java-flight-recorder.enabled = false`.
 
 Low overhead Artery specific events are emitted by default when JFR is enabled, higher overhead events needs a custom settings template and are not enabled automatically with the `profiling` JFR template.
 To enable those create a copy of the `profiling` template and enable all `Pekko` sub category events, for example through the JMC GUI. 

--- a/docs/src/main/paradox/stream/reactive-streams-interop.md
+++ b/docs/src/main/paradox/stream/reactive-streams-interop.md
@@ -19,17 +19,15 @@ To use Pekko Streams, add the module to your project:
 Pekko Streams implements the [Reactive Streams](https://www.reactive-streams.org/) standard for asynchronous stream processing with non-blocking
 back pressure. 
 
-Since Java 9 the APIs of Reactive Streams has been included in the Java Standard library, under the  `java.util.concurrent.Flow` 
-namespace. For Java 8 there is instead a separate Reactive Streams artifact with the same APIs in the package `org.reactivestreams`.
+Since Java 9 the APIs of Reactive Streams has been included in the Java Standard library, under the `java.util.concurrent.Flow`
+namespace. There is also a separate Reactive Streams artifact with the same APIs in the package `org.reactivestreams`.
 
 Pekko streams provides interoperability for both these two API versions, the Reactive Streams interfaces directly through factories on the
-regular `Source` and `Sink` APIs. For the Java 9 and later built in interfaces there is a separate set of factories in 
+regular `Source` and `Sink` APIs. For the `java.util.concurrent.Flow` built in interfaces there is a separate set of factories in
 @scala[`org.apache.pekko.stream.scaladsl.JavaFlowSupport`]@java[`org.apache.pekko.stream.javadsl.JavaFlowSupport`].
 
 In the following samples the standalone Reactive Stream API factories has been used but each such call can be replaced with the
 corresponding method from `JavaFlowSupport` and the JDK @scala[`java.util.concurrent.Flow._`]@java[`java.util.concurrent.Flow.*`] interfaces.
-
-Note that it is not possible to use `JavaFlowSupport` on Java 8 since the needed interfaces simply is not available in the Java standard library.
 
 The two most important interfaces in Reactive Streams are the `Publisher` and `Subscriber`.
 

--- a/docs/src/main/paradox/typed/cluster-sharding.md
+++ b/docs/src/main/paradox/typed/cluster-sharding.md
@@ -669,10 +669,11 @@ Reasons for disabling:
 
 For supporting remembered entities in an environment without disk storage use `eventsourced` mode instead.
 
-@@@ note { title="Java 17" }
+@@@ note
 
-When using `remember-entities-store=ddata` the remember entities store is persisted to disk by LMDB.
-When running with Java 17 you have to add JVM flags `--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED`.
+When using `remember-entities-store=ddata` the remember entities store is persisted to disk by LMDB, which requires
+the JVM flags `--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED` on the JDK 17+
+runtimes required by this Pekko version.
 
 @@@
 

--- a/docs/src/main/paradox/typed/distributed-data.md
+++ b/docs/src/main/paradox/typed/distributed-data.md
@@ -679,9 +679,10 @@ possible to replace that with another implementation by implementing the actor p
 `org.apache.pekko.cluster.ddata.DurableStore` and defining the `pekko.cluster.distributed-data.durable.store-actor-class`
 property for the new implementation.
 
-@@@ note { title="Java 17" }
+@@@ note
 
-When using LMDB with Java 17 you have to add JVM flags `--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED`.
+LMDB requires the JVM flags `--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED`
+on the JDK 17+ runtimes required by this Pekko version.
 
 @@@
 


### PR DESCRIPTION
Pekko 2.0.x requires JDK 17 as the minimum supported runtime (see release-notes/releases-2.0.md and project/JdkOptions.scala).

Modification:
- `remoting-artery.md`: reworded the Aeron `--add-opens` note and the Flight Recorder section, which claimed JFR is enabled by "detecting JDK 11" even though there is no such runtime detection in `FlightRecorderLoader.scala` - it is controlled purely by the `pekko.java-flight-recorder.enabled` config flag.
- `remote-security.md`: dropped a TLS cipher caveat about Java 8 runtimes, which are no longer supported.
- `stream/reactive-streams-interop.md`: removed Java-8-specific Reactive Streams artifact/JavaFlowSupport caveats.
- `persistence.md`, `typed/cluster-sharding.md`, `typed/distributed-data.md`: reworded the LevelDB/LMDB `--add-opens` notes so they no longer frame JDK 17 as an optional/special case.
- `actor/src/main/resources/reference.conf`: fixed the same stale "JDK 11 or later" framing in the java-flight-recorder comment, which is snip-included into docs/src/main/paradox/general/configuration-reference.md.

Result:
Doc pages and the flight-recorder config comment reflect the current JDK 17+ baseline instead of pre-2.0 Java 8/11 assumptions.