### PR TITLE
fix: match actor selection wildcards without backtracking

### DIFF
--- a/actor-tests/src/test/scala/org/apache/pekko/actor/ActorSelectionSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/ActorSelectionSpec.scala
@@ -368,6 +368,23 @@ class ActorSelectionSpec extends PekkoSpec with DefaultTimeout {
       d.recipient.path.toStringWithoutAddress should ===("/user/missing")
     }
 
+    "deliver a wildcard selection promptly even when the pattern would make a regex backtrack" in {
+      val creator = TestProbe()
+      implicit def self: ActorRef = creator.ref
+      val top = system.actorOf(p, "backtrack")
+      // a 36 character child name, the length at which the old regex matching took tens of
+      // seconds for a 26 character pattern
+      val childName = "a" * 36
+      Await.result((top ? Create(childName)).mapTo[ActorRef], timeout.duration)
+
+      val probe = TestProbe()
+      val pattern = ("*a" * 12) + "*b" // cannot match: the name has no 'b'
+      val started = System.nanoTime()
+      system.actorSelection(s"/user/backtrack/$pattern").tell(Identify(4), probe.ref)
+      probe.expectMsg(3.seconds, ActorIdentity(4, None))
+      (System.nanoTime() - started) should be < 3.seconds.toNanos
+    }
+
     "identify actors with wildcard selection correctly" in {
       val creator = TestProbe()
       implicit def self: ActorRef = creator.ref

--- a/actor-tests/src/test/scala/org/apache/pekko/util/GlobSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/GlobSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.util
+
+import org.scalatest.concurrent.TimeLimits
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{ Seconds, Span }
+import org.scalatest.wordspec.AnyWordSpec
+
+class GlobSpec extends AnyWordSpec with Matchers with TimeLimits {
+
+  private def allStrings(alphabet: Seq[Char], maxLength: Int): Seq[String] =
+    (0 to maxLength).flatMap { n =>
+      (1 to n).foldLeft(Seq("")) { (acc, _) =>
+        acc.flatMap(s => alphabet.map(s + _))
+      }
+    }
+
+  "Glob" must {
+
+    "match the literal cases" in {
+      Glob.matches("abc", "abc") should ===(true)
+      Glob.matches("abc", "abd") should ===(false)
+      Glob.matches("", "") should ===(true)
+      Glob.matches("", "a") should ===(false)
+      Glob.matches("a", "") should ===(false)
+    }
+
+    "treat ? as exactly one character" in {
+      Glob.matches("a?c", "abc") should ===(true)
+      Glob.matches("a?c", "ac") should ===(false)
+      Glob.matches("a?c", "abbc") should ===(false)
+      Glob.matches("???", "abc") should ===(true)
+    }
+
+    "treat * as any run of characters" in {
+      Glob.matches("*", "") should ===(true)
+      Glob.matches("*", "anything") should ===(true)
+      Glob.matches("a*", "a") should ===(true)
+      Glob.matches("a*c", "abbbc") should ===(true)
+      Glob.matches("a*c", "abbbd") should ===(false)
+      Glob.matches("**", "ab") should ===(true)
+      Glob.matches("*b*", "abc") should ===(true)
+    }
+
+    "agree with the regular expression it replaces, exhaustively over short inputs" in {
+      // Helpers.makePattern is what SelectChildPattern used before; matching has to be
+      // unchanged, so compare the two over every short pattern and input.
+      val patterns = allStrings(Seq('a', 'b', '*', '?'), 4)
+      val inputs = allStrings(Seq('a', 'b'), 4)
+      patterns.size should be > 300
+      for {
+        pattern <- patterns
+        regex = Helpers.makePattern(pattern)
+        input <- inputs
+      } withClue(s"pattern [$pattern] input [$input]: ") {
+        Glob.matches(pattern, input) should ===(regex.matcher(input).matches)
+      }
+    }
+
+    "match a pattern that makes the regular expression backtrack, promptly" in {
+      // 26 characters against a 36 character name. Through Helpers.makePattern this takes
+      // roughly 47 seconds on one thread; here it is immediate.
+      val pattern = ("*a" * 12) + "*b"
+      val name = "a" * 36
+      failAfter(Span(3, Seconds)) {
+        Glob.matches(pattern, name) should ===(false)
+      }
+    }
+
+    "stay prompt as the input grows" in {
+      val pattern = ("*a" * 20) + "*b"
+      failAfter(Span(5, Seconds)) {
+        Glob.matches(pattern, "a" * 2000) should ===(false)
+      }
+    }
+  }
+}

--- a/actor-tests/src/test/scala/org/apache/pekko/util/GlobSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/GlobSpec.scala
@@ -24,12 +24,11 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class GlobSpec extends AnyWordSpec with Matchers with TimeLimits {
 
-  private def allStrings(alphabet: Seq[Char], maxLength: Int): Seq[String] =
-    (0 to maxLength).flatMap { n =>
-      (1 to n).foldLeft(Seq("")) { (acc, _) =>
-        acc.flatMap(s => alphabet.map(s + _))
-      }
+  private def allStrings(alphabet: Seq[Char], maxLength: Int): Seq[String] = (0 to maxLength).flatMap { n =>
+    (1 to n).foldLeft(Seq("")) { (acc, _) =>
+      acc.flatMap(s => alphabet.map(s + _))
     }
+  }
 
   "Glob" must {
 

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorSelection.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorSelection.scala
@@ -29,7 +29,7 @@ import scala.util.Success
 import org.apache.pekko
 import pekko.pattern.ask
 import pekko.routing.MurmurHash
-import pekko.util.{ Helpers, Timeout }
+import pekko.util.{ Glob, Helpers, Timeout }
 
 /**
  * An ActorSelection is a logical view of a section of an ActorSystem's tree of Actors,
@@ -242,13 +242,13 @@ object ActorSelection {
                 val chldr = refWithCell.children
                 if (iter.isEmpty) {
                   // leaf
-                  val matchingChildren = chldr.filter(c => p.pattern.matcher(c.path.name).matches)
+                  val matchingChildren = chldr.filter(c => p.matches(c.path.name))
                   if (matchingChildren.isEmpty && !sel.wildcardFanOut)
                     emptyRef.tell(sel, sender)
                   else
                     matchingChildren.foreach(_.tell(sel.msg, sender))
                 } else {
-                  val matchingChildren = chldr.filter(c => p.pattern.matcher(c.path.name).matches)
+                  val matchingChildren = chldr.filter(c => p.matches(c.path.name))
                   // don't send to emptyRef after wildcard fan-out
                   if (matchingChildren.isEmpty && !sel.wildcardFanOut)
                     emptyRef.tell(sel, sender)
@@ -324,7 +324,19 @@ private[pekko] final case class SelectChildName(name: String) extends SelectionP
  */
 @SerialVersionUID(2L)
 private[pekko] final case class SelectChildPattern(patternStr: String) extends SelectionPathElement {
-  val pattern: Pattern = Helpers.makePattern(patternStr)
+
+  /**
+   * The equivalent regular expression. Kept for compatibility and no longer used for matching:
+   * it backtracks badly on patterns with several `*`, and the pattern arrives in the message.
+   * Lazy so that deserializing a selection does not compile it.
+   */
+  lazy val pattern: Pattern = Helpers.makePattern(patternStr)
+
+  /**
+   * True if `name` matches this pattern. Runs without backtracking, see [[Glob]].
+   */
+  def matches(name: String): Boolean = Glob.matches(patternStr, name)
+
   override def toString: String = patternStr
 }
 

--- a/actor/src/main/scala/org/apache/pekko/util/Glob.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/Glob.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.util
+
+import org.apache.pekko.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ *
+ * Glob matching with the same semantics as [[Helpers.makePattern]] — `?` matches one
+ * character, `*` matches any run of characters, everything else is literal — without
+ * going through a regular expression.
+ *
+ * The regular expression `makePattern` builds turns every `*` into `.*`, and a chain of
+ * those backtracks: matching `*a*a*a*a*a*a*a*a*a*a*a*a*b`, 26 characters, against a
+ * 36 character name that cannot satisfy the trailing literal takes tens of seconds on one
+ * thread, because the engine tries every way of distributing the literals. Actor selections
+ * carry their pattern in the message, so that cost is reachable from a single small message.
+ *
+ * This matcher never revisits a decision more than once per input position, so it runs in
+ * time proportional to the product of the two lengths at worst, and linearly in practice.
+ */
+@InternalApi private[pekko] object Glob {
+
+  /**
+   * True if `input` matches the glob `pattern`.
+   */
+  def matches(pattern: String, input: String): Boolean = {
+    var p = 0 // next character of the pattern to match
+    var i = 0 // next character of the input to match
+    // where to resume from if the run consumed by the most recent `*` turns out to be too short
+    var starP = -1
+    var starI = -1
+
+    while (i < input.length) {
+      if (p < pattern.length && (pattern.charAt(p) == '?' || pattern.charAt(p) == input.charAt(i))) {
+        p += 1
+        i += 1
+      } else if (p < pattern.length && pattern.charAt(p) == '*') {
+        // remember where to come back to, and start by having the `*` consume nothing
+        starP = p
+        starI = i
+        p += 1
+      } else if (starP >= 0) {
+        // let the most recent `*` consume one more character and try again from there
+        starI += 1
+        i = starI
+        p = starP + 1
+      } else {
+        return false
+      }
+    }
+
+    // trailing `*`s may match nothing, anything else left over means no match
+    while (p < pattern.length && pattern.charAt(p) == '*') p += 1
+    p == pattern.length
+  }
+}


### PR DESCRIPTION
### Motivation
`SelectChildPattern` compiled its glob to a regular expression with `Helpers.makePattern`
(`Helpers.scala:46`), which quotes the literal runs but turns every `*` into `.*`. A chain of
those backtracks badly. Measured on JDK 17, matching a pattern against a name of all `a`s that
cannot satisfy the trailing literal:

```
glob  5 stars (12 chars), name 30 chars ->      5 ms
glob  8 stars (18 chars), name 30 chars ->    214 ms
glob 10 stars (22 chars), name 30 chars ->   1098 ms
glob 12 stars (26 chars), name 30 chars ->   3485 ms

glob  8 stars (18 chars), name 36 chars ->   1204 ms
glob 10 stars (22 chars), name 36 chars ->   9427 ms
glob 12 stars (26 chars), name 36 chars ->  46987 ms
```

An `ActorSelectionMessage` carries its pattern elements in the message
(`MessageContainerSerializer.scala:83-92`), and `SelectChildPattern`'s constructor compiles the
pattern, so both the compile and the match are reachable from one small message.
`ActorSelection.deliverSelection` runs on the caller's thread for a local selection and, for a
remote one, directly on the inbound stream thread (`MessageDispatcher.scala:93`, deliberately,
"to make sure it is not stuck on busy user actor").

My first thought was to cap the pattern length in the serializer. The numbers above say that
would have been useless: 26 characters is already enough, and it is not a suspicious-looking
pattern. The cost has to come out of the matching itself.

Note that `untrusted-mode` does not cover this either — its check
(`MessageDispatcher.scala:81-93`) runs after deserialization, so it stops the matching but not
the compiling.

### Modification
Add `org.apache.pekko.util.Glob` (`@InternalApi`), which matches the same grammar — `?` is
exactly one character, `*` is any run, everything else is literal — with the standard
single-backtrack-point wildcard algorithm: it remembers only the most recent `*` and how much
it has consumed, so it never revisits a decision more than once per input position. Worst case
is proportional to the product of the two lengths; in practice it is linear.

`ActorSelection.deliverSelection` now matches through `SelectChildPattern.matches`.
`SelectChildPattern.pattern` is kept for compatibility but is now `lazy`, so deserializing a
selection no longer compiles a regular expression at all.

Nothing else used `Helpers.makePattern`, which is public API and is left in place.

I did not add a cap on the number of selection elements. Once matching is linear the remaining
per-element cost is a small object allocation, already bounded by the frame size.

### Result
The same selections match as before, in time linear in practice.

### Tests
- `sbt "actor-tests/testOnly org.apache.pekko.util.GlobSpec"` — 6 passed. The important one is
  `agree with the regular expression it replaces, exhaustively over short inputs`: every pattern
  over `{a, b, *, ?}` up to length 4 (341 of them) against every input over `{a, b}` up to
  length 4, compared against `Helpers.makePattern`. All agree, so the grammar is unchanged.
- `sbt "actor-tests/testOnly org.apache.pekko.actor.ActorSelectionSpec"` — 28 passed, including a
  new end-to-end test that sends a wildcard selection with the pathological pattern to a parent
  with a 36 character child and asserts it returns in under 3 seconds.
- That end-to-end test was checked to discriminate: reverted to the regex matching it fails with
  `42561317850 was not less than 3000000000` — 42.5 seconds.
- `sbt "remote/testOnly org.apache.pekko.remote.serialization.MessageContainerSerializerSpec"` — 3 passed
- `sbt "actor/mimaReportBinaryIssues"` — no issues
- `sbt "actor/scalafmtCheckAll" "actor-tests/scalafmtCheckAll" headerCreateAll` — clean

### References
None. `Glob.scala` is new code and carries the standard ASF header.
