### PR TITLE
support "unlimited" for the Jackson stream-read constraints

### DIFF
--- a/serialization-jackson/src/main/resources/reference.conf
+++ b/serialization-jackson/src/main/resources/reference.conf
@@ -56,10 +56,10 @@ pekko.serialization.jackson {
     max-number-length = 1000
     max-string-length = 20000000
     max-name-length = 50000
-    # max-document-length of -1 means unlimited
-    max-document-length = -1
-    # max-token-count of -1 means unlimited
-    max-token-count = -1
+    # max-document-length of `unlimited` (or a negative number such as -1) means unlimited
+    max-document-length = unlimited
+    # max-token-count of `unlimited` (or a negative number such as -1) means unlimited
+    max-token-count = unlimited
   }
 
   write {

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -82,6 +82,11 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       baseConf
   }
 
+  // "unlimited" is accepted as a synonym for -1 in the constraints that treat -1 as no limit
+  private def getLongOrUnlimited(config: Config, path: String): Long =
+    if (config.getString(path) == "unlimited") -1L
+    else config.getLong(path)
+
   private def createJsonFactory(
       bindingName: String,
       objectMapperFactory: JacksonObjectMapperFactory,
@@ -93,8 +98,8 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       .maxNumberLength(config.getInt("read.max-number-length"))
       .maxStringLength(config.getInt("read.max-string-length"))
       .maxNameLength(config.getInt("read.max-name-length"))
-      .maxDocumentLength(config.getLong("read.max-document-length"))
-      .maxTokenCount(config.getLong("read.max-token-count"))
+      .maxDocumentLength(getLongOrUnlimited(config, "read.max-document-length"))
+      .maxTokenCount(getLongOrUnlimited(config, "read.max-token-count"))
       .build()
 
     val streamWriteConstraints = StreamWriteConstraints.builder()

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonFactorySpec.scala
@@ -68,6 +68,21 @@ class JacksonFactorySpec extends TestKit(ActorSystem("JacksonFactorySpec"))
       streamReadConstraints.getMaxTokenCount shouldEqual maxTokenCount
     }
 
