### PR TITLE
fix: bound inbound Artery TCP frame length at framing (#3492)

### DIFF
--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/ArteryTcpTransport.scala
@@ -358,7 +358,8 @@ private[remote] class ArteryTcpTransport(
       Flow[ByteString]
         .via(inboundKillSwitch.flow)
         // must create new FlightRecorder event sink for each connection because they can't be shared
-        .via(new TcpFraming(settings.Advanced.TcpMagicValues, flightRecorder))
+        .via(new TcpFraming(settings.Advanced.TcpMagicValues, flightRecorder,
+          settings.Advanced.MaximumFrameSize, settings.Advanced.MaximumLargeFrameSize))
         .alsoTo(inboundStream)
         .filter(_ => false) // don't send back anything in this TCP socket
         .map(_ => ByteString.empty) // make it a Flow[ByteString] again

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/TcpFraming.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/TcpFraming.scala
@@ -79,7 +79,9 @@ import pekko.util.ByteString
  */
 @InternalApi private[pekko] class TcpFraming(
     acceptedMagic: immutable.Seq[ByteString] = List(TcpFraming.DefaultMagic),
-    flightRecorder: RemotingFlightRecorder = NoOpRemotingFlightRecorder)
+    flightRecorder: RemotingFlightRecorder = NoOpRemotingFlightRecorder,
+    maximumFrameSize: Int = Int.MaxValue,
+    maximumLargeFrameSize: Int = Int.MaxValue)
     extends ByteStringParser[EnvelopeBuffer] {
 
   private val magicLength = acceptedMagic.head.length
@@ -102,15 +104,31 @@ import pekko.util.ByteString
       }
     }
     case object ReadStreamId extends Step {
-      override def parse(reader: ByteReader): ParseResult[EnvelopeBuffer] =
-        ParseResult(None, ReadFrame(reader.readByte()))
+      override def parse(reader: ByteReader): ParseResult[EnvelopeBuffer] = {
+        val streamId = reader.readByte()
+        // A connection carries a single stream for its lifetime; the large-message
+        // stream is allowed bigger frames than the control and ordinary streams.
+        val maxFrameSize =
+          if (streamId == ArteryTransport.LargeStreamId) maximumLargeFrameSize else maximumFrameSize
+        ParseResult(None, ReadFrame(streamId, maxFrameSize))
+      }
     }
