### PR TITLE
build: bump agrona to 2.5.0 to match the version aeron 1.52.3 depends on

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,7 +4,7 @@ updates.pin = [
   # sbt-assembly 2.3 causes build issues (https://github.com/apache/pekko/pull/1744)
   { groupId = "com.eed3si9n", artifactId = "sbt-assembly", version = "2.2." }
   # agrona major+minor version should match the one brought in by aeron
-  { groupId = "org.agrona", artifactId = "agrona", version = "2.4." }
+  { groupId = "org.agrona", artifactId = "agrona", version = "2.5." }
   # we have too many build plugins that need sbt 1.x
   { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." }
 ]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   // Use the major+minor agrona versions matching aeron at
   // https://github.com/aeron-io/aeron/blob/1.x.y/gradle/libs.versions.toml
   // (remember to also update the scala-steward pin)
-  val agronaVersion = "2.4.1"
+  val agronaVersion = "2.5.0"
   val nettyVersion = "4.2.17.Final"
   val logbackVersion = "1.6.3"
 


### PR DESCRIPTION
Changes:

- project/Dependencies.scala: bump agronaVersion from 2.4.1 to 2.5.0.
- .scala-steward.conf: update the matching agrona version pin from "2.4." to "2.5." so scala-steward keeps tracking the same line.
