### PR TITLE
fix: bound inbound Artery TCP frame length at framing

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ArteryTcpTransport.scala
@@ -355,7 +355,8 @@ private[remote] class ArteryTcpTransport(
       Flow[ByteString]
         .via(inboundKillSwitch.flow)
         // must create new FlightRecorder event sink for each connection because they can't be shared
-        .via(new TcpFraming(settings.Advanced.TcpMagicValues, flightRecorder))
+        .via(new TcpFraming(settings.Advanced.TcpMagicValues, flightRecorder,
+          settings.Advanced.MaximumFrameSize, settings.Advanced.MaximumLargeFrameSize))
         .alsoTo(inboundStream)
         .filter(_ => false) // don't send back anything in this TCP socket
         .map(_ => ByteString.empty) // make it a Flow[ByteString] again

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/TcpFraming.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/TcpFraming.scala
@@ -79,7 +79,9 @@ import pekko.util.ByteString
  */
 @InternalApi private[pekko] class TcpFraming(
     acceptedMagic: immutable.Seq[ByteString] = List(TcpFraming.DefaultMagic),
-    flightRecorder: RemotingFlightRecorder = NoOpRemotingFlightRecorder)
+    flightRecorder: RemotingFlightRecorder = NoOpRemotingFlightRecorder,
+    maximumFrameSize: Int = Int.MaxValue,
+    maximumLargeFrameSize: Int = Int.MaxValue)
     extends ByteStringParser[EnvelopeBuffer] {
 
   private val magicLength = acceptedMagic.head.length
@@ -102,15 +104,31 @@ import pekko.util.ByteString
       }
     }
     case object ReadStreamId extends Step {
-      override def parse(reader: ByteReader): ParseResult[EnvelopeBuffer] =
-        ParseResult(None, ReadFrame(reader.readByte()))
+      override def parse(reader: ByteReader): ParseResult[EnvelopeBuffer] = {
+        val streamId = reader.readByte()
+        // A connection carries a single stream for its lifetime; the large-message
+        // stream is allowed bigger frames than the control and ordinary streams.
+        val maxFrameSize =
+          if (streamId == ArteryTransport.LargeStreamId) maximumLargeFrameSize else maximumFrameSize
+        ParseResult(None, ReadFrame(streamId, maxFrameSize))
+      }
     }
-    case class ReadFrame(streamId: Int) extends Step {
+    case class ReadFrame(streamId: Int, maxFrameSize: Int) extends Step {
       override def onTruncation(): Unit =
         failStage(new FramingException("Stream finished but there was a truncated final frame in the buffer"))
 
       override def parse(reader: ByteReader): ParseResult[EnvelopeBuffer] = {
         val frameLength = reader.readIntLE()
+        // frameLength is read from the wire before any data is buffered; reject an
+        // out-of-range value here so a peer cannot drive a huge allocation (which
+        // would be a fatal OutOfMemoryError on the shared inbound stream) by
+        // declaring an oversized or negative frame. FramingException tears down
+        // only this connection.
+        if (frameLength < 0 || frameLength > maxFrameSize)
+          throw new FramingException(
+            s"Frame length [$frameLength] for stream [$streamId] is out of range, " +
+            s"must be between 0 and the maximum frame size [$maxFrameSize]. " +
+            "Connection is rejected.")
         val buffer = createBuffer(reader.take(frameLength))
         ParseResult(Some(buffer), this)
       }

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/TcpFramingSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/TcpFramingSpec.scala
@@ -33,6 +33,9 @@ class TcpFramingSpec extends PekkoSpec("""
   private val magic = TcpFraming.DefaultMagic
   private val acceptedMagic = List(magic, TcpFraming.LegacyMagic)
   private val framingFlow = Flow[ByteString].via(new TcpFraming(acceptedMagic))
+  private val maxFrameSize = 256 * 1024
+  private val boundedFramingFlow =
+    Flow[ByteString].via(new TcpFraming(acceptedMagic, maximumFrameSize = maxFrameSize))
 
   private val payload5 = ByteString((1 to 5).map(_.toByte).toArray)
 
@@ -99,6 +102,25 @@ class TcpFramingSpec extends PekkoSpec("""
           frame.streamId should ===(3)
         }
       }
+    }
+
+    "reject a frame that exceeds the maximum frame size" in {
+      val bytes = TcpFraming.encodeConnectionHeader(magic, 2) ++ encodeFrameHeader(maxFrameSize + 1)
+      val fail = Source(List(bytes)).via(boundedFramingFlow).runWith(Sink.seq).failed.futureValue
+      fail shouldBe a[FramingException]
+    }
+
+    "reject a frame with a negative declared length" in {
+      val bytes = TcpFraming.encodeConnectionHeader(magic, 2) ++ encodeFrameHeader(-1)
+      val fail = Source(List(bytes)).via(boundedFramingFlow).runWith(Sink.seq).failed.futureValue
+      fail shouldBe a[FramingException]
+    }
+
+    "accept a frame at exactly the maximum frame size" in {
+      val payload = ByteString(Array.fill(maxFrameSize)(7.toByte))
+      val bytes = TcpFraming.encodeConnectionHeader(magic, 2) ++ encodeFrameHeader(maxFrameSize) ++ payload
+      val frames = Source(List(bytes)).via(boundedFramingFlow).runWith(Sink.seq).futureValue
+      frames.head.byteBuffer.limit() should ===(maxFrameSize)
     }
 
     "report truncated frames" in {


### PR DESCRIPTION
### Motivation
`TcpFraming` read the 4-byte frame length from the wire and passed it straight to `reader.take` / `ByteBuffer` allocation with no bound (`ReadFrame.parse`). A peer — unauthenticated on the default `tcp` transport — could declare an oversized (up to ~2 GiB) or negative frame length and drive a large allocation.

This matters more than a single connection because the decoder and deserializer stages downstream of the inbound `MergeHub` are **shared by every inbound connection**. A fatal `OutOfMemoryError` there fails the shared inbound stream, and `ArteryTransport.attachInboundStreamRestart` terminates the whole `ActorSystem` after `inbound-max-restarts` (default 5) failures within `inbound-restart-timeout` (default 5 s) — so one malformed connection can escalate to node loss.

### Modification
- Thread the already-configured `maximum-frame-size` and `maximum-large-frame-size` into `TcpFraming`.
- A connection carries a single stream for its lifetime, so `ReadStreamId` selects the applicable bound (the large-message stream keeps its larger limit) and `ReadFrame` rejects a frame length that is negative or over that bound **before any data is buffered**.
- Rejection is a `FramingException`, which tears down only that connection — the correct per-connection outcome, and never a fatal error on the shared stream.

New constructor params default to `Int.MaxValue`, so the change is source- and binary-compatible; `TcpFraming` is `@InternalApi` regardless.

### Result
A malformed or oversized frame is rejected per-connection instead of allocating without limit and risking a fatal error that escalates to `ActorSystem` termination. Legitimate frames up to the configured maxima are unaffected.

### Tests
- `sbt "remote/testOnly org.apache.pekko.remote.artery.tcp.TcpFramingSpec"` — 14 passed, including new oversized, negative-length and at-the-limit frame cases
- `sbt "remote/testOnly org.apache.pekko.remote.artery.LargeMessagesStreamSpec"` — 4 passed (legitimate large frames still delivered end-to-end)
- `sbt "remote/mimaReportBinaryIssues"` — no issues

### References
None - found while reviewing the draft threat model in #3478