-    case class ReadFrame(streamId: Int) extends Step {
+    case class ReadFrame(streamId: Int, maxFrameSize: Int) extends Step {
       override def onTruncation(): Unit =
         failStage(new FramingException("Stream finished but there was a truncated final frame in the buffer"))
 
       override def parse(reader: ByteReader): ParseResult[EnvelopeBuffer] = {
         val frameLength = reader.readIntLE()
+        // frameLength is read from the wire before any data is buffered; reject an
+        // out-of-range value here so a peer cannot drive a huge allocation (which
+        // would be a fatal OutOfMemoryError on the shared inbound stream) by
+        // declaring an oversized or negative frame. FramingException tears down
+        // only this connection.
+        if (frameLength < 0 || frameLength > maxFrameSize)
+          throw new FramingException(
+            s"Frame length [$frameLength] for stream [$streamId] is out of range, " +
+            s"must be between 0 and the maximum frame size [$maxFrameSize]. " +
+            "Connection is rejected.")
         val buffer = createBuffer(reader.take(frameLength))
         ParseResult(Some(buffer), this)
       }

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/TcpFramingSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/TcpFramingSpec.scala
@@ -36,6 +36,12 @@ class TcpFramingSpec extends PekkoSpec("""
   private val maxFrameSize = 256 * 1024
   private val boundedFramingFlow =
     Flow[ByteString].via(new TcpFraming(acceptedMagic, maximumFrameSize = maxFrameSize))
+  private val maxLargeFrameSize = maxFrameSize * 2
+  private val perStreamBoundedFramingFlow =
+    Flow[ByteString].via(new TcpFraming(
+      acceptedMagic,
+      maximumFrameSize = maxFrameSize,
+      maximumLargeFrameSize = maxLargeFrameSize))
 
   private val payload5 = ByteString((1 to 5).map(_.toByte).toArray)
 
@@ -121,6 +127,28 @@ class TcpFramingSpec extends PekkoSpec("""
       val bytes = TcpFraming.encodeConnectionHeader(magic, 2) ++ encodeFrameHeader(maxFrameSize) ++ payload
       val frames = Source(List(bytes)).via(boundedFramingFlow).runWith(Sink.seq).futureValue
       frames.head.byteBuffer.limit() should ===(maxFrameSize)
+    }
+
+    "accept, on the large-message stream, a frame over the ordinary maximum but within the large maximum" in {
+      val length = maxFrameSize + 1
+      val payload = ByteString(Array.fill(length)(7.toByte))
+      val bytes = TcpFraming.encodeConnectionHeader(magic, ArteryTransport.LargeStreamId) ++
+        encodeFrameHeader(length) ++ payload
+      val frames = Source(List(bytes)).via(perStreamBoundedFramingFlow).runWith(Sink.seq).futureValue
+      frames.head.byteBuffer.limit() should ===(length)
+      frames.head.streamId should ===(ArteryTransport.LargeStreamId)
+    }
+
+    "reject, on the ordinary stream, a frame over the ordinary maximum even though it is within the large maximum" in {
+      // the payload is included, at full length, so this can only fail via the max-frame-size check -
+      // not via truncation - and so genuinely proves the ordinary stream is bounded by maximumFrameSize,
+      // not the larger maximumLargeFrameSize that only applies to ArteryTransport.LargeStreamId
+      val length = maxFrameSize + 1
+      val payload = ByteString(Array.fill(length)(7.toByte))
+      val bytes = TcpFraming.encodeConnectionHeader(magic, ArteryTransport.OrdinaryStreamId) ++
+        encodeFrameHeader(length) ++ payload
+      val fail = Source(List(bytes)).via(perStreamBoundedFramingFlow).runWith(Sink.seq).failed.futureValue
+      fail shouldBe a[FramingException]
     }
 
     "report truncated frames" in {

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/TcpFramingSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/tcp/TcpFramingSpec.scala
@@ -33,6 +33,9 @@ class TcpFramingSpec extends PekkoSpec("""
   private val magic = TcpFraming.DefaultMagic
   private val acceptedMagic = List(magic, TcpFraming.PekkoMagic)
   private val framingFlow = Flow[ByteString].via(new TcpFraming(acceptedMagic))
+  private val maxFrameSize = 256 * 1024
+  private val boundedFramingFlow =
+    Flow[ByteString].via(new TcpFraming(acceptedMagic, maximumFrameSize = maxFrameSize))
 
   private val payload5 = ByteString((1 to 5).map(_.toByte).toArray)
 
@@ -99,6 +102,25 @@ class TcpFramingSpec extends PekkoSpec("""
           frame.streamId should ===(3)
         }
       }
+    }
+
+    "reject a frame that exceeds the maximum frame size" in {
+      val bytes = TcpFraming.encodeConnectionHeader(magic, 2) ++ encodeFrameHeader(maxFrameSize + 1)
+      val fail = Source(List(bytes)).via(boundedFramingFlow).runWith(Sink.seq).failed.futureValue
+      fail shouldBe a[FramingException]
+    }
+
+    "reject a frame with a negative declared length" in {
+      val bytes = TcpFraming.encodeConnectionHeader(magic, 2) ++ encodeFrameHeader(-1)
+      val fail = Source(List(bytes)).via(boundedFramingFlow).runWith(Sink.seq).failed.futureValue
+      fail shouldBe a[FramingException]
+    }
+
+    "accept a frame at exactly the maximum frame size" in {
+      val payload = ByteString(Array.fill(maxFrameSize)(7.toByte))
+      val bytes = TcpFraming.encodeConnectionHeader(magic, 2) ++ encodeFrameHeader(maxFrameSize) ++ payload
+      val frames = Source(List(bytes)).via(boundedFramingFlow).runWith(Sink.seq).futureValue
+      frames.head.byteBuffer.limit() should ===(maxFrameSize)
     }
 
     "report truncated frames" in {


### PR DESCRIPTION
### Motivation
Backport of #3492 to 1.7.x: `TcpFraming` read the 4-byte frame length from the wire and
passed it straight to `reader.take` / `ByteBuffer` allocation with no bound. A peer —
unauthenticated on the default `tcp` transport — could declare an oversized (up to
~2 GiB) or negative frame length and drive a large allocation. The decoder and
deserializer stages downstream of the inbound `MergeHub` are shared by every inbound
connection, so a fatal `OutOfMemoryError` there fails the shared inbound stream and,
after `inbound-max-restarts`, terminates the whole `ActorSystem` — one malformed
connection escalating to node loss.

### Modification
Two commits:

1. Cherry-pick of fcc340ce9a (#3492) — applied clean, no conflicts. The
   already-configured `maximum-frame-size` / `maximum-large-frame-size` are threaded
   into `TcpFraming`; `ReadStreamId` selects the applicable bound per stream (the
   large-message stream keeps its larger limit) and `ReadFrame` rejects a negative or
   over-bound frame length before any data is buffered, as a per-connection
   `FramingException`.
2. The two per-stream bound tests just added on main in #3524, so 1.7.x gets the same
   coverage: with distinct maxima configured, a frame over the ordinary maximum but
   within the large maximum is accepted on `ArteryTransport.LargeStreamId` and rejected
   on `ArteryTransport.OrdinaryStreamId`, with full payloads so a false accept cannot
   hide behind truncation.

New `TcpFraming` constructor params default to `Int.MaxValue`, so the change is source-
and binary-compatible; `TcpFraming` is `@InternalApi` regardless.

### Result
Same as #3492: a malformed or oversized frame is rejected per-connection instead of
allocating without limit and risking a fatal error that escalates to `ActorSystem`
termination. Legitimate frames up to the configured maxima are unaffected.

### Tests
- `sbt "remote/testOnly org.apache.pekko.remote.artery.tcp.TcpFramingSpec"` — 17 passed
  (the #3492 oversized/negative/at-the-limit cases plus the two #3524 per-stream cases)
- `sbt "++ 2.12.21 remote/Test/compile"` — clean, validating Scala 2.12
- `sbt "remote/scalafmtCheckAll"` — clean on the touched file (the pre-existing
  formatting drift in `NestedPayloadDepthSpec` on 1.7.x is deliberately left untouched)

### References
Backport of #3492; includes the tests from #3524.
