### PR TITLE
fix: bound Jackson payload decompression size

### DIFF
--- a/serialization-jackson/src/main/resources/reference.conf
+++ b/serialization-jackson/src/main/resources/reference.conf
@@ -205,6 +205,12 @@ pekko.serialization.jackson {
     # If compression is enabled with the `algorithm` setting the payload is compressed
     # when it's larger than this value.
     compress-larger-than = 0 KiB
+
+    # Maximum size of a payload after decompression. A compressed (gzip or lz4)
+    # payload that decompresses to more than this is rejected rather than
+    # allocated, guarding against a small message that inflates without bound.
+    # This applies on deserialization regardless of the `algorithm` setting above.
+    max-decompressed-size = 256 MiB
   }
 
   # Whether the type should be written to the manifest.

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
@@ -207,6 +207,7 @@ import pekko.util.OptionVal
           """"off" or "gzip"""")
     }
   }
+  private val maxDecompressedSize: Long = conf.getBytes("compression.max-decompressed-size")
   private val migrations: Map[String, JacksonMigration] = {
     import scala.jdk.CollectionConverters._
     conf.getConfig("migrations").root.unwrapped.asScala.toMap.map {
@@ -535,18 +536,42 @@ import pekko.util.OptionVal
   def decompress(bytes: Array[Byte]): Array[Byte] = {
     if (isGZipped(bytes)) {
       val in = new GZIPInputStream(new UnsynchronizedByteArrayInputStream(bytes))
-      val out = new ByteArrayOutputStream()
-      try in.transferTo(out)
+      try gunzip(in)
       finally in.close()
-      out.toByteArray
     } else {
       LZ4Meta.get(bytes) match {
         case OptionVal.Some(meta) =>
+          // meta.length is the decompressed size declared on the wire; a small
+          // message can declare a huge (or negative) size and drive a large
+          // allocation, so bound it before decompressing.
+          if (meta.length < 0 || meta.length > maxDecompressedSize)
+            throw new IllegalArgumentException(
+              s"Compressed message declares decompressed size [${meta.length}] bytes, which exceeds the maximum " +
+              s"of [$maxDecompressedSize] bytes (pekko.serialization.jackson.compression.max-decompressed-size)")
           val srcLen = bytes.length - meta.offset
           lz4Decompressor.decompress(bytes, meta.offset, srcLen, meta.length)
         case _ => bytes
       }
     }
+  }
+
+  // gunzip with a bound on the decompressed size, so a small gzip payload cannot
+  // inflate without limit (a "zip bomb").
+  private def gunzip(in: GZIPInputStream): Array[Byte] = {
+    val out = new ByteArrayOutputStream()
+    val buffer = new Array[Byte](BufferSize)
+    var total = 0L
+    var n = in.read(buffer)
+    while (n != -1) {
+      total += n
+      if (total > maxDecompressedSize)
+        throw new IllegalArgumentException(
+          s"Decompressed message exceeds the maximum of [$maxDecompressedSize] bytes " +
+          "(pekko.serialization.jackson.compression.max-decompressed-size)")
+      out.write(buffer, 0, n)
+      n = in.read(buffer)
+    }
+    out.toByteArray
   }
 
 }

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
@@ -653,6 +653,40 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       check(SimpleCommand("Bob"), false)
       check(new SimpleCommandNotCaseClass("Bob"), false)
     }
+
+    "reject a gzip payload that decompresses beyond max-decompressed-size" in withSystem("""
+        pekko.serialization.jackson.jackson-json.compression {
+          algorithm = gzip
+          compress-larger-than = 0 KiB
+          max-decompressed-size = 1 KiB
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      val serializer = serializerFor(msg, sys)
+      val blob = serializeToBinary(msg, sys)
+      JacksonSerializer.isGZipped(blob) should ===(true)
+      val ex = intercept[IllegalArgumentException] {
+        deserializeFromBinary(blob, serializer.identifier, serializer.manifest(msg), sys)
+      }
+      ex.getMessage should include("max-decompressed-size")
+    }
+
+    "reject an lz4 payload that declares a size beyond max-decompressed-size" in withSystem("""
+        pekko.serialization.jackson.jackson-json.compression {
+          algorithm = lz4
+          compress-larger-than = 0 KiB
+          max-decompressed-size = 1 KiB
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      val serializer = serializerFor(msg, sys)
+      val blob = serializeToBinary(msg, sys)
+      JacksonSerializer.isLZ4(blob) should ===(true)
+      val ex = intercept[IllegalArgumentException] {
+        deserializeFromBinary(blob, serializer.identifier, serializer.manifest(msg), sys)
+      }
+      ex.getMessage should include("max-decompressed-size")
+    }
   }
 
   "JacksonJsonSerializer without type in manifest" should {

--- a/serialization-jackson3/src/main/resources/reference.conf
+++ b/serialization-jackson3/src/main/resources/reference.conf
@@ -186,6 +186,12 @@ pekko.serialization.jackson3 {
     # If compression is enabled with the `algorithm` setting the payload is compressed
     # when it's larger than this value.
     compress-larger-than = 0 KiB
+
+    # Maximum size of a payload after decompression. A compressed (gzip or lz4)
+    # payload that decompresses to more than this is rejected rather than
+    # allocated, guarding against a small message that inflates without bound.
+    # This applies on deserialization regardless of the `algorithm` setting above.
+    max-decompressed-size = 256 MiB
   }
 
   # Whether the type should be written to the manifest.

--- a/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonSerializer.scala
+++ b/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonSerializer.scala
@@ -208,6 +208,7 @@ import pekko.util.OptionVal
           """"off" or "gzip"""")
     }
   }
