### PR TITLE
test: fix flaky FusingSpec activeStage assertion

### DIFF
--- a/stream-tests/src/test/scala/org/apache/pekko/stream/FusingSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/FusingSpec.scala
@@ -377,7 +377,11 @@ class FusingSpec extends StreamSpec {
       Await.result(ready.future, 3.seconds)
       Await.result(stageActorFuture, 3.seconds) ! "complete"
       Await.result(done, 3.seconds) should ===(Done)
-      Await.result(interpreterPromise.future, 3.seconds).activeStage should be(null)
+      val completedInterpreter = Await.result(interpreterPromise.future, 3.seconds)
+      // `done` completes from within the downstream sink's own processing, so the interpreter
+      // may still be finalizing that stage (and briefly hold it as `activeStage`) when this
+      // thread wakes. Poll until it has settled rather than reading once and racing the clear.
+      awaitAssert(completedInterpreter.activeStage should be(null))
     }
 
     "stop a lazy stage actor dispatch after its handler fails" in {


### PR DESCRIPTION
### Motivation
`FusingSpec` — "leave activeStage cleared when a stage actor callback completes its stage" (added in #3461) — is intermittently failing (#3494), observing the downstream `IgnoreSink` as `activeStage` rather than `null`.

The invariant #3461 introduced is holding: the async source stage the test guards against leaking **was** cleared. The reported `activeStage` is the downstream `Sink.ignore`, which the interpreter is still finalizing. `done` (Sink.ignore's materialized future) is completed from **within** `IgnoreSink.onUpstreamFinish`, at which point `activeStage` still references the sink, and only afterwards does the interpreter run `releaseStage` to clear it (`GraphInterpreter.scala:821`). The test thread, woken by `done`, read the non-volatile `activeStage` in a race with that clear — usually saw `null`, occasionally the sink.

So this is a test-synchronization race, not a product bug.

### Modification
Poll the final assertion with `awaitAssert`, so it settles once the interpreter reaches idle, instead of reading `activeStage` once and racing the clear. Also rename the local from `interpreter` to `completedInterpreter` to avoid shadowing `GraphStageLogic.interpreter` inside the inner stage (a fatal warning under the project's `-Wconf`).

### Result
The test asserts the same invariant — `activeStage` ends up `null` after the callback completes its stage — without the timing race.

### Tests
- `sbt "stream-tests/testOnly org.apache.pekko.stream.FusingSpec"` — 24 passed

### References
Fixes #3494
