### PR TITLE
test: cover the per-stream frame-size bound in TcpFraming

### DIFF
--- a/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/TcpFramingSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/TcpFramingSpec.scala
@@ -36,6 +36,12 @@ class TcpFramingSpec extends PekkoSpec("""
   private val maxFrameSize = 256 * 1024
   private val boundedFramingFlow =
     Flow[ByteString].via(new TcpFraming(acceptedMagic, maximumFrameSize = maxFrameSize))
+  private val maxLargeFrameSize = maxFrameSize * 2
+  private val perStreamBoundedFramingFlow =
+    Flow[ByteString].via(new TcpFraming(
+      acceptedMagic,
+      maximumFrameSize = maxFrameSize,
+      maximumLargeFrameSize = maxLargeFrameSize))
 
   private val payload5 = ByteString((1 to 5).map(_.toByte).toArray)
 
@@ -121,6 +127,28 @@ class TcpFramingSpec extends PekkoSpec("""
       val bytes = TcpFraming.encodeConnectionHeader(magic, 2) ++ encodeFrameHeader(maxFrameSize) ++ payload
       val frames = Source(List(bytes)).via(boundedFramingFlow).runWith(Sink.seq).futureValue
       frames.head.byteBuffer.limit() should ===(maxFrameSize)
+    }
+
+    "accept, on the large-message stream, a frame over the ordinary maximum but within the large maximum" in {
+      val length = maxFrameSize + 1
+      val payload = ByteString(Array.fill(length)(7.toByte))
+      val bytes = TcpFraming.encodeConnectionHeader(magic, ArteryTransport.LargeStreamId) ++
+        encodeFrameHeader(length) ++ payload
+      val frames = Source(List(bytes)).via(perStreamBoundedFramingFlow).runWith(Sink.seq).futureValue
+      frames.head.byteBuffer.limit() should ===(length)
+      frames.head.streamId should ===(ArteryTransport.LargeStreamId)
+    }
+
+    "reject, on the ordinary stream, a frame over the ordinary maximum even though it is within the large maximum" in {
+      // the payload is included, at full length, so this can only fail via the max-frame-size check -
+      // not via truncation - and so genuinely proves the ordinary stream is bounded by maximumFrameSize,
+      // not the larger maximumLargeFrameSize that only applies to ArteryTransport.LargeStreamId
+      val length = maxFrameSize + 1
+      val payload = ByteString(Array.fill(length)(7.toByte))
+      val bytes = TcpFraming.encodeConnectionHeader(magic, ArteryTransport.OrdinaryStreamId) ++
+        encodeFrameHeader(length) ++ payload
+      val fail = Source(List(bytes)).via(perStreamBoundedFramingFlow).runWith(Sink.seq).failed.futureValue
+      fail shouldBe a[FramingException]
     }
 
     "report truncated frames" in {


### PR DESCRIPTION
### Motivation
`TcpFraming.ReadStreamId` selects `maximumLargeFrameSize` only for
`ArteryTransport.LargeStreamId` and `maximumFrameSize` otherwise (#3492), but no test
exercised that selection. The existing bound tests (`"reject a frame that exceeds the
maximum frame size"`, `"accept a frame at exactly the maximum frame size"`) construct
`TcpFraming` with only `maximumFrameSize` set — `maximumLargeFrameSize` defaults to
`Int.MaxValue` — so they cannot distinguish the correct per-stream selection from a bug
that applied one bound to every stream regardless of `streamId`.

### Modification
Add a `perStreamBoundedFramingFlow` fixture with distinct `maximumFrameSize` and
`maximumLargeFrameSize`, and two tests:

- a frame over the ordinary maximum but within the large maximum is **accepted** on
  `ArteryTransport.LargeStreamId`
- the same frame is **rejected** on `ArteryTransport.OrdinaryStreamId`

Both frames carry their full declared payload rather than just the header, so an
incorrectly-accepted frame can't be mistaken for a truncation failure — I hit exactly
that mistake while writing the reject test (an under-length frame fails from truncation
regardless of the bound logic) and caught it by deliberately breaking the production
selection and confirming the test still passed for the wrong reason, then fixed the test
to include the payload.

### Result
The per-stream bound selection in `ReadStreamId` is covered directly, rather than only
by the code being read during review.

### Tests
- `sbt "remote/testOnly org.apache.pekko.remote.artery.tcp.TcpFramingSpec"` — 16 passed
- Checked the new tests discriminate: with `ReadStreamId`'s selection temporarily
  replaced by an unconditional `maximumLargeFrameSize`, the ordinary-stream test failed
  (`Future.failed not completed with a throwable`) while the large-stream test still
  passed; reverted after confirming
- `sbt "remote/scalafmtCheckAll"` — clean

### References
None - test-coverage gap noticed while comparing `TcpFraming.scala` (hardened in #3492)
against an unrelated fix for the same class of issue in a downstream project.