+  private val maxDecompressedSize: Long = conf.getBytes("compression.max-decompressed-size")
   private val migrations: Map[String, JacksonMigration] = {
     import scala.jdk.CollectionConverters._
     conf.getConfig("migrations").root.unwrapped.asScala.toMap.map {
@@ -536,18 +537,42 @@ import pekko.util.OptionVal
   def decompress(bytes: Array[Byte]): Array[Byte] = {
     if (isGZipped(bytes)) {
       val in = new GZIPInputStream(new UnsynchronizedByteArrayInputStream(bytes))
-      val out = new ByteArrayOutputStream()
-      try in.transferTo(out)
+      try gunzip(in)
       finally in.close()
-      out.toByteArray
     } else {
       LZ4Meta.get(bytes) match {
         case OptionVal.Some(meta) =>
+          // meta.length is the decompressed size declared on the wire; a small
+          // message can declare a huge (or negative) size and drive a large
+          // allocation, so bound it before decompressing.
+          if (meta.length < 0 || meta.length > maxDecompressedSize)
+            throw new IllegalArgumentException(
+              s"Compressed message declares decompressed size [${meta.length}] bytes, which exceeds the maximum " +
+              s"of [$maxDecompressedSize] bytes (pekko.serialization.jackson3.compression.max-decompressed-size)")
           val srcLen = bytes.length - meta.offset
           lz4Decompressor.decompress(bytes, meta.offset, srcLen, meta.length)
         case _ => bytes
       }
     }
+  }
+
+  // gunzip with a bound on the decompressed size, so a small gzip payload cannot
+  // inflate without limit (a "zip bomb").
+  private def gunzip(in: GZIPInputStream): Array[Byte] = {
+    val out = new ByteArrayOutputStream()
+    val buffer = new Array[Byte](BufferSize)
+    var total = 0L
+    var n = in.read(buffer)
+    while (n != -1) {
+      total += n
+      if (total > maxDecompressedSize)
+        throw new IllegalArgumentException(
+          s"Decompressed message exceeds the maximum of [$maxDecompressedSize] bytes " +
+          "(pekko.serialization.jackson3.compression.max-decompressed-size)")
+      out.write(buffer, 0, n)
+      n = in.read(buffer)
+    }
+    out.toByteArray
   }
 
 }

--- a/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
+++ b/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
@@ -598,6 +598,40 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       check(SimpleCommand("Bob"), false)
       check(new SimpleCommandNotCaseClass("Bob"), false)
     }
+
+    "reject a gzip payload that decompresses beyond max-decompressed-size" in withSystem("""
+        pekko.serialization.jackson3.jackson-json.compression {
+          algorithm = gzip
+          compress-larger-than = 0 KiB
+          max-decompressed-size = 1 KiB
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      val serializer = serializerFor(msg, sys)
+      val blob = serializeToBinary(msg, sys)
+      JacksonSerializer.isGZipped(blob) should ===(true)
+      val ex = intercept[IllegalArgumentException] {
+        deserializeFromBinary(blob, serializer.identifier, serializer.manifest(msg), sys)
+      }
+      ex.getMessage should include("max-decompressed-size")
+    }
+
+    "reject an lz4 payload that declares a size beyond max-decompressed-size" in withSystem("""
+        pekko.serialization.jackson3.jackson-json.compression {
+          algorithm = lz4
+          compress-larger-than = 0 KiB
+          max-decompressed-size = 1 KiB
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      val serializer = serializerFor(msg, sys)
+      val blob = serializeToBinary(msg, sys)
+      JacksonSerializer.isLZ4(blob) should ===(true)
+      val ex = intercept[IllegalArgumentException] {
+        deserializeFromBinary(blob, serializer.identifier, serializer.manifest(msg), sys)
+      }
+      ex.getMessage should include("max-decompressed-size")
+    }
   }
 
   "JacksonJsonSerializer without type in manifest" should {


### PR DESCRIPTION
### Motivation
`JacksonSerializer.decompress` inflated gzip payloads with an unbounded `transferTo`, and passed the lz4 decompressed length declared on the wire straight to the decompressor as the allocation size. A small, well-formed compressed message could therefore declare (lz4) or expand to (gzip) an arbitrarily large size and drive an `OutOfMemoryError` on deserialization — reachable wherever the Jackson serializer deserializes attacker-influenced payloads.

### Modification
- Add a `compression.max-decompressed-size` setting (default `256 MiB`) to both the `serialization-jackson` and `serialization-jackson3` reference configs.
- On deserialization the gzip path now copies through a bounded loop (`gunzip`) that fails once the output exceeds the cap; the lz4 path rejects a declared length that is negative or over the cap **before** allocating.
- The bound applies regardless of the `algorithm` setting, because decompression is selected by the payload's magic bytes, not by local config.

All changed symbols are `@InternalApi`/private, so no MiMa impact.

### Result
A payload that would decompress beyond the cap is rejected with an `IllegalArgumentException` instead of exhausting the heap. Payloads within the cap round-trip as before.

### Tests
- `sbt "serialization-jackson/testOnly *JacksonJsonSerializerSpec" "serialization-jackson3/testOnly *JacksonJsonSerializerSpec"` — 71 passed each, including new gzip and lz4 cap-rejection tests
- `sbt "serialization-jackson/mimaReportBinaryIssues"` — no issues
- `sbt scalafmt` for the changed main and test sources

### References
None - found while reviewing the draft threat model in #3478
