### PR TITLE
fix: don't dereference a null superclass in the protobuf allow list check

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/ProtobufSerializer.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/ProtobufSerializer.scala
@@ -181,7 +181,10 @@ class ProtobufSerializer(val system: ExtendedActorSystem) extends BaseSerializer
    * and still bind with the same class (interface).
    */
   private def isInAllowList(clazz: Class[?]): Boolean = {
-    isBoundToProtobufSerializer(clazz) || isInAllowListClassName(clazz)
+    // The name check comes first because it cannot throw: `isBoundToProtobufSerializer` calls
+    // `serializerFor`, which raises (and fills in the stack trace of) a NotSerializableException
+    // for a class that is not bound.
+    isInAllowListClassName(clazz) || isBoundToProtobufSerializer(clazz)
   }
 
   private def isBoundToProtobufSerializer(clazz: Class[?]): Boolean = {
@@ -194,8 +197,10 @@ class ProtobufSerializer(val system: ExtendedActorSystem) extends BaseSerializer
   }
 
   private def isInAllowListClassName(clazz: Class[?]): Boolean = {
+    // getSuperclass is null for an interface, for Object and for a primitive, and the manifest
+    // class comes off the wire, so it can be any of those
     allowedClassNames(clazz.getName) ||
-    allowedClassNames(clazz.getSuperclass.getName) ||
+    ((clazz.getSuperclass ne null) && allowedClassNames(clazz.getSuperclass.getName)) ||
     clazz.getInterfaces.exists(c => allowedClassNames(c.getName))
   }
 }

--- a/remote/src/test/scala/org/apache/pekko/remote/serialization/ProtobufSerializerSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/serialization/ProtobufSerializerSpec.scala
@@ -123,6 +123,24 @@ class ProtobufSerializerSpec extends PekkoSpec(s"""
       }
     }
 
+    "reject an interface manifest rather than failing on its missing superclass" in {
+      // getSuperclass is null for an interface, and the manifest class comes off the wire.
+      // This used to raise NullPointerException from the allow list check instead of the
+      // IllegalArgumentException that refusing the class is supposed to produce.
+      val originalSerializer = ser.serializerFor(classOf[MyMessage])
+      intercept[IllegalArgumentException] {
+        ser.deserialize(Array[Byte](), originalSerializer.identifier, classOf[Runnable].getName).get
+      }.getMessage should include("allow list")
+    }
+
+    "reject java.lang.Object as a manifest" in {
+      // Object.getSuperclass is null too
+      val originalSerializer = ser.serializerFor(classOf[MyMessage])
+      intercept[IllegalArgumentException] {
+        ser.deserialize(Array[Byte](), originalSerializer.identifier, classOf[Object].getName).get
+      }.getMessage should include("allow list")
+    }
+
     "allow deserialization of classes in configured allowed classes" in {
       val originalSerializer = ser.serializerFor(classOf[MyMessage])
 


### PR DESCRIPTION
### Motivation
This is the `pekko-remote` half of the allow list ordering noted in #3503, and looking at it
turned up something more than a reorder.

`ProtobufSerializer.isInAllowListClassName` (`:196-200`) reads `clazz.getSuperclass.getName`
unconditionally. `getSuperclass` is `null` for an interface, for `java.lang.Object` and for a
primitive, and the class being checked is the manifest that arrived on the wire — so a manifest
naming an interface raises `NullPointerException` out of the allow list check instead of the
`IllegalArgumentException` that refusing a class is supposed to produce. It is reachable
whenever the named class is not bound to a protobuf serializer, which is exactly the case the
allow list exists to refuse.

Separately, `isInAllowList` (`:183-185`) evaluated `isBoundToProtobufSerializer` first. That
calls `serializerFor`, which raises `NotSerializableException` — stack trace and all — for a
class that is not bound, which is the common case for a class allowed only by
`pekko.serialization.protobuf.allowed-classes`.

### Modification
Skip the superclass when there is none, and test the name list before the binding lookup, which
cannot throw. Both operands are pure predicates, so which one runs first does not change the
decision.

The ordering matters less here than in Jackson: `ProtobufSerializer` caches its parsing handle
after the check (`:124-133`), so it pays the cost once per class rather than once per message.
The null dereference is the part worth fixing.

### Result
An interface or `Object` manifest is refused with the allow list error rather than a
`NullPointerException`.

### Tests
- `sbt "remote/testOnly org.apache.pekko.remote.serialization.*"` — 196 passed, 1 pending

Two new tests in `ProtobufSerializerSpec`, both checked to discriminate by reverting the
production file and re-running — each then fails with `NullPointerException was thrown`:

- `reject an interface manifest rather than failing on its missing superclass`
- `reject java.lang.Object as a manifest`

- `sbt "remote/mimaReportBinaryIssues"` — no issues
- `sbt "remote/scalafmtCheckAll" headerCreateAll` — clean

### References
Completes the `isInAllowList` ordering from #3503, which changed the two Jackson serializers and
deliberately left this one out of a Jackson-scoped PR.
