### PR TITLE
fix: resolve, check and parse manifests more carefully in the Jackson serializers

### DIFF
--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
@@ -119,7 +119,8 @@ import pekko.util.OptionVal
     }
 
     def get(buffer: ByteBuffer): OptionVal[LZ4Meta] = {
-      if (buffer.remaining() < 4) {
+      // the header is the magic plus the declared length, so 8 bytes are read below
+      if (buffer.remaining() < 8) {
         OptionVal.None
       } else if (buffer.getInt() != LZ4_MAGIC) {
         OptionVal.None
@@ -347,14 +348,23 @@ import pekko.util.OptionVal
       checkAllowedClassName(className)
 
     if (isCaseObject(className)) {
+      // `getObjectFor` reads the MODULE$ field, which initializes the class. Resolve the class
+      // with `getClassFor` first, which does not initialize, and run the allow list check on it,
+      // so a manifest naming a class this serializer would reject cannot run that class's
+      // initializer on the way to being rejected.
+      val clazz = system.dynamicAccess.getClassFor[AnyRef](className) match {
+        case Success(c) => c
+        case Failure(_) =>
+          throw new NotSerializableException(
+            s"Cannot find manifest case object [$className] for serializer [${getClass.getName}].")
+      }
+      checkAllowedClass(clazz)
       val result = system.dynamicAccess.getObjectFor[AnyRef](className) match {
         case Success(obj) => obj
         case Failure(_)   =>
           throw new NotSerializableException(
             s"Cannot find manifest case object [$className] for serializer [${getClass.getName}].")
       }
-      val clazz = result.getClass
-      checkAllowedClass(clazz)
       // no migrations for case objects, since no json tree
       logFromBinaryDuration(bytes, bytes, startTime, clazz)
       result
@@ -460,7 +470,10 @@ import pekko.util.OptionVal
    * and still bind with the same class (interface).
    */
   private def isInAllowList(clazz: Class[?]): Boolean = {
-    isBoundToJacksonSerializer(clazz) || hasAllowedClassPrefix(clazz.getName)
+    // The prefix check comes first because it cannot throw: `isBoundToJacksonSerializer` calls
+    // `serializerFor`, which raises (and fills in the stack trace of) a NotSerializableException
+    // for an unbound class, and this runs on every `fromBinary`.
+    hasAllowedClassPrefix(clazz.getName) || isBoundToJacksonSerializer(clazz)
   }
 
   private def isBoundToJacksonSerializer(clazz: Class[?]): Boolean = {
@@ -509,7 +522,14 @@ import pekko.util.OptionVal
 
   private def parseManifest(manifest: String) = {
     val i = manifest.lastIndexOf('#')
-    val fromVersion = if (i == -1) 1 else manifest.substring(i + 1).toInt
+    val fromVersion =
+      if (i == -1) 1
+      else
+        manifest
+          .substring(i + 1)
+          .toIntOption
+          .getOrElse(throw new NotSerializableException(
+            s"Manifest [$manifest] for serializer [${getClass.getName}] does not end with a numeric version."))
     val manifestClassName = if (i == -1) manifest else manifest.substring(0, i)
     (fromVersion, manifestClassName)
   }

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/CaseObjectInitializationProbe.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/CaseObjectInitializationProbe.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.serialization.jackson
+
+/**
+ * Records whether [[NotAllowedCaseObject]] has been initialized. A test asserts this stays
+ * false while deserializing a manifest that names it, so refer to that object by its class
+ * name as a string and never in code, which would initialize it.
+ */
+object CaseObjectInitializationProbe {
+  @volatile var initialized: Boolean = false
+}
+
+/**
+ * Neither bound to a Jackson serializer nor covered by `allowed-class-prefix`, so a manifest
+ * naming it has to be rejected by the allow list.
+ */
+object NotAllowedCaseObject {
+  CaseObjectInitializationProbe.initialized = true
+}

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.serialization.jackson
 
 import java.lang
+import java.io.NotSerializableException
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.time.Instant
@@ -856,6 +857,9 @@ abstract class JacksonSerializerSpec(serializerName: String)
     serialization(sys).deserialize(blob, serializerId, manifest).get
   }
 
+  // referenced by name only: mentioning the object in code would initialize it
+  val NotAllowedCaseObjectName = "org.apache.pekko.serialization.jackson.NotAllowedCaseObject$"
+
   def serializerFor(obj: AnyRef, sys: ActorSystem = system): JacksonSerializer =
     serialization(sys).findSerializerFor(obj) match {
       case serializer: JacksonSerializer => serializer
@@ -1309,6 +1313,50 @@ abstract class JacksonSerializerSpec(serializerName: String)
           serializer.fromBinary(blob, classOf[Status.Success].getName)
         }.getMessage.toLowerCase should include("allowed-class-prefix")
       }
+    }
+
+    "not allow deserialization of a case object that is not in serialization-bindings" in {
+      withTransportInformation() { () =>
+        val msg = SimpleCommand("ok")
+        val serializer = serializerFor(msg)
+        val blob = serializer.toBinary(msg)
+        intercept[IllegalArgumentException] {
+          // maliciously changing manifest to a case object
+          serializer.fromBinary(blob, NotAllowedCaseObjectName)
+        }.getMessage.toLowerCase should include("allowed-class-prefix")
+      }
+    }
+
+    "not initialize a case object class it goes on to reject" in {
+      withTransportInformation() { () =>
+        val msg = SimpleCommand("ok")
+        val serializer = serializerFor(msg)
+        val blob = serializer.toBinary(msg)
+        CaseObjectInitializationProbe.initialized should ===(false)
+        intercept[IllegalArgumentException] {
+          serializer.fromBinary(blob, NotAllowedCaseObjectName)
+        }
+        // reading MODULE$ would have run the object's body
+        CaseObjectInitializationProbe.initialized should ===(false)
+      }
+    }
+
+    "reject a manifest whose version is not a number" in {
+      withTransportInformation() { () =>
+        val msg = SimpleCommand("ok")
+        val serializer = serializerFor(msg)
+        val blob = serializer.toBinary(msg)
+        intercept[NotSerializableException] {
+          serializer.fromBinary(blob, classOf[SimpleCommand].getName + "#not-a-number")
+        }.getMessage should include("numeric version")
+      }
+    }
+
+    "not underflow on a payload that is only as long as the LZ4 magic" in {
+      // the LZ4 header is the magic plus a 4 byte length, so 4 bytes cannot be an LZ4 payload
+      JacksonSerializer.isLZ4(Array(0x87, 0xD9, 0x6D, 0xF6).map(_.toByte)) should ===(false)
+      JacksonSerializer.isLZ4(JacksonSerializer.LZ4Meta(Array.emptyByteArray).prependTo(Array.emptyByteArray)) should
+      ===(true)
     }
 
     "not allow serialization-bindings of open-ended types" in {

--- a/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonSerializer.scala
+++ b/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonSerializer.scala
@@ -120,7 +120,8 @@ import pekko.util.OptionVal
     }
 
     def get(buffer: ByteBuffer): OptionVal[LZ4Meta] = {
-      if (buffer.remaining() < 4) {
+      // the header is the magic plus the declared length, so 8 bytes are read below
+      if (buffer.remaining() < 8) {
         OptionVal.None
       } else if (buffer.getInt() != LZ4_MAGIC) {
         OptionVal.None
@@ -348,14 +349,23 @@ import pekko.util.OptionVal
       checkAllowedClassName(className)
 
     if (isCaseObject(className)) {
+      // `getObjectFor` reads the MODULE$ field, which initializes the class. Resolve the class
+      // with `getClassFor` first, which does not initialize, and run the allow list check on it,
+      // so a manifest naming a class this serializer would reject cannot run that class's
+      // initializer on the way to being rejected.
+      val clazz = system.dynamicAccess.getClassFor[AnyRef](className) match {
+        case Success(c) => c
+        case Failure(_) =>
+          throw new NotSerializableException(
+            s"Cannot find manifest case object [$className] for serializer [${getClass.getName}].")
+      }
+      checkAllowedClass(clazz)
       val result = system.dynamicAccess.getObjectFor[AnyRef](className) match {
         case Success(obj) => obj
         case Failure(_)   =>
           throw new NotSerializableException(
             s"Cannot find manifest case object [$className] for serializer [${getClass.getName}].")
       }
-      val clazz = result.getClass
-      checkAllowedClass(clazz)
       // no migrations for case objects, since no json tree
       logFromBinaryDuration(bytes, bytes, startTime, clazz)
       result
@@ -461,7 +471,10 @@ import pekko.util.OptionVal
    * and still bind with the same class (interface).
    */
   private def isInAllowList(clazz: Class[?]): Boolean = {
-    isBoundToJacksonSerializer(clazz) || hasAllowedClassPrefix(clazz.getName)
+    // The prefix check comes first because it cannot throw: `isBoundToJacksonSerializer` calls
+    // `serializerFor`, which raises (and fills in the stack trace of) a NotSerializableException
+    // for an unbound class, and this runs on every `fromBinary`.
+    hasAllowedClassPrefix(clazz.getName) || isBoundToJacksonSerializer(clazz)
   }
 
   private def isBoundToJacksonSerializer(clazz: Class[?]): Boolean = {
@@ -510,7 +523,14 @@ import pekko.util.OptionVal
 
   private def parseManifest(manifest: String) = {
     val i = manifest.lastIndexOf('#')
-    val fromVersion = if (i == -1) 1 else manifest.substring(i + 1).toInt
+    val fromVersion =
+      if (i == -1) 1
+      else
+        manifest
+          .substring(i + 1)
+          .toIntOption
+          .getOrElse(throw new NotSerializableException(
+            s"Manifest [$manifest] for serializer [${getClass.getName}] does not end with a numeric version."))
     val manifestClassName = if (i == -1) manifest else manifest.substring(0, i)
     (fromVersion, manifestClassName)
   }

--- a/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/CaseObjectInitializationProbe.scala
+++ b/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/CaseObjectInitializationProbe.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.serialization.jackson3
+
+/**
+ * Records whether [[NotAllowedCaseObject]] has been initialized. A test asserts this stays
+ * false while deserializing a manifest that names it, so refer to that object by its class
+ * name as a string and never in code, which would initialize it.
+ */
+object CaseObjectInitializationProbe {
+  @volatile var initialized: Boolean = false
+}
+
+/**
+ * Neither bound to a Jackson serializer nor covered by `allowed-class-prefix`, so a manifest
+ * naming it has to be rejected by the allow list.
+ */
+object NotAllowedCaseObject {
+  CaseObjectInitializationProbe.initialized = true
+}

--- a/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
+++ b/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.serialization.jackson3
 
 import java.lang
+import java.io.NotSerializableException
 import java.nio.charset.StandardCharsets
 import java.time.{ Duration, Instant, LocalDateTime }
 import java.time.temporal.ChronoUnit
@@ -801,6 +802,9 @@ abstract class JacksonSerializerSpec(serializerName: String)
     serialization(sys).deserialize(blob, serializerId, manifest).get
   }
 
+  // referenced by name only: mentioning the object in code would initialize it
+  val NotAllowedCaseObjectName = "org.apache.pekko.serialization.jackson3.NotAllowedCaseObject$"
+
   def serializerFor(obj: AnyRef, sys: ActorSystem = system): JacksonSerializer =
     serialization(sys).findSerializerFor(obj) match {
       case serializer: JacksonSerializer => serializer
@@ -1254,6 +1258,50 @@ abstract class JacksonSerializerSpec(serializerName: String)
           serializer.fromBinary(blob, classOf[Status.Success].getName)
         }.getMessage.toLowerCase should include("allowed-class-prefix")
       }
+    }
+
+    "not allow deserialization of a case object that is not in serialization-bindings" in {
+      withTransportInformation() { () =>
+        val msg = SimpleCommand("ok")
+        val serializer = serializerFor(msg)
+        val blob = serializer.toBinary(msg)
+        intercept[IllegalArgumentException] {
+          // maliciously changing manifest to a case object
+          serializer.fromBinary(blob, NotAllowedCaseObjectName)
+        }.getMessage.toLowerCase should include("allowed-class-prefix")
+      }
+    }
+
+    "not initialize a case object class it goes on to reject" in {
+      withTransportInformation() { () =>
+        val msg = SimpleCommand("ok")
+        val serializer = serializerFor(msg)
+        val blob = serializer.toBinary(msg)
+        CaseObjectInitializationProbe.initialized should ===(false)
+        intercept[IllegalArgumentException] {
+          serializer.fromBinary(blob, NotAllowedCaseObjectName)
+        }
+        // reading MODULE$ would have run the object's body
+        CaseObjectInitializationProbe.initialized should ===(false)
+      }
+    }
+
+    "reject a manifest whose version is not a number" in {
+      withTransportInformation() { () =>
+        val msg = SimpleCommand("ok")
+        val serializer = serializerFor(msg)
+        val blob = serializer.toBinary(msg)
+        intercept[NotSerializableException] {
+          serializer.fromBinary(blob, classOf[SimpleCommand].getName + "#not-a-number")
+        }.getMessage should include("numeric version")
+      }
+    }
+
+    "not underflow on a payload that is only as long as the LZ4 magic" in {
+      // the LZ4 header is the magic plus a 4 byte length, so 4 bytes cannot be an LZ4 payload
+      JacksonSerializer.isLZ4(Array(0x87, 0xD9, 0x6D, 0xF6).map(_.toByte)) should ===(false)
+      JacksonSerializer.isLZ4(JacksonSerializer.LZ4Meta(Array.emptyByteArray).prependTo(Array.emptyByteArray)) should
+      ===(true)
     }
 
     "not allow serialization-bindings of open-ended types" in {


### PR DESCRIPTION
### Motivation
Four issues in `JacksonSerializer`, all reachable from the manifest string on the wire.

**The case object branch resolved the class in a way that initializes it, before checking
the allow list.** When the manifest ends in `$`, `fromBinary` called
`system.dynamicAccess.getObjectFor(className)`, which reads the `MODULE$` field through a
`VarHandle` and so runs the class's initializer; `checkAllowedClass` ran only afterwards.
The only gate before that point is `checkAllowedClassName`, which consults Jackson's gadget
deny list rather than `serialization-bindings` or `allowed-class-prefix`. So a manifest
naming any Scala `object` on the classpath ran that object's body on the way to being
rejected. The sibling branch already does the right thing — `getClassFor` is
`Class.forName(fqcn, false, cl)` and does not initialize. Same shape as #3495.

**`LZ4Meta.get` checked for four remaining bytes and then read eight** — the magic plus the
declared length. A 4-to-7 byte payload beginning with `0x87D96DF6` raised
`BufferUnderflowException` out of `decompress`.

**`parseManifest` called `toInt`** on whatever followed the last `#`, so `Foo#abc` or a
trailing `#` raised `NumberFormatException` rather than a serialization error.

**`isInAllowList` evaluated the throwing operand first.** `isBoundToJacksonSerializer` calls
`serializerFor`, which raises `NotSerializableException` — stack trace and all — for a class
that is not bound, and that is exactly the case for a class allowed only by
`allowed-class-prefix`. `checkAllowedClass` runs on every `fromBinary`, so this built and
discarded one exception per message on that path.

### Modification
- Resolve the case object's class with `getClassFor`, run `checkAllowedClass` on it, and read
  the module field only after that.
- Require 8 remaining bytes before reading an LZ4 header.
- Parse the manifest version with `toIntOption` and report a non-numeric one as
  `NotSerializableException` naming the manifest.
- Test `hasAllowedClassPrefix` before `isBoundToJacksonSerializer`.

Applied identically to `serialization-jackson` and `serialization-jackson3`.

The reordering in `isInAllowList` is the only change with no behaviour difference — both
operands are pure predicates and `isBoundToJacksonSerializer` already swallows its exception —
so it is covered by the existing `allowed-class-prefix` tests rather than a new one.

### Result
A rejected manifest no longer initializes the class it names; two malformed manifests are
reported as serialization failures instead of unrelated runtime exceptions; the allow list
check no longer constructs an exception per message on the prefix path. No change for
manifests that were accepted before.

### Tests
New tests in `JacksonSerializerSpec` in both modules (so each runs under both the JSON and
CBOR serializers):

- `not allow deserialization of a case object that is not in serialization-bindings` — the
  allow list still rejects it
- `not initialize a case object class it goes on to reject` — a test-only object whose body
  sets a flag; the flag must still be false after the rejection
- `reject a manifest whose version is not a number`
- `not underflow on a payload that is only as long as the LZ4 magic`

I checked these discriminate by reverting the production change and re-running: the last
three fail without it (`true did not equal false`, `NumberFormatException was thrown`, and
the underflow respectively). The first passes either way — it documents that the allow list
decision itself is unchanged, which is the point.

- `sbt "serialization-jackson/testOnly org.apache.pekko.serialization.jackson.*"` — 128 passed
- `sbt "serialization-jackson3/testOnly org.apache.pekko.serialization.jackson3.*"` — 126 passed
- `sbt "serialization-jackson/mimaReportBinaryIssues"` — no issues (`serialization-jackson3`
  disables MimaPlugin)
- `sbt scalafmtAll headerCreateAll` — no changes

### References
The case object issue is the same shape as #3495, which stopped the serializer resolving a
wire-supplied manifest class it would not use.

`ProtobufSerializer.isInAllowList` has the same throwing-operand-first ordering, but it
caches its method handle after the check so it pays the cost once per class rather than once
per message; it is in `pekko-remote` and is left for a separate change.
