### PR TITLE
fix: default the Jackson max-decompressed-size to unlimited

### DIFF
--- a/serialization-jackson/src/main/resources/reference.conf
+++ b/serialization-jackson/src/main/resources/reference.conf
@@ -210,10 +210,11 @@ pekko.serialization.jackson {
     # payload that decompresses to more than this is rejected rather than
     # allocated, guarding against a small message that inflates without bound.
     # This applies on deserialization regardless of the `algorithm` setting above.
-    # The default of -1 applies no limit, preserving the behaviour of earlier
-    # releases; set a size such as `256 MiB` to bound decompression, choosing a
-    # value larger than any payload the system legitimately exchanges.
-    max-decompressed-size = -1
+    # The default of `unlimited` applies no limit, preserving the behaviour of
+    # earlier releases; a negative number such as -1 also means unlimited. Set a
+    # size such as `256 MiB` to bound decompression, choosing a value larger than
+    # any payload the system legitimately exchanges.
+    max-decompressed-size = unlimited
   }
 
   # Whether the type should be written to the manifest.

--- a/serialization-jackson/src/main/resources/reference.conf
+++ b/serialization-jackson/src/main/resources/reference.conf
@@ -210,7 +210,10 @@ pekko.serialization.jackson {
     # payload that decompresses to more than this is rejected rather than
     # allocated, guarding against a small message that inflates without bound.
     # This applies on deserialization regardless of the `algorithm` setting above.
-    max-decompressed-size = 256 MiB
+    # The default of -1 applies no limit, preserving the behaviour of earlier
+    # releases; set a size such as `256 MiB` to bound decompression, choosing a
+    # value larger than any payload the system legitimately exchanges.
+    max-decompressed-size = -1
   }
 
   # Whether the type should be written to the manifest.

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
@@ -207,7 +207,12 @@ import pekko.util.OptionVal
           """"off" or "gzip"""")
     }
   }
