### PR TITLE
fix: bound nesting depth when deserializing enclosed payloads (#3500)

### DIFF
--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -775,14 +775,14 @@ pekko {
     #
     # Please note that this option does not stop you from manually invoking java serialization
     #
+    allow-java-serialization = off
+
     # Maximum nesting depth when a serialized payload encloses another serialized
     # payload (for example Some, Optional, Status.Failure, StatusReply, a Throwable
     # cause, or an ActorSelectionMessage). Each level is parsed separately, so this is
     # the only bound on the chain. A message nested deeper than this is rejected with a
     # NotSerializableException rather than failing with a StackOverflowError.
     serialization-max-nesting-depth = 32
-
-    allow-java-serialization = off
 
     # Log warnings when the Java serialization is used to serialize messages.
     # Java serialization is not very performant and should not be used in production

--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -775,6 +775,13 @@ pekko {
     #
     # Please note that this option does not stop you from manually invoking java serialization
     #
+    # Maximum nesting depth when a serialized payload encloses another serialized
+    # payload (for example Some, Optional, Status.Failure, StatusReply, a Throwable
+    # cause, or an ActorSelectionMessage). Each level is parsed separately, so this is
+    # the only bound on the chain. A message nested deeper than this is rejected with a
+    # NotSerializableException rather than failing with a StackOverflowError.
+    serialization-max-nesting-depth = 32
+
     allow-java-serialization = off
 
     # Log warnings when the Java serialization is used to serialize messages.

--- a/actor/src/main/scala/org/apache/pekko/serialization/NestedDeserialization.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/NestedDeserialization.scala
@@ -38,6 +38,8 @@ import org.apache.pekko.annotation.InternalApi
 @InternalApi
 private[pekko] object NestedDeserialization {
 
+  // a one-element Array[Int] serves as a mutable int holder, so incrementing the
+  // depth does not box the way a ThreadLocal[Int] would on every get/set
   private val depth = new ThreadLocal[Array[Int]] {
     override def initialValue(): Array[Int] = new Array[Int](1)
   }

--- a/actor/src/main/scala/org/apache/pekko/serialization/NestedDeserialization.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/NestedDeserialization.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.serialization
+
+import java.io.NotSerializableException
+
+import org.apache.pekko.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ *
+ * Bounds how deeply one deserialization may nest.
+ *
+ * Several wire formats carry a nested payload: the enclosed message is an opaque byte
+ * array that is deserialized in turn, and that payload may itself enclose another. Each
+ * level is parsed on its own, so a protobuf parser's nesting limit does not bound the
+ * chain - only the size of the message does. Recursion therefore tracks the nesting
+ * rather than the size of the message, and a sufficiently deep chain fails with a
+ * `StackOverflowError` instead of a serialization error.
+ *
+ * The depth is per thread because one message is deserialized synchronously on one thread.
+ */
+@InternalApi
+private[pekko] object NestedDeserialization {
+
+  private val depth = new ThreadLocal[Array[Int]] {
+    override def initialValue(): Array[Int] = new Array[Int](1)
+  }
+
+  /**
+   * Runs `body` one level deeper, failing with `NotSerializableException` - the ordinary
+   * way a message that cannot be deserialized is reported - when the nesting exceeds `max`.
+   */
+  def atNextLevel[T](max: Int)(body: => T): T = {
+    val counter = depth.get()
+    counter(0) += 1
+    try {
+      if (counter(0) > max)
+        throw new NotSerializableException(
+          s"Message exceeds the maximum deserialization nesting depth of [$max]. " +
+          "Configure with 'pekko.actor.serialization-max-nesting-depth'.")
+      body
+    } finally counter(0) -= 1
+  }
+
+  /** Current nesting depth, for testing. */
+  def currentDepth: Int = depth.get()(0)
+}

--- a/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
@@ -156,6 +156,13 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
   val log: LoggingAdapter = _log
   private val manifestCache = new AtomicReference[Map[String, Option[Class[_]]]](Map.empty[String, Option[Class[_]]])
 
+  /**
+   * INTERNAL API: maximum nesting depth for a payload that encloses another serialized payload.
+   */
+  @InternalApi
+  private[pekko] val maxNestingDepth: Int =
+    system.settings.config.getInt("pekko.actor.serialization-max-nesting-depth")
+
   /** INTERNAL API */
   @InternalApi private[pekko] def serializationInformation: Serialization.Information =
     system.provider.serializationInformation
@@ -227,27 +234,29 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
     }
 
     withTransportInformation { () =>
-      serializer match {
-        case s2: SerializerWithStringManifest => s2.fromBinary(bytes, manifest)
-        case s1                               =>
-          if (manifest == "")
-            s1.fromBinary(bytes, None)
-          else {
-            val cache = manifestCache.get
-            cache.get(manifest) match {
-              case Some(cachedClassManifest) => s1.fromBinary(bytes, cachedClassManifest)
-              case None                      =>
-                system.dynamicAccess.getClassFor[AnyRef](manifest) match {
-                  case Success(classManifest) =>
-                    val classManifestOption: Option[Class[_]] = Some(classManifest)
-                    updateCache(cache, manifest, classManifestOption)
-                    s1.fromBinary(bytes, classManifestOption)
-                  case Failure(_) =>
-                    throw new NotSerializableException(
-                      s"Cannot find manifest class [$manifest] for serializer with id [${serializer.identifier}].")
-                }
+      NestedDeserialization.atNextLevel(maxNestingDepth) {
+        serializer match {
+          case s2: SerializerWithStringManifest => s2.fromBinary(bytes, manifest)
+          case s1                               =>
+            if (manifest == "")
+              s1.fromBinary(bytes, None)
+            else {
+              val cache = manifestCache.get
+              cache.get(manifest) match {
+                case Some(cachedClassManifest) => s1.fromBinary(bytes, cachedClassManifest)
+                case None                      =>
+                  system.dynamicAccess.getClassFor[AnyRef](manifest) match {
+                    case Success(classManifest) =>
+                      val classManifestOption: Option[Class[_]] = Some(classManifest)
+                      updateCache(cache, manifest, classManifestOption)
+                      s1.fromBinary(bytes, classManifestOption)
+                    case Failure(_) =>
+                      throw new NotSerializableException(
+                        s"Cannot find manifest class [$manifest] for serializer with id [${serializer.identifier}].")
+                  }
+              }
             }
-          }
+        }
       }
     }
   }

--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/WrappedPayloadSupport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/WrappedPayloadSupport.scala
@@ -22,6 +22,7 @@ import pekko.remote.ContainerFormats
 import pekko.serialization.ByteBufferSerializer
 import pekko.serialization.{ SerializationExtension, Serializers }
 import pekko.serialization.DisabledJavaSerializer
+import pekko.serialization.NestedDeserialization
 import pekko.serialization.Serialization
 import pekko.serialization.SerializerWithStringManifest
 
@@ -93,15 +94,20 @@ private[pekko] object WrappedPayloadSupport {
 
   def deserializePayload(payload: ContainerFormats.Payload, serialization: Serialization): Any = {
     val manifest = if (payload.hasMessageManifest) payload.getMessageManifest.toStringUtf8 else ""
+    // A payload may enclose another payload; bound how deep that can go. The level is counted
+    // where a serializer is actually invoked: the two branches below call one directly and count
+    // it here, while the third delegates to `Serialization`, which counts it itself.
+    val max = serialization.maxNestingDepth
     serialization.serializerByIdentity(payload.getSerializerId) match {
       case serializer: ByteBufferSerializer =>
         // may avoid one copy of the serialized payload if the proto byte is the right kind and the
         // underlying payload serializer handles byte buffers
         val buffer = payload.getEnclosedMessage.asReadOnlyByteBuffer()
         buffer.order(ByteOrder.LITTLE_ENDIAN)
-        serializer.fromBinary(buffer, manifest)
+        NestedDeserialization.atNextLevel(max)(serializer.fromBinary(buffer, manifest))
       case serializer: SerializerWithStringManifest =>
-        serializer.fromBinary(payload.getEnclosedMessage.toByteArray, manifest)
+        NestedDeserialization.atNextLevel(max)(
+          serializer.fromBinary(payload.getEnclosedMessage.toByteArray, manifest))
       case _ =>
         // only old class based manifest serializers?
         serialization.deserialize(payload.getEnclosedMessage.toByteArray, payload.getSerializerId, manifest).get

--- a/remote/src/test/scala/org/apache/pekko/remote/serialization/NestedPayloadDepthSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/serialization/NestedPayloadDepthSpec.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.remote.serialization
+
+import java.io.NotSerializableException
+
+import org.apache.pekko
+import pekko.actor.Status
+import pekko.protobufv3.internal.{ ByteString => ProtoByteString }
+import pekko.remote.ContainerFormats
+import pekko.serialization.SerializationExtension
+import pekko.serialization.Serializers
+import pekko.testkit.PekkoSpec
+
+class NestedPayloadDepthSpec extends PekkoSpec("""
+    pekko.actor.allow-java-serialization = off
+  """) {
+
+  private val serialization = SerializationExtension(system)
+  private val MiscSerializerId = 16
+  private val OptionManifest = "C"
+
+  private def payloadFor(obj: AnyRef): ContainerFormats.Payload = {
+    val ser = serialization.findSerializerFor(obj)
+    ContainerFormats.Payload
+      .newBuilder()
+      .setEnclosedMessage(ProtoByteString.copyFrom(serialization.serialize(obj).get))
+      .setSerializerId(ser.identifier)
+      .setMessageManifest(ProtoByteString.copyFromUtf8(Serializers.manifestFor(ser, obj)))
+      .build()
+  }
+
+  /** Wraps a payload in one more `Some(...)` layer, as the wire format encodes it. */
+  private def wrapInOption(inner: ContainerFormats.Payload): ContainerFormats.Payload = {
+    val optionBytes = ContainerFormats.Option.newBuilder().setValue(inner).build().toByteArray
+    ContainerFormats.Payload
+      .newBuilder()
+      .setEnclosedMessage(ProtoByteString.copyFrom(optionBytes))
+      .setSerializerId(MiscSerializerId)
+      .setMessageManifest(ProtoByteString.copyFromUtf8(OptionManifest))
+      .build()
+  }
+
+  private def nestedOption(depth: Int): ContainerFormats.Payload = (1 to depth).foldLeft(payloadFor(pekko.Done))(
+    (acc, _) => wrapInOption(acc))
+
+  private def deserialize(p: ContainerFormats.Payload): AnyRef =
+    serialization.deserialize(p.getEnclosedMessage.toByteArray, p.getSerializerId, OptionManifest).get
+
+  "Deserialization of a nested payload" must {
+
+    "accept nesting within the configured depth" in {
+      serialization.maxNestingDepth should ===(32)
+      deserialize(nestedOption(4)) should ===(Some(Some(Some(Some(pekko.Done)))))
+    }
+
+    "reject nesting beyond the configured depth with NotSerializableException" in {
+      // Deeper than the limit, but still a tiny message: without a bound the depth of
+      // this recursion is limited only by the stack.
+      val ex = intercept[NotSerializableException] {
+        deserialize(nestedOption(200))
+      }
+      ex.getMessage should include("nesting depth")
+    }
+
+    "reject deep nesting that would otherwise exhaust the stack" in {
+      val deep = nestedOption(20000)
+      withClue(s"payload is only ${deep.getEnclosedMessage.size()} bytes: ") {
+        intercept[NotSerializableException] {
+          deserialize(deep)
+        }
+      }
+    }
+
+    "not leak depth between messages" in {
+      intercept[NotSerializableException](deserialize(nestedOption(200)))
+      // a later, well-formed message must still be accepted
+      deserialize(nestedOption(4)) should ===(Some(Some(Some(Some(pekko.Done)))))
+    }
+
+    "still deserialize ordinary wrapped messages" in {
+      val failure = Status.Failure(new IllegalArgumentException("boom"))
+      val roundTripped = serialization
+        .deserialize(
+          serialization.serialize(failure).get,
+          serialization.findSerializerFor(failure).identifier,
+          Serializers.manifestFor(serialization.findSerializerFor(failure), failure))
+        .get
+      roundTripped.getClass should ===(classOf[Status.Failure])
+    }
+  }
+}


### PR DESCRIPTION
cherry pick 3def3978a79e3a07db2703d40a0c0ac1789752ee #3500