+    "support unlimited as a StreamReadConstraints value" in {
+      val bindingName = "testJackson"
+      val config = ConfigFactory.parseString(
+        s"""pekko.serialization.jackson.read.max-document-length=unlimited
+             |pekko.serialization.jackson.read.max-token-count=unlimited
+             |""".stripMargin)
+        .withFallback(defaultConfig)
+      val jacksonConfig = JacksonObjectMapperProvider.configForBinding(bindingName, config)
+      val mapper = JacksonObjectMapperProvider.createObjectMapper(
+        bindingName, None, objectMapperFactory, jacksonConfig, dynamicAccess, None)
+      val streamReadConstraints = mapper.getFactory.streamReadConstraints()
+      streamReadConstraints.getMaxDocumentLength shouldEqual -1L
+      streamReadConstraints.getMaxTokenCount shouldEqual -1L
+    }
+
     "support StreamWriteConstraints" in {
       val bindingName = "testJackson"
       val maxNestingDepth = 54321

--- a/serialization-jackson3/src/main/resources/reference.conf
+++ b/serialization-jackson3/src/main/resources/reference.conf
@@ -53,10 +53,10 @@ pekko.serialization.jackson3 {
     max-number-length = 1000
     max-string-length = 20000000
     max-name-length = 50000
-    # max-document-length of -1 means unlimited
-    max-document-length = -1
-    # max-token-count of -1 means unlimited
-    max-token-count = -1
+    # max-document-length of `unlimited` (or a negative number such as -1) means unlimited
+    max-document-length = unlimited
+    # max-token-count of `unlimited` (or a negative number such as -1) means unlimited
+    max-token-count = unlimited
   }
 
   write {

--- a/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonObjectMapperProvider.scala
@@ -75,6 +75,11 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       baseConf
   }
 
+  // "unlimited" is accepted as a synonym for -1 in the constraints that treat -1 as no limit
+  private def getLongOrUnlimited(config: Config, path: String): Long =
+    if (config.getString(path) == "unlimited") -1L
+    else config.getLong(path)
+
   private[pekko] def createJsonFactory(
       bindingName: String,
       objectMapperFactory: JacksonObjectMapperFactory,
@@ -86,8 +91,8 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       .maxNumberLength(config.getInt("read.max-number-length"))
       .maxStringLength(config.getInt("read.max-string-length"))
       .maxNameLength(config.getInt("read.max-name-length"))
-      .maxDocumentLength(config.getLong("read.max-document-length"))
-      .maxTokenCount(config.getLong("read.max-token-count"))
+      .maxDocumentLength(getLongOrUnlimited(config, "read.max-document-length"))
+      .maxTokenCount(getLongOrUnlimited(config, "read.max-token-count"))
       .build()
 
     val streamWriteConstraints = StreamWriteConstraints.builder()
@@ -159,7 +164,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       .maxNumberLength(config.getInt("read.max-number-length"))
       .maxStringLength(config.getInt("read.max-string-length"))
       .maxNameLength(config.getInt("read.max-name-length"))
-      .maxDocumentLength(config.getLong("read.max-document-length"))
+      .maxDocumentLength(getLongOrUnlimited(config, "read.max-document-length"))
       .build()
 
     val streamWriteConstraints = StreamWriteConstraints.builder()

--- a/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonFactorySpec.scala
+++ b/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonFactorySpec.scala
@@ -67,6 +67,21 @@ class JacksonFactorySpec extends TestKit(ActorSystem("JacksonFactorySpec"))
       streamReadConstraints.getMaxTokenCount shouldEqual maxTokenCount
     }
 
+    "support unlimited as a StreamReadConstraints value" in {
+      val bindingName = "testJackson"
+      val config = ConfigFactory.parseString(
+        s"""pekko.serialization.jackson3.read.max-document-length=unlimited
+           |pekko.serialization.jackson3.read.max-token-count=unlimited
+           |""".stripMargin)
+        .withFallback(defaultConfig)
+      val jacksonConfig = JacksonObjectMapperProvider.configForBinding(bindingName, config)
+      val factory = JacksonObjectMapperProvider.createJsonFactory(
+        bindingName, objectMapperFactory, jacksonConfig, None)
+      val streamReadConstraints = factory.streamReadConstraints()
+      streamReadConstraints.getMaxDocumentLength shouldEqual -1L
+      streamReadConstraints.getMaxTokenCount shouldEqual -1L
+    }
+
     "support StreamWriteConstraints" in {
       val bindingName = "testJackson"
       val maxNestingDepth = 54321


### PR DESCRIPTION
### Motivation
Review on #3515 preferred an explicit `unlimited` keyword over `-1` as a magic number.
Auditing the configuration listed in #3513 for other `-1`-means-unlimited settings turned
up exactly one family: the Jackson stream-read constraints `read.max-document-length` and
`read.max-token-count`, whose comments say "-1 means unlimited" but which only accept
numbers (`getLong`).

Nothing else in that list qualifies: the other new settings are durations, counts with
real defaults, booleans or strings, and `fork-join-executor.minimum-runnable = -1` means
"JDK-aware default" — not unlimited — so the keyword would be wrong there.
`compression.max-decompressed-size` already gains `unlimited` in #3515.

### Modification
`JacksonObjectMapperProvider` in both `serialization-jackson` and
`serialization-jackson3` reads `unlimited` as `-1` for `read.max-document-length` and
`read.max-token-count`, and the reference.conf defaults are written as `unlimited`. A
negative number such as `-1` is still accepted, so existing overrides keep working.

Both modules are changed together so the jackson3 section keeps mirroring the jackson
one, per the migration guide.

### Result
`max-document-length = unlimited` and `max-token-count = unlimited` work in both
modules; the effective defaults are unchanged.

### Tests
- New `support unlimited as a StreamReadConstraints value` test in each module's
  `JacksonFactorySpec`, asserting the built `StreamReadConstraints` carries `-1`
- The existing suites also now exercise the keyword through the changed defaults
- `sbt "serialization-jackson/testOnly org.apache.pekko.serialization.jackson.*"` — 129 passed
- `sbt "serialization-jackson3/testOnly org.apache.pekko.serialization.jackson3.*"` — 127 passed
- `sbt "serialization-jackson/scalafmtCheckAll" "serialization-jackson3/scalafmtCheckAll"` — clean
- MiMa left to the `Check / Binary Compatibility` job; the only code change is a private
  helper

### References
Refs #3513, Refs #3515