-  private val maxDecompressedSize: Long = conf.getBytes("compression.max-decompressed-size")
+  // negative means no limit; getBytes refuses negative numbers, so read those first
+  private val maxDecompressedSize: Long =
+    conf.getString("compression.max-decompressed-size").toLongOption match {
+      case Some(n) if n < 0 => n
+      case _                => conf.getBytes("compression.max-decompressed-size")
+    }
   private val migrations: Map[String, JacksonMigration] = {
     import scala.jdk.CollectionConverters._
     conf.getConfig("migrations").root.unwrapped.asScala.toMap.map {
@@ -544,7 +549,10 @@ import pekko.util.OptionVal
           // meta.length is the decompressed size declared on the wire; a small
           // message can declare a huge (or negative) size and drive a large
           // allocation, so bound it before decompressing.
-          if (meta.length < 0 || meta.length > maxDecompressedSize)
+          if (meta.length < 0)
+            throw new IllegalArgumentException(
+              s"Compressed message declares a negative decompressed size [${meta.length}] bytes")
+          if (maxDecompressedSize >= 0 && meta.length > maxDecompressedSize)
             throw new IllegalArgumentException(
               s"Compressed message declares decompressed size [${meta.length}] bytes, which exceeds the maximum " +
               s"of [$maxDecompressedSize] bytes (pekko.serialization.jackson.compression.max-decompressed-size)")
@@ -556,7 +564,7 @@ import pekko.util.OptionVal
   }
 
   // gunzip with a bound on the decompressed size, so a small gzip payload cannot
-  // inflate without limit (a "zip bomb").
+  // inflate without limit (a "zip bomb"). A negative maximum applies no bound.
   private def gunzip(in: GZIPInputStream): Array[Byte] = {
     val out = new ByteArrayOutputStream()
     val buffer = new Array[Byte](BufferSize)
@@ -564,7 +572,7 @@ import pekko.util.OptionVal
     var n = in.read(buffer)
     while (n != -1) {
       total += n
-      if (total > maxDecompressedSize)
+      if (maxDecompressedSize >= 0 && total > maxDecompressedSize)
         throw new IllegalArgumentException(
           s"Decompressed message exceeds the maximum of [$maxDecompressedSize] bytes " +
           "(pekko.serialization.jackson.compression.max-decompressed-size)")

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonSerializer.scala
@@ -207,12 +207,16 @@ import pekko.util.OptionVal
           """"off" or "gzip"""")
     }
   }
-  // negative means no limit; getBytes refuses negative numbers, so read those first
-  private val maxDecompressedSize: Long =
-    conf.getString("compression.max-decompressed-size").toLongOption match {
-      case Some(n) if n < 0 => n
-      case _                => conf.getBytes("compression.max-decompressed-size")
-    }
+  // "unlimited" or a negative number means no limit; getBytes refuses both, so read them first
+  private val maxDecompressedSize: Long = {
+    val raw = conf.getString("compression.max-decompressed-size")
+    if (raw == "unlimited") -1L
+    else
+      raw.toLongOption match {
+        case Some(n) if n < 0 => n
+        case _                => conf.getBytes("compression.max-decompressed-size")
+      }
+  }
   private val migrations: Map[String, JacksonMigration] = {
     import scala.jdk.CollectionConverters._
     conf.getConfig("migrations").root.unwrapped.asScala.toMap.map {

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
@@ -711,6 +711,18 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       JacksonSerializer.isLZ4(serializeToBinary(msg, sys)) should ===(true)
       checkSerialization(msg, sys)
     }
+
+    "apply no decompression limit when max-decompressed-size is unlimited" in withSystem("""
+        pekko.serialization.jackson.jackson-json.compression {
+          algorithm = gzip
+          compress-larger-than = 0 KiB
+          max-decompressed-size = unlimited
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      JacksonSerializer.isGZipped(serializeToBinary(msg, sys)) should ===(true)
+      checkSerialization(msg, sys)
+    }
   }
 
   "JacksonJsonSerializer without type in manifest" should {

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
@@ -687,6 +687,30 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       }
       ex.getMessage should include("max-decompressed-size")
     }
+
+    "apply no gzip decompression limit when max-decompressed-size is -1" in withSystem("""
+        pekko.serialization.jackson.jackson-json.compression {
+          algorithm = gzip
+          compress-larger-than = 0 KiB
+          max-decompressed-size = -1
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      JacksonSerializer.isGZipped(serializeToBinary(msg, sys)) should ===(true)
+      checkSerialization(msg, sys)
+    }
+
+    "apply no lz4 decompression limit when max-decompressed-size is -1" in withSystem("""
+        pekko.serialization.jackson.jackson-json.compression {
+          algorithm = lz4
+          compress-larger-than = 0 KiB
+          max-decompressed-size = -1
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      JacksonSerializer.isLZ4(serializeToBinary(msg, sys)) should ===(true)
+      checkSerialization(msg, sys)
+    }
   }
 
   "JacksonJsonSerializer without type in manifest" should {

--- a/serialization-jackson3/src/main/resources/reference.conf
+++ b/serialization-jackson3/src/main/resources/reference.conf
@@ -191,10 +191,11 @@ pekko.serialization.jackson3 {
     # payload that decompresses to more than this is rejected rather than
     # allocated, guarding against a small message that inflates without bound.
     # This applies on deserialization regardless of the `algorithm` setting above.
-    # The default of -1 applies no limit, preserving the behaviour of earlier
-    # releases; set a size such as `256 MiB` to bound decompression, choosing a
-    # value larger than any payload the system legitimately exchanges.
-    max-decompressed-size = -1
+    # The default of `unlimited` applies no limit, preserving the behaviour of
+    # earlier releases; a negative number such as -1 also means unlimited. Set a
+    # size such as `256 MiB` to bound decompression, choosing a value larger than
+    # any payload the system legitimately exchanges.
+    max-decompressed-size = unlimited
   }
 
   # Whether the type should be written to the manifest.

--- a/serialization-jackson3/src/main/resources/reference.conf
+++ b/serialization-jackson3/src/main/resources/reference.conf
@@ -191,7 +191,10 @@ pekko.serialization.jackson3 {
     # payload that decompresses to more than this is rejected rather than
     # allocated, guarding against a small message that inflates without bound.
     # This applies on deserialization regardless of the `algorithm` setting above.
-    max-decompressed-size = 256 MiB
+    # The default of -1 applies no limit, preserving the behaviour of earlier
+    # releases; set a size such as `256 MiB` to bound decompression, choosing a
+    # value larger than any payload the system legitimately exchanges.
+    max-decompressed-size = -1
   }
 
   # Whether the type should be written to the manifest.

--- a/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonSerializer.scala
+++ b/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonSerializer.scala
@@ -208,7 +208,12 @@ import pekko.util.OptionVal
           """"off" or "gzip"""")
     }
   }
-  private val maxDecompressedSize: Long = conf.getBytes("compression.max-decompressed-size")
+  // negative means no limit; getBytes refuses negative numbers, so read those first
+  private val maxDecompressedSize: Long =
+    conf.getString("compression.max-decompressed-size").toLongOption match {
+      case Some(n) if n < 0 => n
+      case _                => conf.getBytes("compression.max-decompressed-size")
+    }
   private val migrations: Map[String, JacksonMigration] = {
     import scala.jdk.CollectionConverters._
     conf.getConfig("migrations").root.unwrapped.asScala.toMap.map {
@@ -545,7 +550,10 @@ import pekko.util.OptionVal
           // meta.length is the decompressed size declared on the wire; a small
           // message can declare a huge (or negative) size and drive a large
           // allocation, so bound it before decompressing.
-          if (meta.length < 0 || meta.length > maxDecompressedSize)
+          if (meta.length < 0)
+            throw new IllegalArgumentException(
+              s"Compressed message declares a negative decompressed size [${meta.length}] bytes")
+          if (maxDecompressedSize >= 0 && meta.length > maxDecompressedSize)
             throw new IllegalArgumentException(
               s"Compressed message declares decompressed size [${meta.length}] bytes, which exceeds the maximum " +
               s"of [$maxDecompressedSize] bytes (pekko.serialization.jackson3.compression.max-decompressed-size)")
@@ -557,7 +565,7 @@ import pekko.util.OptionVal
   }
 
   // gunzip with a bound on the decompressed size, so a small gzip payload cannot
-  // inflate without limit (a "zip bomb").
+  // inflate without limit (a "zip bomb"). A negative maximum applies no bound.
   private def gunzip(in: GZIPInputStream): Array[Byte] = {
     val out = new ByteArrayOutputStream()
     val buffer = new Array[Byte](BufferSize)
@@ -565,7 +573,7 @@ import pekko.util.OptionVal
     var n = in.read(buffer)
     while (n != -1) {
       total += n
-      if (total > maxDecompressedSize)
+      if (maxDecompressedSize >= 0 && total > maxDecompressedSize)
         throw new IllegalArgumentException(
           s"Decompressed message exceeds the maximum of [$maxDecompressedSize] bytes " +
           "(pekko.serialization.jackson3.compression.max-decompressed-size)")

--- a/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonSerializer.scala
+++ b/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonSerializer.scala
@@ -208,12 +208,16 @@ import pekko.util.OptionVal
           """"off" or "gzip"""")
     }
   }
-  // negative means no limit; getBytes refuses negative numbers, so read those first
-  private val maxDecompressedSize: Long =
-    conf.getString("compression.max-decompressed-size").toLongOption match {
-      case Some(n) if n < 0 => n
-      case _                => conf.getBytes("compression.max-decompressed-size")
-    }
+  // "unlimited" or a negative number means no limit; getBytes refuses both, so read them first
+  private val maxDecompressedSize: Long = {
+    val raw = conf.getString("compression.max-decompressed-size")
+    if (raw == "unlimited") -1L
+    else
+      raw.toLongOption match {
+        case Some(n) if n < 0 => n
+        case _                => conf.getBytes("compression.max-decompressed-size")
+      }
+  }
   private val migrations: Map[String, JacksonMigration] = {
     import scala.jdk.CollectionConverters._
     conf.getConfig("migrations").root.unwrapped.asScala.toMap.map {

--- a/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
+++ b/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
@@ -632,6 +632,30 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       }
       ex.getMessage should include("max-decompressed-size")
     }
+
+    "apply no gzip decompression limit when max-decompressed-size is -1" in withSystem("""
+        pekko.serialization.jackson3.jackson-json.compression {
+          algorithm = gzip
+          compress-larger-than = 0 KiB
+          max-decompressed-size = -1
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      JacksonSerializer.isGZipped(serializeToBinary(msg, sys)) should ===(true)
+      checkSerialization(msg, sys)
+    }
+
+    "apply no lz4 decompression limit when max-decompressed-size is -1" in withSystem("""
+        pekko.serialization.jackson3.jackson-json.compression {
+          algorithm = lz4
+          compress-larger-than = 0 KiB
+          max-decompressed-size = -1
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      JacksonSerializer.isLZ4(serializeToBinary(msg, sys)) should ===(true)
+      checkSerialization(msg, sys)
+    }
   }
 
   "JacksonJsonSerializer without type in manifest" should {

--- a/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
+++ b/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
@@ -656,6 +656,18 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       JacksonSerializer.isLZ4(serializeToBinary(msg, sys)) should ===(true)
       checkSerialization(msg, sys)
     }
+
+    "apply no decompression limit when max-decompressed-size is unlimited" in withSystem("""
+        pekko.serialization.jackson3.jackson-json.compression {
+          algorithm = gzip
+          compress-larger-than = 0 KiB
+          max-decompressed-size = unlimited
+        }
+      """) { sys =>
+      val msg = SimpleCommand("0" * (8 * 1024))
+      JacksonSerializer.isGZipped(serializeToBinary(msg, sys)) should ===(true)
+      checkSerialization(msg, sys)
+    }
   }
 
   "JacksonJsonSerializer without type in manifest" should {


### PR DESCRIPTION
### Motivation
#3491 bounded Jackson payload decompression with
`pekko.serialization.jackson.compression.max-decompressed-size`, defaulting to 256 MiB. A
bounded default could reject a payload an existing system legitimately exchanges, so a
patch release carrying it could break running systems on upgrade, and there is no default
that is provably above every deployment's largest payload. The bound should be opt-in,
matching the change made to `pekko.serialization.max-decompressed-size` in #3502.

### Modification
Default the setting to `unlimited`, meaning no limit and matching the behaviour of
releases before #3491, in both `serialization-jackson` and `serialization-jackson3`. A
negative number such as `-1` also means unlimited — the convention of the neighbouring
`read.max-document-length` and `read.max-token-count` settings — per review, so both
spellings are accepted. Operators who want the protection set a size such as `256 MiB`,
larger than anything their system legitimately sends.

An unlimited maximum skips the gzip size check and the LZ4 declared-size check. A negative
*declared* LZ4 size is still rejected — it is malformed regardless of the limit — and now
with a message saying that, rather than one claiming it exceeds the maximum.

Config's `getBytes` refuses both spellings, so the setting is read as a string first and
as a memory size only when it is neither `unlimited` nor a negative number.

### Result
Jackson payload decompression is unbounded by default; configuring a size bounds it. A
configured limit behaves exactly as before.

### Tests
Three new tests per module (so each runs under both the JSON and CBOR serializers):

- `apply no gzip decompression limit when max-decompressed-size is -1`
- `apply no lz4 decompression limit when max-decompressed-size is -1`
- `apply no decompression limit when max-decompressed-size is unlimited`

The `-1` tests were checked to discriminate by reverting the production change and
re-running: each then fails with `ConfigException$BadValue: Attempt to construct memory
size with negative number: -1`, which is also what an operator configuring `-1` on the
current code would get at serializer construction; `unlimited` fails the same way as a
`BadValue` on the keyword.

- `sbt "serialization-jackson/testOnly org.apache.pekko.serialization.jackson.*"` — passed
- `sbt "serialization-jackson3/testOnly org.apache.pekko.serialization.jackson3.*"` — passed
- `sbt "serialization-jackson/scalafmtCheckAll" "serialization-jackson3/scalafmtCheckAll"` — clean
- `sbt "serialization-jackson/mimaReportBinaryIssues"` — no issues (`serialization-jackson3`
  disables MimaPlugin)

### References
Refs #3491, Refs #3502
