### PR TITLE
fix: don't resolve HOCON includes in config that arrived in a message

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/serialization/WireConfigSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/serialization/WireConfigSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.serialization
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path }
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.pekko.testkit.PekkoSpec
+
+import com.typesafe.config.{ ConfigFactory, ConfigRenderOptions }
+
+class WireConfigSpec extends PekkoSpec {
+
+  // a file the parser must not read when a message asks it to
+  private val secretFile: Path = {
+    val f = Files.createTempFile("wire-config-spec", ".conf")
+    Files.write(f, "secret = leaked".getBytes(StandardCharsets.UTF_8))
+    f
+  }
+  private val filePath = secretFile.toAbsolutePath.toString
+  private val fileUrl = secretFile.toUri.toString
+
+  override def afterTermination(): Unit = Files.deleteIfExists(secretFile)
+
+  "WireConfig" must {
+
+    "parse ordinary HOCON" in {
+      val config = WireConfig.parseString("a = 1\nb { c = two }")
+      config.getInt("a") should ===(1)
+      config.getString("b.c") should ===("two")
+    }
+
+    "parse what a serializer writes" in {
+      // every serializer renders config with ConfigRenderOptions.concise
+      val rendered = ConfigFactory.parseString("pekko.cluster.roles = [a, b]").root.render(ConfigRenderOptions.concise())
+      WireConfig.parseString(rendered).getStringList("pekko.cluster.roles").asScala.toList should ===(List("a", "b"))
+    }
+
+    "not read a file named by an include" in {
+      val config = WireConfig.parseString(s"include file(\"$filePath\")\na = 1")
+      config.hasPath("secret") should ===(false)
+      config.getInt("a") should ===(1)
+    }
+
+    "not read a file named by a required include" in {
+      WireConfig.parseString(s"include required(file(\"$filePath\"))\na = 1").hasPath("secret") should ===(false)
+    }
+
+    "not fetch a URL named by an include" in {
+      // a file: URL stands in for an outbound request, so the test needs no network
+      val config = WireConfig.parseString(s"include url(\"$fileUrl\")\na = 1")
+      config.hasPath("secret") should ===(false)
+      config.getInt("a") should ===(1)
+    }
+
+    "not read a resource named by a classpath include" in {
+      // reference.conf is on the test classpath, so the default includer would pull it in
+      WireConfig.parseString("include classpath(\"reference.conf\")\na = 1").hasPath("pekko.version") should ===(false)
+    }
+
+    "differ from the default parser, which does resolve all three" in {
+      // guards the premise of the tests above: these directives really do resolve without the
+      // includer, so those tests are checking the change rather than an inert directive
+      ConfigFactory.parseString(s"include file(\"$filePath\")").hasPath("secret") should ===(true)
+      ConfigFactory.parseString(s"include url(\"$fileUrl\")").hasPath("secret") should ===(true)
+      ConfigFactory.parseString("include classpath(\"reference.conf\")").hasPath("pekko.version") should ===(true)
+    }
+  }
+}

