### PR TITLE
fix: bound the number of entries in a compression table advertisement

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/serialization/ArteryMessageSerializer.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/serialization/ArteryMessageSerializer.scala
@@ -27,6 +27,7 @@ import pekko.remote.artery.OutboundHandshake.{ HandshakeReq, HandshakeRsp }
 import pekko.remote.artery.compress.{ CompressionProtocol, CompressionTable }
 import pekko.remote.artery.compress.CompressionProtocol._
 import pekko.serialization.{ BaseSerializer, Serialization, SerializationExtension, SerializerWithStringManifest }
+import pekko.util.Helpers.toRootLowerCase
 
 /** INTERNAL API */
 private[pekko] object ArteryMessageSerializer {
@@ -59,6 +60,18 @@ private[pekko] final class ArteryMessageSerializer(val system: ExtendedActorSyst
   import ArteryMessageSerializer._
 
   private lazy val serialization = SerializationExtension(system)
+
+  // `pekko.remote.artery.advanced.compression.<table>.max` bounds the number of entries the
+  // sending side puts in a table, and is normally the same setting across a cluster. Parsed the
+  // same way ArterySettings parses it, without building the whole settings object here.
+  private def compressionMax(table: String): Int = {
+    val path = s"pekko.remote.artery.advanced.compression.$table.max"
+    if (toRootLowerCase(system.settings.config.getString(path)) == "off") 0
+    else system.settings.config.getInt(path)
+  }
+
+  private val maxActorRefCompressionEntries: Int = compressionMax("actor-refs")
+  private val maxClassManifestCompressionEntries: Int = compressionMax("manifests")
 
   override def manifest(o: AnyRef): String = o match { // most frequent ones first
     case _: SystemMessageDelivery.SystemMessageEnvelope                  => SystemMessageEnvelopeManifest
@@ -123,7 +136,11 @@ private[pekko] final class ArteryMessageSerializer(val system: ExtendedActorSyst
       case ActorRefCompressionAdvertisementAckManifest =>
         deserializeCompressionTableAdvertisementAck(bytes, ActorRefCompressionAdvertisementAck.apply)
       case ClassManifestCompressionAdvertisementManifest =>
-        deserializeCompressionAdvertisement(bytes, identity, ClassManifestCompressionAdvertisement.apply)
+        deserializeCompressionAdvertisement(
+          bytes,
+          identity,
+          maxClassManifestCompressionEntries,
+          ClassManifestCompressionAdvertisement.apply)
       case ClassManifestCompressionAdvertisementAckManifest =>
         deserializeCompressionTableAdvertisementAck(bytes, ClassManifestCompressionAdvertisementAck.apply)
       case ArteryHeartbeatManifest    => RemoteWatcher.ArteryHeartbeat
@@ -158,7 +175,11 @@ private[pekko] final class ArteryMessageSerializer(val system: ExtendedActorSyst
     serializeCompressionAdvertisement(adv)(serializeActorRef)
 
   def deserializeActorRefCompressionAdvertisement(bytes: Array[Byte]): ActorRefCompressionAdvertisement =
-    deserializeCompressionAdvertisement(bytes, deserializeActorRef, ActorRefCompressionAdvertisement.apply)
+    deserializeCompressionAdvertisement(
+      bytes,
+      deserializeActorRef,
+      maxActorRefCompressionEntries,
+      ActorRefCompressionAdvertisement.apply)
 
   def serializeCompressionAdvertisement[T](adv: CompressionAdvertisement[T])(
       keySerializer: T => String): ArteryControlFormats.CompressionTableAdvertisement = {
@@ -179,8 +200,18 @@ private[pekko] final class ArteryMessageSerializer(val system: ExtendedActorSyst
   def deserializeCompressionAdvertisement[T, U](
       bytes: Array[Byte],
       keyDeserializer: String => T,
+      maxEntries: Int,
       create: (UniqueAddress, CompressionTable[T]) => U): U = {
     val protoAdv = ArteryControlFormats.CompressionTableAdvertisement.parseFrom(bytes)
+
+    // Every key is resolved, and for actor refs that means parsing a path and populating the
+    // resolve cache, so a message with far more entries than a table can hold is work out of
+    // proportion to its size. `maxEntries` is 0 when compression is switched off here, and then
+    // there is no configured number to check against.
+    if (maxEntries > 0 && protoAdv.getKeysCount > maxEntries)
+      throw new NotSerializableException(
+        s"Compression table advertisement carries [${protoAdv.getKeysCount}] entries, more than " +
+        s"the configured maximum of [$maxEntries]")
 
     val kvs =
       protoAdv.getKeysList.asScala

--- a/remote/src/test/scala/org/apache/pekko/remote/serialization/ArteryMessageSerializerSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/serialization/ArteryMessageSerializerSpec.scala
@@ -17,7 +17,7 @@ import java.io.NotSerializableException
 
 import org.apache.pekko
 import pekko.actor._
-import pekko.remote.{ RemoteWatcher, UniqueAddress }
+import pekko.remote.{ ArteryControlFormats, RemoteWatcher, UniqueAddress }
 import pekko.remote.artery.{ ActorSystemTerminating, ActorSystemTerminatingAck, Quarantined, SystemMessageDelivery }
 import pekko.remote.artery.Flush
 import pekko.remote.artery.FlushAck
@@ -73,6 +73,30 @@ class ArteryMessageSerializerSpec extends PekkoSpec {
     }
 
     "not support UniqueAddresses without host/port set" in pending
+
+    "reject a compression table advertisement with more entries than the configured maximum" in {
+      val serializer = new ArteryMessageSerializer(system.asInstanceOf[ExtendedActorSystem])
+      val max = system.settings.config.getInt("pekko.remote.artery.advanced.compression.actor-refs.max")
+
+      def advertisement(entries: Int): Array[Byte] = {
+        val builder = ArteryControlFormats.CompressionTableAdvertisement.newBuilder
+          .setFrom(serializer.serializeUniqueAddress(uniqueAddress()))
+          .setOriginUid(17L)
+          .setTableVersion(1)
+        (0 until entries).foreach { i =>
+          builder.addKeys(s"pekko://sys@host:1234/user/a$i")
+          builder.addValues(i)
+        }
+        builder.build().toByteArray
+      }
+
+      // a table of exactly the configured size is what a peer legitimately advertises
+      serializer.fromBinary(advertisement(max), "f") shouldBe a[ActorRefCompressionAdvertisement]
+
+      intercept[NotSerializableException] {
+        serializer.fromBinary(advertisement(max + 1), "f")
+      }.getMessage should include(s"more than the configured maximum of [$max]")
+    }
 
     "reject invalid manifest" in {
       intercept[IllegalArgumentException] {


### PR DESCRIPTION
### Motivation
`deserializeCompressionAdvertisement` (`ArteryMessageSerializer:179-192`) resolves every key in
the advertised table — for actor refs that means `resolveActorRef`, which parses a path and
populates the per-thread resolve cache. The key list was unbounded, so the only limit was the
transport frame size.

Measured on this branch:

```
   256 entries ->     9009 wire bytes,  32 ms
  1000 entries ->    35793 wire bytes,  37 ms
 10000 entries ->   368793 wire bytes, 150 ms
 50000 entries ->  1922409 wire bytes, 622 ms
```

256 is what a peer legitimately advertises (`compression.actor-refs.max` defaults to 256), and
9 KB. The default `maximum-frame-size` of 256 KiB allows roughly 7000 entries, so the reachable
worst case is around 100 ms of CPU on the inbound control stream per message, repeatable.

### Modification
Reject an advertisement carrying more entries than
`pekko.remote.artery.advanced.compression.<table>.max` — the setting that bounds the table on
the sending side, parsed here the same way `ArterySettings` parses it. When it is `"off"`
locally the setting is 0, there is no configured number to check against, and no bound is
applied.

**The tradeoff worth a reviewer's attention:** this bounds by the *receiver's* setting, but the
table is sized by the *sender's*. Configurations are normally uniform across a cluster, but
during a rolling change of `actor-refs.max` a node still on the smaller value would reject a
larger advertisement. I checked what that costs before choosing it: a `fromBinary` failure on
the inbound stream is caught at `Codecs.scala:692-704`, which logs an error and drops the
message — no quarantine — and `InboundCompressions` resends advertisements periodically
(`InboundCompressions.scala:553`, "The ActorRefCompressionAdvertisement message is resent
because it can be lost"). So the worst case for a skewed config is that compression is not
established for that association until both sides are updated; messages still flow uncompressed.
If reviewers would rather have headroom than exactness, the alternative is a separate setting
with a default well above the table maxes.

### What I did not change
The review this came from also flagged `ActorRefResolveCache` as hash-floodable:
`LruBoundedCache` never grows and `Unsafe.fastHash` is seeded with two fixed public constants,
so colliding actor paths can be precomputed offline. I measured it rather than assume:
generating 4096 keys that all land in one slot took 558 ms, and cache operations then went from
2347 ns to 13631 ns, about 5.8x.

That is a real effect but far short of the degradation I expected, the cache is bounded at 1024
entries so nothing grows without limit, and closing it means changing the seed of a public
`Unsafe.fastHash`. 5.8x on one cache lookup does not seem to justify that, so I left it alone
and am recording the numbers here instead.

### Result
An oversized advertisement is reported as a serialization failure. A legitimately sized one is
unaffected.

### Tests
- `sbt "remote/testOnly org.apache.pekko.remote.serialization.*"` — 195 passed, 1 pending

One new test in `ArteryMessageSerializerSpec`, checked to discriminate by reverting the
production file and re-running, where it fails with `no exception was thrown`:

- `reject a compression table advertisement with more entries than the configured maximum` —
  asserts a table of exactly `max` entries still deserializes, and that `max + 1` is rejected

- `sbt "remote/mimaReportBinaryIssues"` — no issues
- `sbt "remote/scalafmtCheckAll" headerCreateAll` — clean

### References
Touches the same method as #3507, so whichever merges second needs a trivial rebase; the two
guards are independent.
