### PR TITLE
docs: fix comment placement around serialization-max-nesting-depth

### DIFF
--- a/actor/src/main/resources/reference.conf
+++ b/actor/src/main/resources/reference.conf
@@ -822,14 +822,14 @@ pekko {
     #
     # Please note that this option does not stop you from manually invoking java serialization
     #
+    allow-java-serialization = off
+
     # Maximum nesting depth when a serialized payload encloses another serialized
     # payload (for example Some, Optional, Status.Failure, StatusReply, a Throwable
     # cause, or an ActorSelectionMessage). Each level is parsed separately, so this is
     # the only bound on the chain. A message nested deeper than this is rejected with a
     # NotSerializableException rather than failing with a StackOverflowError.
     serialization-max-nesting-depth = 32
-
-    allow-java-serialization = off
 
     # Log warnings when the Java serialization is used to serialize messages.
     # Java serialization is not very performant and should not be used in production

--- a/actor/src/main/scala/org/apache/pekko/serialization/NestedDeserialization.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/NestedDeserialization.scala
@@ -38,6 +38,8 @@ import org.apache.pekko.annotation.InternalApi
 @InternalApi
 private[pekko] object NestedDeserialization {
 
+  // a one-element Array[Int] serves as a mutable int holder, so incrementing the
+  // depth does not box the way a ThreadLocal[Int] would on every get/set
   private val depth = new ThreadLocal[Array[Int]] {
     override def initialValue(): Array[Int] = new Array[Int](1)
   }


### PR DESCRIPTION
### Motivation
Review of the 1.7.x cherry-pick (#3501) found two comment issues in #3500 that also apply to main:

- In `reference.conf`, the new `serialization-max-nesting-depth` block was inserted between the `allow-java-serialization` doc comment and its setting, orphaning that comment.
- `NestedDeserialization` uses a one-element `Array[Int]` in a `ThreadLocal` without explaining why.

### Modification
Move `allow-java-serialization = off` back under its doc comment, placing the `serialization-max-nesting-depth` comment and setting after it, and add a code comment noting the `Array[Int]` avoids the boxing a `ThreadLocal[Int]` would incur.

### Result
The `allow-java-serialization` comment is attached to its setting again, and the boxing rationale is recorded. No behavioral change; HOCON keys are order-independent.

### Tests
- Not run - docs only (comment-only changes; `scalafmt` run on the changed Scala file)

### References
Refs #3500, Refs #3501