--- a/actor-tests/src/test/scala/org/apache/pekko/serialization/WireConfigSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/serialization/WireConfigSpec.scala
@@ -49,7 +49,8 @@ class WireConfigSpec extends PekkoSpec {
 
     "parse what a serializer writes" in {
       // every serializer renders config with ConfigRenderOptions.concise
-      val rendered = ConfigFactory.parseString("pekko.cluster.roles = [a, b]").root.render(ConfigRenderOptions.concise())
+      val rendered =
+        ConfigFactory.parseString("pekko.cluster.roles = [a, b]").root.render(ConfigRenderOptions.concise())
       WireConfig.parseString(rendered).getStringList("pekko.cluster.roles").asScala.toList should ===(List("a", "b"))
     }
 

--- a/actor/src/main/scala/org/apache/pekko/serialization/WireConfig.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/WireConfig.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.serialization
+
+import java.io.File
+import java.net.URL
+
+import org.apache.pekko.annotation.InternalApi
+
+import com.typesafe.config.{
+  Config,
+  ConfigFactory,
+  ConfigIncludeContext,
+  ConfigIncluder,
+  ConfigIncluderClasspath,
+  ConfigIncluderFile,
+  ConfigIncluderURL,
+  ConfigObject,
+  ConfigParseOptions
+}
+
+/**
+ * INTERNAL API
+ *
+ * Parsing of HOCON that arrived in a message.
+ *
+ * HOCON `include` directives are resolved by the parser, not by `resolve()`, so parsing a
+ * string with the default includer reads whatever it names: `include file(...)` and
+ * `include classpath(...)` read from the local filesystem and classpath, and
+ * `include url(...)` performs an outbound request. None of that belongs on a path whose
+ * input came from a peer.
+ *
+ * Every serializer writes config with `ConfigRenderOptions.concise`, which renders JSON and
+ * cannot produce an `include`, so dropping them costs a well-behaved sender nothing.
+ */
+@InternalApi private[pekko] object WireConfig {
+
+  /**
+   * Resolves every form of `include` to an empty object.
+   *
+   * All four interfaces have to be implemented: the parser dispatches `include file(...)`,
+   * `include url(...)` and `include classpath(...)` to the typed methods and falls back to
+   * its own default handling — which does read the resource — when the configured includer
+   * does not implement the matching interface. Only bare `include "..."` goes to `include`.
+   */
+  private object NoIncludes
+      extends ConfigIncluder
+      with ConfigIncluderFile
+      with ConfigIncluderURL
+      with ConfigIncluderClasspath {
+
+    private def empty: ConfigObject = ConfigFactory.empty().root()
+
+    override def withFallback(fallback: ConfigIncluder): ConfigIncluder = this
+    override def include(context: ConfigIncludeContext, what: String): ConfigObject = empty
+    override def includeFile(context: ConfigIncludeContext, what: File): ConfigObject = empty
+    override def includeURL(context: ConfigIncludeContext, what: URL): ConfigObject = empty
+    override def includeResources(context: ConfigIncludeContext, what: String): ConfigObject = empty
+  }
+
+  private val parseOptions: ConfigParseOptions = ConfigParseOptions.defaults().setIncluder(NoIncludes)
+
+  /**
+   * Like `ConfigFactory.parseString`, but with `include` directives resolved to nothing.
+   */
+  def parseString(hocon: String): Config = ConfigFactory.parseString(hocon, parseOptions)
+}

--- a/cluster/src/main/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializer.scala
@@ -299,7 +299,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
   private def deserializeInitJoin(bytes: Array[Byte]): InternalClusterAction.InitJoin = {
     val m = cm.InitJoin.parseFrom(bytes)
     if (m.hasCurrentConfig)
-      InternalClusterAction.InitJoin(ConfigFactory.parseString(m.getCurrentConfig))
+      InternalClusterAction.InitJoin(WireConfig.parseString(m.getCurrentConfig))
     else
       InternalClusterAction.InitJoin(ConfigFactory.empty)
   }
@@ -310,7 +310,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
       val configCheck =
         i.getConfigCheck.getType match {
           case cm.ConfigCheck.Type.CompatibleConfig =>
-            CompatibleConfig(ConfigFactory.parseString(i.getConfigCheck.getClusterConfig))
+            CompatibleConfig(WireConfig.parseString(i.getConfigCheck.getClusterConfig))
           case cm.ConfigCheck.Type.IncompatibleConfig => IncompatibleConfig
           case cm.ConfigCheck.Type.UncheckedConfig    => UncheckedConfig
         }

--- a/cluster/src/test/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -13,6 +13,9 @@
 
 package org.apache.pekko.cluster.protobuf
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
 import scala.annotation.nowarn
 
 import collection.immutable.SortedSet
@@ -21,6 +24,7 @@ import org.apache.pekko
 import pekko.actor.{ Address, ExtendedActorSystem }
 import pekko.cluster._
 import pekko.cluster.InternalClusterAction.CompatibleConfig
+import pekko.cluster.protobuf.msg.{ ClusterMessages => cm }
 import pekko.cluster.routing.{ ClusterRouterPool, ClusterRouterPoolSettings }
 import pekko.routing.RoundRobinPool
 import pekko.testkit.PekkoSpec
@@ -182,6 +186,37 @@ class ClusterMessageSerializerSpec extends PekkoSpec("pekko.actor.provider = clu
       val env = roundtrip(GossipEnvelope(a1.uniqueAddress, d1.uniqueAddress, Gossip(SortedSet(a1, d1))))
       env.gossip.members.head.roles should be(Set(ClusterSettings.DcRolePrefix + "default"))
       env.gossip.members.tail.head.roles should be(Set("r1", ClusterSettings.DcRolePrefix + "foo"))
+    }
+
+    "not resolve includes in the config of a join message" in {
+      // The joining node renders its config with ConfigRenderOptions.concise, which is JSON and
+      // cannot carry an include, so nothing legitimate is lost by refusing to resolve one. An
+      // include that did resolve would read a local file or issue an outbound request while
+      // deserializing a message from a node that has not joined yet.
+      val secretFile = Files.createTempFile("cluster-message-serializer-spec", ".conf")
+      try {
+        Files.write(secretFile, """secret = "leaked"""".getBytes(StandardCharsets.UTF_8))
+        val hocon = s"""include file("${secretFile.toAbsolutePath}")
+          pekko.cluster.roles = []"""
+
+        val initJoin = serializer
+          .fromBinary(cm.InitJoin.newBuilder().setCurrentConfig(hocon).build().toByteArray, "IJ")
+          .asInstanceOf[InternalClusterAction.InitJoin]
+        initJoin.configOfJoiningNode.hasPath("secret") should ===(false)
+
+        val ackBytes = cm.InitJoinAck
+          .newBuilder()
+          .setAddress(serializer.addressToProto(Address("pekko", "system", "some.host.org", 4711)))
+          .setConfigCheck(
+            cm.ConfigCheck
+              .newBuilder()
+              .setType(cm.ConfigCheck.Type.CompatibleConfig)
+              .setClusterConfig(hocon))
+          .build()
+          .toByteArray
+        val ack = serializer.fromBinary(ackBytes, "IJA").asInstanceOf[InternalClusterAction.InitJoinAck]
+        ack.configCheck.asInstanceOf[CompatibleConfig].clusterConfig.hasPath("secret") should ===(false)
+      } finally Files.deleteIfExists(secretFile)
     }
 
     "add a default data center role to internal join action if none is present" in {

--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/MiscMessageSerializer.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/MiscMessageSerializer.scala
@@ -30,7 +30,13 @@ import pekko.remote._
 import pekko.remote.WireFormats.AddressData
 import pekko.remote.routing.RemoteRouterConfig
 import pekko.routing._
-import pekko.serialization.{ BaseSerializer, Serialization, SerializationExtension, SerializerWithStringManifest }
+import pekko.serialization.{
+  BaseSerializer,
+  Serialization,
+  SerializationExtension,
+  SerializerWithStringManifest,
+  WireConfig
+}
 
 import com.typesafe.config.{ Config, ConfigFactory, ConfigRenderOptions }
 
@@ -546,7 +552,7 @@ class MiscMessageSerializer(val system: ExtendedActorSystem) extends SerializerW
 
   private def deserializeConfig(bytes: Array[Byte]): Config = {
     if (bytes.isEmpty) EmptyConfig
-    else ConfigFactory.parseString(new String(bytes, StandardCharsets.UTF_8))
+    else WireConfig.parseString(new String(bytes, StandardCharsets.UTF_8))
   }
 
   private def deserializeFromConfig(bytes: Array[Byte]): FromConfig =

--- a/remote/src/test/scala/org/apache/pekko/remote/serialization/MiscMessageSerializerSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/serialization/MiscMessageSerializerSpec.scala
@@ -14,6 +14,8 @@
 package org.apache.pekko.remote.serialization
 
 import java.io.NotSerializableException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.Optional
 import java.util.concurrent.TimeoutException
 
@@ -33,7 +35,7 @@ import pekko.serialization.SerializationExtension
 import pekko.testkit.JavaSerializable
 import pekko.testkit.PekkoSpec
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object MiscMessageSerializerSpec {
   val serializationTestOverrides =
@@ -156,6 +158,23 @@ class MiscMessageSerializerSpec extends PekkoSpec(MiscMessageSerializerSpec.test
         s"serialize and de-serialize $scenario" in {
           verifySerialization(item)
         }
+    }
+
+    "not resolve includes in a serialized Config" in {
+      // Config is written with ConfigRenderOptions.concise, which is JSON and cannot carry an
+      // include, so refusing to resolve one loses nothing. An include that did resolve would
+      // read a local file or issue an outbound request while deserializing a peer's message.
+      val secretFile = Files.createTempFile("misc-message-serializer-spec", ".conf")
+      try {
+        Files.write(secretFile, """secret = "leaked"""".getBytes(StandardCharsets.UTF_8))
+        val serializer = new MiscMessageSerializer(system.asInstanceOf[ExtendedActorSystem])
+        val hocon = s"""include file("${secretFile.toAbsolutePath}")
+          a = 1"""
+
+        val config = serializer.fromBinary(hocon.getBytes(StandardCharsets.UTF_8), "CF").asInstanceOf[Config]
+        config.hasPath("secret") should ===(false)
+        config.getInt("a") should ===(1)
+      } finally Files.deleteIfExists(secretFile)
     }
 
     "reject invalid manifest" in {


### PR DESCRIPTION
### Motivation
Three sites parse HOCON that arrived in a message, using the default parse options:

| Site | Reached by |
| --- | --- |
| `ClusterMessageSerializer:302` — `deserializeInitJoin` | `InitJoin`, from a node that has not joined |
| `ClusterMessageSerializer:313` — `deserializeInitJoinAck` | `InitJoinAck`, from a claimed seed node |
| `MiscMessageSerializer:549` — `deserializeConfig` | any `Config` payload from an associated peer |

HOCON `include` directives are resolved by the *parser*, not by `resolve()`, so they take
effect as soon as the message is deserialized — before `ClusterDaemon` forms any opinion
about the sender. `InitJoin` is accepted in the `uninitialized` state
(`ClusterDaemon.scala:501`), so for that one the sender need not be a cluster member at all.

That gives a peer a blind SSRF primitive from inside the node (`include url("http://…")`
reaches addresses the sender cannot) and a forced read of local files and classpath
resources.

I checked the behaviour against config 1.4.6 rather than assuming it, and the result changed
the shape of the fix. A plain `ConfigIncluder` is **not** enough — the parser falls back to
its own handling, which does read the resource, for any typed form the includer does not
implement:

```
include form            defaults   plain ConfigIncluder   all four interfaces
include file(...)       reads      reads                  blocked
include required(file)  reads      reads                  blocked
include url(...)        reads      reads                  blocked
include classpath(...)  reads      reads                  blocked
include "..."           no-op      blocked                blocked
```

(Bare `include "..."` is already inert here: `SimpleIncluder` resolves it relative to the
including source, and a string has none.)

### Modification
Add `org.apache.pekko.serialization.WireConfig` (`@InternalApi`), which parses with
`ConfigParseOptions.defaults().setIncluder(...)` where the includer resolves every form to an
empty object. It implements `ConfigIncluder`, `ConfigIncluderFile`, `ConfigIncluderURL` and
`ConfigIncluderClasspath` — all four are needed, per the table above. Route the three sites
through it.

Every serializer writes config with `ConfigRenderOptions.concise` (`MiscMessageSerializer:172`,
`ClusterMessageSerializer:401`), which renders JSON and cannot produce an `include`, so a
well-behaved sender loses nothing and no rolling-upgrade path is affected.

Includes are dropped silently rather than logged. `deserializeConfig` is on the ordinary
per-message path, so a peer-triggerable log line there is its own small flooding surface, and
the drop is already fail-safe. Happy to add a `LogMarker.Security` debug line if reviewers
would rather have the signal.

### Result
Deserializing a message no longer reads local files or classpath resources, or issues
outbound requests, on behalf of the sender.

### Tests
- `sbt "actor-tests/testOnly org.apache.pekko.serialization.WireConfigSpec"` — 7 passed: ordinary
  HOCON and concise-rendered config still parse; `file`, `required(file)`, `url` and `classpath`
  includes all resolve to nothing; and one test asserts the *default* parser does resolve all
  three, so the others are testing the change rather than an inert directive
- `sbt "cluster/testOnly org.apache.pekko.cluster.protobuf.ClusterMessageSerializerSpec"` — 10 passed,
  including a new test covering both `InitJoin` and `InitJoinAck`
- `sbt "remote/testOnly org.apache.pekko.remote.serialization.MiscMessageSerializerSpec"` — 104 passed,
  including a new test for the `Config` payload
- Both new module tests were checked to discriminate by reverting the production change and
  re-running: each fails with `true did not equal false`
- `sbt "actor/mimaReportBinaryIssues" "remote/mimaReportBinaryIssues" "cluster/mimaReportBinaryIssues"` — no issues
- `sbt scalafmtAll headerCreateAll` — no changes

### References
None. `WireConfig.scala` is new code and carries the standard ASF header.
