### PR TITLE
chore: remove leftover Scala 2.12 idioms

### DIFF
--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.actor.testkit.typed.internal
 import java.util
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.util.control.Exception.Catcher
@@ -104,7 +103,7 @@ private[pekko] final class BehaviorTestKitImpl[T](
 
   override def selfInbox(): TestInboxImpl[T] = context.selfInbox
 
-  override def retrieveAllEffects(): immutable.Seq[Effect] = {
+  override def retrieveAllEffects(): Seq[Effect] = {
     @tailrec def rec(acc: List[Effect]): List[Effect] = context.effectQueue.poll() match {
       case null => acc.reverse
       case x    => rec(x :: acc)
@@ -202,7 +201,7 @@ private[pekko] final class BehaviorTestKitImpl[T](
 
   override def getAllLogEntries(): util.List[CapturedLogEvent] = logEntries().asJava
 
-  override def logEntries(): immutable.Seq[CapturedLogEvent] = context.logEntries
+  override def logEntries(): Seq[CapturedLogEvent] = context.logEntries
 
   override def clearLog(): Unit = context.clearLog()
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestInboxImpl.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestInboxImpl.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.actor.testkit.typed.internal
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.actor.{ ActorPath, Address, RootActorPath }
@@ -51,7 +50,7 @@ private[pekko] final class TestInboxImpl[T](path: ActorPath)
     this
   }
 
-  override protected def internalReceiveAll(): immutable.Seq[T] = {
+  override protected def internalReceiveAll(): Seq[T] = {
     @tailrec def rec(acc: List[T]): List[T] = q.poll() match {
       case null => acc.reverse
       case x    => rec(x :: acc)

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -20,7 +20,6 @@ import java.util.concurrent.LinkedBlockingDeque
 import java.util.function.Supplier
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
@@ -251,10 +250,10 @@ private[pekko] final class TestProbeImpl[M](name: String, system: ActorSystem[?]
     }
   }
 
-  override def receiveMessages(n: Int): immutable.Seq[M] =
+  override def receiveMessages(n: Int): Seq[M] =
     receiveMessages_internal(n, remainingOrDefault)
 
-  override def receiveMessages(n: Int, max: FiniteDuration): immutable.Seq[M] =
+  override def receiveMessages(n: Int, max: FiniteDuration): Seq[M] =
     receiveMessages_internal(n, max.dilated)
 
   override def receiveSeveralMessages(n: Int): JList[M] =
@@ -263,7 +262,7 @@ private[pekko] final class TestProbeImpl[M](name: String, system: ActorSystem[?]
   override def receiveSeveralMessages(n: Int, max: JDuration): JList[M] =
     receiveMessages_internal(n, max.toScala.dilated).asJava
 
-  private def receiveMessages_internal(n: Int, max: FiniteDuration): immutable.Seq[M] = {
+  private def receiveMessages_internal(n: Int, max: FiniteDuration): Seq[M] = {
     val stop = max + now
     for (x <- 1 to n) yield {
       val timeout = stop - now
@@ -275,17 +274,17 @@ private[pekko] final class TestProbeImpl[M](name: String, system: ActorSystem[?]
     }
   }
 
-  override def fishForMessage(max: FiniteDuration, hint: String)(fisher: M => FishingOutcome): immutable.Seq[M] =
+  override def fishForMessage(max: FiniteDuration, hint: String)(fisher: M => FishingOutcome): Seq[M] =
     fishForMessage_internal(max.dilated, hint, fisher)
 
   override def fishForMessagePF(max: FiniteDuration, hint: String)(
-      fisher: PartialFunction[M, FishingOutcome]): immutable.Seq[M] =
+      fisher: PartialFunction[M, FishingOutcome]): Seq[M] =
     fishForMessage(max, hint)(fisher)
 
-  override def fishForMessage(max: FiniteDuration)(fisher: M => FishingOutcome): immutable.Seq[M] =
+  override def fishForMessage(max: FiniteDuration)(fisher: M => FishingOutcome): Seq[M] =
     fishForMessage(max, "")(fisher)
 
-  override def fishForMessagePF(max: FiniteDuration)(fisher: PartialFunction[M, FishingOutcome]): immutable.Seq[M] =
+  override def fishForMessagePF(max: FiniteDuration)(fisher: PartialFunction[M, FishingOutcome]): Seq[M] =
     fishForMessage(max)(fisher)
 
   override def fishForMessage(max: JDuration, fisher: java.util.function.Function[M, FishingOutcome]): JList[M] =

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestInbox.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/javadsl/TestInbox.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.actor.testkit.typed.javadsl
 
 import java.util.concurrent.ThreadLocalRandom
 
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 
 import org.apache.pekko
@@ -71,7 +70,7 @@ abstract class TestInbox[T] {
    */
   def getAllReceived(): java.util.List[T] = internalReceiveAll().asJava
 
-  protected def internalReceiveAll(): immutable.Seq[T]
+  protected def internalReceiveAll(): Seq[T]
 
   def hasMessages: Boolean
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.actor.testkit.typed.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom
 
-import scala.collection.immutable
 import scala.reflect.ClassTag
 
 import org.apache.pekko
@@ -115,7 +114,7 @@ trait BehaviorTestKit[T] {
    * Requests all the effects. The effects are consumed, subsequent calls will only
    * see new effects.
    */
-  def retrieveAllEffects(): immutable.Seq[Effect]
+  def retrieveAllEffects(): Seq[Effect]
 
   /**
    * Returns if there have been any effects.
@@ -174,7 +173,7 @@ trait BehaviorTestKit[T] {
   /**
    * Returns all the [[CapturedLogEvent]] issued by this behavior(s)
    */
-  def logEntries(): immutable.Seq[CapturedLogEvent]
+  def logEntries(): Seq[CapturedLogEvent]
 
   /**
    * Clear the log entries

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestInbox.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestInbox.scala
@@ -15,8 +15,6 @@ package org.apache.pekko.actor.testkit.typed.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.{ Address, RootActorPath }
@@ -68,9 +66,9 @@ trait TestInbox[T] {
   /**
    * Collect all messages in the inbox and clear it out
    */
-  def receiveAll(): immutable.Seq[T] = internalReceiveAll()
+  def receiveAll(): Seq[T] = internalReceiveAll()
 
-  protected def internalReceiveAll(): immutable.Seq[T]
+  protected def internalReceiveAll(): Seq[T]
 
   def hasMessages: Boolean
 

--- a/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestProbe.scala
+++ b/actor-testkit-typed/src/main/scala/org/apache/pekko/actor/testkit/typed/scaladsl/TestProbe.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.actor.testkit.typed.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
@@ -179,14 +178,14 @@ object TestProbe {
   /**
    * Same as `receiveMessages(n, remaining)` but using the default timeout as deadline.
    */
-  def receiveMessages(n: Int): immutable.Seq[M]
+  def receiveMessages(n: Int): Seq[M]
 
   /**
    * Receive `n` messages in a row before the given deadline.
    *
    * Note that the timeout is scaled using the configuration entry "pekko.actor.testkit.typed.timefactor".
    */
-  def receiveMessages(n: Int, max: FiniteDuration): immutable.Seq[M]
+  def receiveMessages(n: Int, max: FiniteDuration): Seq[M]
 
   /**
    * Allows for flexible matching of multiple messages within a timeout, the fisher function is fed each incoming
@@ -206,22 +205,22 @@ object TestProbe {
    *            The timeout is scaled using the configuration entry "pekko.actor.testkit.typed.timefactor".
    * @return The messages accepted in the order they arrived
    */
-  def fishForMessage(max: FiniteDuration, hint: String)(fisher: M => FishingOutcome): immutable.Seq[M]
+  def fishForMessage(max: FiniteDuration, hint: String)(fisher: M => FishingOutcome): Seq[M]
 
   /**
    * Same as `fishForMessage` but accepting a partial function and failing for non-matches
    */
-  def fishForMessagePF(max: FiniteDuration, hint: String)(fisher: PartialFunction[M, FishingOutcome]): immutable.Seq[M]
+  def fishForMessagePF(max: FiniteDuration, hint: String)(fisher: PartialFunction[M, FishingOutcome]): Seq[M]
 
   /**
    * Same as the other `fishForMessage` but with no hint
    */
-  def fishForMessage(max: FiniteDuration)(fisher: M => FishingOutcome): immutable.Seq[M]
+  def fishForMessage(max: FiniteDuration)(fisher: M => FishingOutcome): Seq[M]
 
   /**
    * Same as `fishForMessage` but with no hint, accepting a partial function and failing for non-matches
    */
-  def fishForMessagePF(max: FiniteDuration)(fisher: PartialFunction[M, FishingOutcome]): immutable.Seq[M]
+  def fishForMessagePF(max: FiniteDuration)(fisher: PartialFunction[M, FishingOutcome]): Seq[M]
 
   /**
    * Expect the given actor to be stopped or stop within the given timeout or

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/DynamicAccessSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/DynamicAccessSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.actor
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
@@ -97,7 +96,7 @@ class DynamicAccessSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll
     "preserve the target exception from a failing constructor" in {
       val result = dynamicAccess.createInstanceFor[TestClassWithThrowingConstructor](
         classOf[TestClassWithThrowingConstructor],
-        immutable.Seq(classOf[String] -> "ignored"))
+        Seq(classOf[String] -> "ignored"))
       val exception = result.failed.get
       exception shouldBe a[IllegalArgumentException]
       exception.getMessage should ===("user-bug")
@@ -118,7 +117,7 @@ class DynamicAccessSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll
         case s: Success[TestSuperclass]        => s
         case Failure(_: NoSuchMethodException) =>
           dynamicAccess
-            .createInstanceFor[TestSuperclass](fqcn, immutable.Seq((classOf[String], "string ctor argument")))
+            .createInstanceFor[TestSuperclass](fqcn, Seq((classOf[String], "string ctor argument")))
         case f: Failure[?] => f
       }
 

--- a/actor-tests/src/test/scala/org/apache/pekko/actor/RelativeActorPathSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/actor/RelativeActorPathSpec.scala
@@ -16,14 +16,12 @@ package org.apache.pekko.actor
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-import scala.collection.immutable
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class RelativeActorPathSpec extends AnyWordSpec with Matchers {
 
-  def elements(path: String): immutable.Seq[String] = RelativeActorPath.unapply(path).getOrElse(Nil)
+  def elements(path: String): Seq[String] = RelativeActorPath.unapply(path).getOrElse(Nil)
 
   "RelativeActorPath" must {
     "match single name" in {

--- a/actor-tests/src/test/scala/org/apache/pekko/io/SimpleDnsCacheSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/SimpleDnsCacheSpec.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.io
 import java.net.InetAddress
 import java.util.concurrent.atomic.AtomicLong
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -38,7 +37,7 @@ class SimpleDnsCacheSpec extends AnyWordSpec with Matchers {
       val ttl = Ttl.fromPositive(5000.millis)
       val cacheEntry = DnsProtocol.Resolved(
         "test.local",
-        immutable.Seq(ARecord("test.local", ttl, InetAddress.getByName("127.0.0.1"))))
+        Seq(ARecord("test.local", ttl, InetAddress.getByName("127.0.0.1"))))
       cache.put(("test.local", Ip()), cacheEntry, ttl)
 
       cache.cached(DnsProtocol.Resolve("test.local")) should ===(Some(cacheEntry))
@@ -57,7 +56,7 @@ class SimpleDnsCacheSpec extends AnyWordSpec with Matchers {
       val cacheEntry =
         DnsProtocol.Resolved(
           "test.local",
-          immutable.Seq(ARecord("test.local", ttl, InetAddress.getByName("127.0.0.1"))))
+          Seq(ARecord("test.local", ttl, InetAddress.getByName("127.0.0.1"))))
       cache.put(("test.local", Ip()), cacheEntry, ttl)
 
       cache.cached(DnsProtocol.Resolve("test.local")) should ===(Some(cacheEntry))

--- a/actor-tests/src/test/scala/org/apache/pekko/io/TcpConnectionSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/TcpConnectionSpec.scala
@@ -24,7 +24,6 @@ import java.nio.file.Files
 import java.util.Random
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -962,7 +961,7 @@ class TcpConnectionSpec extends PekkoSpec("""
 
     def createConnectionActor(
         serverAddress: InetSocketAddress = serverAddress,
-        options: immutable.Seq[SocketOption] = Nil,
+        options: Seq[SocketOption] = Nil,
         timeout: Option[FiniteDuration] = None,
         pullMode: Boolean = false): TestActorRef[TcpOutgoingConnection] = {
       val ref = createConnectionActorWithoutRegistration(serverAddress, options, timeout, pullMode)
@@ -981,7 +980,7 @@ class TcpConnectionSpec extends PekkoSpec("""
 
     def createConnectionActorWithoutRegistration(
         serverAddress: InetSocketAddress = serverAddress,
-        options: immutable.Seq[SocketOption] = Nil,
+        options: Seq[SocketOption] = Nil,
         timeout: Option[FiniteDuration] = None,
         pullMode: Boolean = false): TestActorRef[TcpOutgoingConnection] =
       TestActorRef(

--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/AsyncDnsManagerSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/AsyncDnsManagerSpec.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.io.dns.internal
 
-import scala.collection.immutable.Seq
-
 import org.apache.pekko
 import pekko.io.Dns
 import pekko.io.dns.AAAARecord

--- a/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/TcpDnsClientSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/io/dns/internal/TcpDnsClientSpec.scala
@@ -15,8 +15,6 @@ package org.apache.pekko.io.dns.internal
 
 import java.net.InetSocketAddress
 
-import scala.collection.immutable.Seq
-
 import org.apache.pekko
 import pekko.actor.{ ActorKilledException, Kill, Props }
 import pekko.io.Tcp

--- a/actor-tests/src/test/scala/org/apache/pekko/routing/ConfiguredLocalRoutingSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/routing/ConfiguredLocalRoutingSpec.scala
@@ -127,7 +127,7 @@ class ConfiguredLocalRoutingSpec
     case _ => throw new IllegalArgumentException(s"Unexpected actorref $ref")
   }
 
-  def collectRouteePaths(probe: TestProbe, router: ActorRef, n: Int): immutable.Seq[ActorPath] = {
+  def collectRouteePaths(probe: TestProbe, router: ActorRef, n: Int): Seq[ActorPath] = {
     for (i <- 1 to n) yield {
       val msg = i.toString
       router.tell(msg, probe.ref)

--- a/actor-tests/src/test/scala/org/apache/pekko/util/ReflectSpec.scala
+++ b/actor-tests/src/test/scala/org/apache/pekko/util/ReflectSpec.scala
@@ -18,7 +18,6 @@ import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.TimeoutException
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -52,46 +51,46 @@ class ReflectSpec extends AnyWordSpec with Matchers {
   "Reflect#findConstructor" must {
 
     "deal with simple 1 matching case" in {
-      Reflect.findConstructor(classOf[One], immutable.Seq(new A))
+      Reflect.findConstructor(classOf[One], Seq(new A))
     }
     "deal with 2-params 1 matching case" in {
-      Reflect.findConstructor(classOf[Two], immutable.Seq(new A, new B))
+      Reflect.findConstructor(classOf[Two], Seq(new A, new B))
     }
     "deal with 2-params where one is `null` 1 matching case" in {
-      Reflect.findConstructor(classOf[Two], immutable.Seq(new A, null))
-      Reflect.findConstructor(classOf[Two], immutable.Seq(null, new B))
+      Reflect.findConstructor(classOf[Two], Seq(new A, null))
+      Reflect.findConstructor(classOf[Two], Seq(null, new B))
     }
     "deal with `null` in 1 matching case" in {
-      val constructor = Reflect.findConstructor(classOf[One], immutable.Seq(null))
+      val constructor = Reflect.findConstructor(classOf[One], Seq(null))
       constructor.invoke(null.asInstanceOf[AnyRef])
     }
     "deal with multiple constructors" in {
-      Reflect.findConstructor(classOf[MultipleOne], immutable.Seq(new A))
-      Reflect.findConstructor(classOf[MultipleOne], immutable.Seq(new B))
-      Reflect.findConstructor(classOf[MultipleOne], immutable.Seq(new A, new B))
+      Reflect.findConstructor(classOf[MultipleOne], Seq(new A))
+      Reflect.findConstructor(classOf[MultipleOne], Seq(new B))
+      Reflect.findConstructor(classOf[MultipleOne], Seq(new A, new B))
     }
     "throw when multiple matching constructors" in {
       intercept[IllegalArgumentException] {
-        Reflect.findConstructor(classOf[MultipleOne], immutable.Seq(null))
+        Reflect.findConstructor(classOf[MultipleOne], Seq(null))
       }
     }
     "use public lookup for public JDK constructors in non-open modules" in {
-      val constructor = Reflect.findConstructor(classOf[TimeoutException], immutable.Seq("err"))
-      val instance = Reflect.instantiate[TimeoutException](constructor, immutable.Seq("err"))
+      val constructor = Reflect.findConstructor(classOf[TimeoutException], Seq("err"))
+      val instance = Reflect.instantiate[TimeoutException](constructor, Seq("err"))
       instance.getMessage should ===("err")
     }
     "not confuse null with an Object argument across lookups" in {
-      Reflect.instantiate(classOf[StringOnly], immutable.Seq(null)).value shouldBe null
+      Reflect.instantiate(classOf[StringOnly], Seq(null)).value shouldBe null
       intercept[IllegalArgumentException] {
-        Reflect.findConstructor(classOf[StringOnly], immutable.Seq(new Object))
+        Reflect.findConstructor(classOf[StringOnly], Seq(new Object))
       }.getMessage should include("no matching constructor")
     }
     "access private constructors when the package is open" in {
-      Reflect.instantiate(classOf[PrivateConstructor], immutable.Seq("private")).value should ===("private")
+      Reflect.instantiate(classOf[PrivateConstructor], Seq("private")).value should ===("private")
     }
     "preserve InvocationTargetException for constructor failures" in {
       val exception = intercept[InvocationTargetException] {
-        Reflect.instantiate(classOf[ThrowingConstructor], immutable.Seq("ignored"))
+        Reflect.instantiate(classOf[ThrowingConstructor], Seq("ignored"))
       }
       exception.getCause shouldBe a[IllegalArgumentException]
       exception.getCause.getMessage should ===("user-bug")
@@ -104,7 +103,7 @@ class ReflectSpec extends AnyWordSpec with Matchers {
     }
     "invoke varargs constructors as fixed arity" in {
       val processBuilder =
-        Reflect.instantiate(classOf[ProcessBuilder], immutable.Seq(Array("echo", "fixed-arity")))
+        Reflect.instantiate(classOf[ProcessBuilder], Seq(Array("echo", "fixed-arity")))
       processBuilder.command().toArray should ===(Array[AnyRef]("echo", "fixed-arity"))
     }
   }

--- a/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/FSMDocSpec.scala
+++ b/actor-typed-tests/src/test/scala/docs/org/apache/pekko/typed/FSMDocSpec.scala
@@ -18,7 +18,6 @@ import pekko.actor.testkit.typed.scaladsl.TestProbe
 import pekko.actor.typed.scaladsl.Behaviors
 import pekko.actor.typed.{ ActorRef, Behavior }
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
@@ -42,9 +41,9 @@ object FSMDocSpec {
     // #storing-state
     sealed trait Data
     case object Uninitialized extends Data
-    final case class Todo(target: ActorRef[Batch], queue: immutable.Seq[Any]) extends Data
+    final case class Todo(target: ActorRef[Batch], queue: Seq[Any]) extends Data
 
-    final case class Batch(obj: immutable.Seq[Any])
+    final case class Batch(obj: Seq[Any])
     // #storing-state
 
     // #simple-state
@@ -94,12 +93,12 @@ class FSMDocSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with Log
       buncher ! Buncher.SetTarget(probe.ref)
       buncher ! Buncher.Queue(42)
       buncher ! Buncher.Queue(43)
-      probe.expectMessage(Buncher.Batch(immutable.Seq(42, 43)))
+      probe.expectMessage(Buncher.Batch(Seq(42, 43)))
       buncher ! Buncher.Queue(44)
       buncher ! Buncher.Flush
       buncher ! Buncher.Queue(45)
-      probe.expectMessage(Buncher.Batch(immutable.Seq(44)))
-      probe.expectMessage(Buncher.Batch(immutable.Seq(45)))
+      probe.expectMessage(Buncher.Batch(Seq(44)))
+      probe.expectMessage(Buncher.Batch(Seq(45)))
 
     }
   }

--- a/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/internal/ProducerControllerImpl.scala
+++ b/actor-typed/src/main/scala/org/apache/pekko/actor/typed/delivery/internal/ProducerControllerImpl.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.actor.typed.delivery.internal
 import java.util.concurrent.TimeoutException
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.Failure
 import scala.util.Success
@@ -136,7 +135,7 @@ object ProducerControllerImpl {
       replyAfterStore: Map[SeqNr, ActorRef[SeqNr]],
       supportResend: Boolean,
       unconfirmed: Vector[ConsumerController.SequencedMessage[A]],
-      remainingChunks: immutable.Seq[SequencedMessage[A]],
+      remainingChunks: Seq[SequencedMessage[A]],
       storeMessageSentInProgress: SeqNr,
       firstSeqNr: SeqNr,
       producer: ActorRef[ProducerController.RequestNext[A]],
@@ -349,7 +348,7 @@ object ProducerControllerImpl {
       throw new IllegalArgumentException(s"Consumer [$ref] should be local.")
   }
 
-  def createChunks[A](m: A, chunkSize: Int, serialization: Serialization): immutable.Seq[ChunkedMessage] = {
+  def createChunks[A](m: A, chunkSize: Int, serialization: Serialization): Seq[ChunkedMessage] = {
     val mAnyRef = m.asInstanceOf[AnyRef]
     // serialization exceptions are thrown
     val bytes = serialization.serialize(mAnyRef).get
@@ -408,7 +407,7 @@ private class ProducerControllerImpl[A: ClassTag](
     def onMsg(
         seqMsg: SequencedMessage[A],
         newReplyAfterStore: Map[SeqNr, ActorRef[SeqNr]],
-        newRemainingChunks: immutable.Seq[SequencedMessage[A]]): Behavior[InternalCommand] = {
+        newRemainingChunks: Seq[SequencedMessage[A]]): Behavior[InternalCommand] = {
       checkOnMsgRequestedState()
       if (seqMsg.isLastChunk != newRemainingChunks.isEmpty)
         throw new IllegalStateException(
@@ -733,7 +732,7 @@ private class ProducerControllerImpl[A: ClassTag](
       }
     }
 
-    def chunk(m: A, ack: Boolean): immutable.Seq[SequencedMessage[A]] = {
+    def chunk(m: A, ack: Boolean): Seq[SequencedMessage[A]] = {
       val chunkSize = settings.chunkLargeMessagesBytes
       if (chunkSize > 0) {
         val chunkedMessages = createChunks(m, chunkSize, serialization)

--- a/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ActorSystem.scala
@@ -19,7 +19,6 @@ import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext, ExecutionContextExecutor, Future, Promise }
 import scala.concurrent.blocking
 import scala.concurrent.duration.Duration
@@ -433,7 +432,7 @@ object ActorSystem {
 
     final val LogLevel: String = getString("pekko.loglevel")
     final val StdoutLogLevel: String = getString("pekko.stdout-loglevel")
-    final val Loggers: immutable.Seq[String] = immutableSeq(getStringList("pekko.loggers"))
+    final val Loggers: Seq[String] = immutableSeq(getStringList("pekko.loggers"))
     final val LoggersDispatcher: String = getString("pekko.loggers-dispatcher")
     final val LoggingFilter: String = getString("pekko.logging-filter")
     final val LoggerStartTimeout: Timeout = Timeout(config.getMillisDuration("pekko.logger-startup-timeout"))
@@ -1168,7 +1167,7 @@ private[pekko] class ActorSystemImpl(
     dynamicAccess
       .createInstanceFor[Scheduler](
         settings.SchedulerClass,
-        immutable.Seq(
+        Seq(
           classOf[Config] -> settings.config,
           classOf[LoggingAdapter] -> log,
           classOf[ThreadFactory] -> threadFactory.withName(threadFactory.name + "-scheduler")))

--- a/actor/src/main/scala/org/apache/pekko/actor/Address.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Address.scala
@@ -169,7 +169,7 @@ private[pekko] trait PathUtils {
  *  * "/user/hello/world"
  */
 object RelativeActorPath extends PathUtils {
-  def unapply(addr: String): Option[immutable.Seq[String]] = {
+  def unapply(addr: String): Option[Seq[String]] = {
     try {
       val uri = new URI(addr)
       if (uri.isAbsolute) None

--- a/actor/src/main/scala/org/apache/pekko/actor/DynamicAccess.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/DynamicAccess.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.actor
 
-import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.Try
 
@@ -40,7 +39,7 @@ import pekko.annotation.DoNotInherit
    * val obj = DynamicAccess.createInstanceFor(clazz, Seq(classOf[Config] -> config, classOf[String] -> name))
    * }}}
    */
-  def createInstanceFor[T: ClassTag](clazz: Class[?], args: immutable.Seq[(Class[?], AnyRef)]): Try[T]
+  def createInstanceFor[T: ClassTag](clazz: Class[?], args: Seq[(Class[?], AnyRef)]): Try[T]
 
   /**
    * Obtain a `Class[_]` object loaded with the right class loader (i.e. the one
@@ -57,7 +56,7 @@ import pekko.annotation.DoNotInherit
    * `args` argument. The exact usage of args depends on which type is requested,
    * see the relevant requesting code for details.
    */
-  def createInstanceFor[T: ClassTag](fqcn: String, args: immutable.Seq[(Class[?], AnyRef)]): Try[T]
+  def createInstanceFor[T: ClassTag](fqcn: String, args: Seq[(Class[?], AnyRef)]): Try[T]
 
   /**
    * Obtain the Scala “object” instance for the given fully-qualified class name, if there is one.

--- a/actor/src/main/scala/org/apache/pekko/actor/FaultHandling.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/FaultHandling.scala
@@ -246,7 +246,7 @@ object SupervisorStrategy extends SupervisorStrategyLowPriorityImplicits {
    * Implicit conversion from `Seq` of Throwables to a `Decider`.
    * This maps the given Throwables to restarts, otherwise escalates.
    */
-  implicit def seqThrowable2Decider(trapExit: immutable.Seq[Class[? <: Throwable]]): Decider = makeDecider(trapExit)
+  implicit def seqThrowable2Decider(trapExit: Seq[Class[? <: Throwable]]): Decider = makeDecider(trapExit)
 
   type Decider = PartialFunction[Throwable, Directive]
   type JDecider = pekko.japi.function.Function[Throwable, Directive]
@@ -256,7 +256,7 @@ object SupervisorStrategy extends SupervisorStrategyLowPriorityImplicits {
    * Decider builder which just checks whether one of
    * the given Throwables matches the cause and restarts, otherwise escalates.
    */
-  def makeDecider(trapExit: immutable.Seq[Class[? <: Throwable]]): Decider = {
+  def makeDecider(trapExit: Seq[Class[? <: Throwable]]): Decider = {
     case x => if (trapExit.exists(_.isInstance(x))) Restart else Escalate
   }
 
@@ -289,7 +289,7 @@ object SupervisorStrategy extends SupervisorStrategyLowPriorityImplicits {
    *
    * INTERNAL API
    */
-  private[pekko] def sort(in: Iterable[CauseDirective]): immutable.Seq[CauseDirective] =
+  private[pekko] def sort(in: Iterable[CauseDirective]): Seq[CauseDirective] =
     in.foldLeft(new ArrayBuffer[CauseDirective](in.size)) { (buf, ca) =>
       buf.indexWhere(_._1.isAssignableFrom(ca._1)) match {
         case -1 => buf.append(ca)
@@ -461,7 +461,7 @@ abstract class SupervisorStrategy {
  *   if the limit is exceeded the child actor is stopped
  * @param withinTimeRange duration of the time window for maxNrOfRetries, Duration.Inf means no window
  * @param decider mapping from Throwable to [[pekko.actor.SupervisorStrategy.Directive]], you can also use a
- *   [[scala.collection.immutable.Seq]] of Throwables which maps the given Throwables to restarts, otherwise escalates.
+ *   [[Seq]] of Throwables which maps the given Throwables to restarts, otherwise escalates.
  * @param loggingEnabled the strategy logs the failure if this is enabled (true), by default it is enabled
  */
 case class AllForOneStrategy(
@@ -576,7 +576,7 @@ case class AllForOneStrategy(
  *  if the duration is infinite. If the limit is exceeded the child actor is stopped
  * @param withinTimeRange duration of the time window for maxNrOfRetries, Duration.Inf means no window
  * @param decider mapping from Throwable to [[pekko.actor.SupervisorStrategy.Directive]], you can also use a
- *   [[scala.collection.immutable.Seq]] of Throwables which maps the given Throwables to restarts, otherwise escalates.
+ *   [[Seq]] of Throwables which maps the given Throwables to restarts, otherwise escalates.
  * @param loggingEnabled the strategy logs the failure if this is enabled (true), by default it is enabled
  */
 case class OneForOneStrategy(

--- a/actor/src/main/scala/org/apache/pekko/actor/IndirectActorProducer.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/IndirectActorProducer.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.actor
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.japi.function.Creator
@@ -52,7 +51,7 @@ private[pekko] object IndirectActorProducer {
   val CreatorConsumerClass = classOf[CreatorConsumer]
   val TypedCreatorFunctionConsumerClass = classOf[TypedCreatorFunctionConsumer]
   @nowarn
-  def apply(clazz: Class[?], args: immutable.Seq[Any]): IndirectActorProducer = {
+  def apply(clazz: Class[?], args: Seq[Any]): IndirectActorProducer = {
     if (classOf[IndirectActorProducer].isAssignableFrom(clazz)) {
       def get1stArg[T]: T = args.head.asInstanceOf[T]
       def get2ndArg[T]: T = args.tail.head.asInstanceOf[T]
@@ -103,7 +102,7 @@ private[pekko] class TypedCreatorFunctionConsumer(clz: Class[? <: Actor], creato
 /**
  * INTERNAL API
  */
-private[pekko] class ArgsReflectConstructor(clz: Class[? <: Actor], args: immutable.Seq[Any])
+private[pekko] class ArgsReflectConstructor(clz: Class[? <: Actor], args: Seq[Any])
     extends IndirectActorProducer {
   private val constructor = Reflect.constructorInvoker(Reflect.findConstructor(clz, args))
   private val arguments = Reflect.argumentArray(args)

--- a/actor/src/main/scala/org/apache/pekko/actor/LightArrayRevolverScheduler.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/LightArrayRevolverScheduler.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
@@ -253,9 +252,9 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
         s"Task scheduled with [${delayNanos.nanos.toSeconds}] seconds delay, " +
         s"which is too far in future, maximum delay is [${(tickNanos * Int.MaxValue).nanos.toSeconds - 1}] seconds")
 
-  private val stopped = new AtomicReference[Promise[immutable.Seq[TimerTask]]]
-  private def stop(): Future[immutable.Seq[TimerTask]] = {
-    val p = Promise[immutable.Seq[TimerTask]]()
+  private val stopped = new AtomicReference[Promise[Seq[TimerTask]]]
+  private def stop(): Future[Seq[TimerTask]] = {
+    val p = Promise[Seq[TimerTask]]()
     if (stopped.compareAndSet(null, p)) {
       // Interrupting the timer thread to make it shut down faster is not good since
       // it could be in the middle of executing the scheduled tasks, which might not
@@ -272,7 +271,7 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
     val wheel = Array.fill(WheelSize)(new TaskQueue)
     var spareTaskQueue = new TaskQueue
 
-    private def clearAll(): immutable.Seq[TimerTask] = {
+    private def clearAll(): Seq[TimerTask] = {
       @tailrec def collect(q: TaskQueue, acc: Vector[TimerTask]): Vector[TimerTask] = {
         q.poll() match {
           case null => acc

--- a/actor/src/main/scala/org/apache/pekko/actor/Props.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Props.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.actor
 
 import scala.annotation.varargs
-import scala.collection.immutable
 import scala.reflect.ClassTag
 
 import org.apache.pekko
@@ -121,7 +120,7 @@ object Props extends AbstractProps {
  * }}}
  */
 @SerialVersionUID(2L)
-final case class Props(deploy: Deploy, clazz: Class[?], args: immutable.Seq[Any]) {
+final case class Props(deploy: Deploy, clazz: Class[?], args: Seq[Any]) {
 
   Props.validate(clazz)
 

--- a/actor/src/main/scala/org/apache/pekko/actor/ReflectiveDynamicAccess.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/ReflectiveDynamicAccess.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.actor
 import java.lang.invoke.{ MethodHandle, MethodHandles, MethodType, VarHandle }
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.Failure
 import scala.util.Try
@@ -47,7 +46,7 @@ class ReflectiveDynamicAccess(val classLoader: ClassLoader) extends DynamicAcces
       if (t.isAssignableFrom(c)) c else throw new ClassCastException(t.toString + " is not assignable from " + c)
     }
 
-  override def createInstanceFor[T: ClassTag](clazz: Class[?], args: immutable.Seq[(Class[?], AnyRef)]): Try[T] =
+  override def createInstanceFor[T: ClassTag](clazz: Class[?], args: Seq[(Class[?], AnyRef)]): Try[T] =
     Try {
       val types = new Array[Class[?]](args.size)
       val values = new Array[AnyRef](args.size)
@@ -67,7 +66,7 @@ class ReflectiveDynamicAccess(val classLoader: ClassLoader) extends DynamicAcces
       else throw new ClassCastException(clazz.getName + " is not a subtype of " + t)
     }
 
-  override def createInstanceFor[T: ClassTag](fqcn: String, args: immutable.Seq[(Class[?], AnyRef)]): Try[T] =
+  override def createInstanceFor[T: ClassTag](fqcn: String, args: Seq[(Class[?], AnyRef)]): Try[T] =
     getClassFor(fqcn).flatMap { c =>
       createInstanceFor(c, args)
     }

--- a/actor/src/main/scala/org/apache/pekko/actor/Stash.scala
+++ b/actor/src/main/scala/org/apache/pekko/actor/Stash.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.actor
 
-import scala.collection.immutable
 import scala.util.control.NoStackTrace
 
 import org.apache.pekko
@@ -193,7 +192,7 @@ private[pekko] trait StashSupport {
    * Prepends `others` to this stash. This method is optimized for a large stash and
    * small `others`.
    */
-  private[pekko] def prepend(others: immutable.Seq[Envelope]): Unit =
+  private[pekko] def prepend(others: Seq[Envelope]): Unit =
     theStash = others.foldRight(theStash)((e, s) => e +: s)
 
   /**

--- a/actor/src/main/scala/org/apache/pekko/dispatch/affinity/AffinityPool.scala
+++ b/actor/src/main/scala/org/apache/pekko/dispatch/affinity/AffinityPool.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.{ LockSupport, ReentrantLock }
 
 import scala.annotation.{ switch, tailrec }
-import scala.collection.{ immutable, mutable }
+import scala.collection.mutable
 
 import org.apache.pekko
 import pekko.annotation.{ ApiMayChange, InternalApi }
@@ -341,7 +341,7 @@ private[pekko] final class AffinityPoolConfigurator(config: Config, prerequisite
   private val queueSelectorFactoryFQCN = config.getString("queue-selector")
   private val queueSelectorFactory: QueueSelectorFactory =
     prerequisites.dynamicAccess
-      .createInstanceFor[QueueSelectorFactory](queueSelectorFactoryFQCN, immutable.Seq(classOf[Config] -> config))
+      .createInstanceFor[QueueSelectorFactory](queueSelectorFactoryFQCN, Seq(classOf[Config] -> config))
       .recover {
         case _ =>
           throw new IllegalArgumentException(

--- a/actor/src/main/scala/org/apache/pekko/event/EventBus.scala
+++ b/actor/src/main/scala/org/apache/pekko/event/EventBus.scala
@@ -195,12 +195,12 @@ trait SubchannelClassification { this: EventBus =>
     //       since it is only called from new functionality in EventStreamUnsubscriber
     cache.values.exists { _ contains subscriber }
 
-  private def removeFromCache(changes: immutable.Seq[(Classifier, Set[Subscriber])]): Unit =
+  private def removeFromCache(changes: Seq[(Classifier, Set[Subscriber])]): Unit =
     cache = changes.foldLeft(cache) {
       case (m, (c, cs)) => m.updated(c, m.getOrElse(c, Set.empty[Subscriber]).diff(cs))
     }
 
-  private def addToCache(changes: immutable.Seq[(Classifier, Set[Subscriber])]): Unit =
+  private def addToCache(changes: Seq[(Classifier, Set[Subscriber])]): Unit =
     cache = changes.foldLeft(cache) {
       case (m, (c, cs)) => m.updated(c, m.getOrElse(c, Set.empty[Subscriber]).union(cs))
     }

--- a/actor/src/main/scala/org/apache/pekko/event/Logging.scala
+++ b/actor/src/main/scala/org/apache/pekko/event/Logging.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.locks.ReentrantLock
 
 import scala.annotation.implicitNotFound
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.language.existentials
 import scala.util.control.{ NoStackTrace, NonFatal }
@@ -559,7 +558,7 @@ object Logging {
   }
 
   // these type ascriptions/casts are necessary to avoid CCEs during construction while retaining correct type
-  val AllLogLevels: immutable.Seq[LogLevel] = Vector(ErrorLevel, WarningLevel, InfoLevel, DebugLevel)
+  val AllLogLevels: Seq[LogLevel] = Vector(ErrorLevel, WarningLevel, InfoLevel, DebugLevel)
 
   /**
    * Obtain LoggingAdapter for the given actor system and source object. This

--- a/actor/src/main/scala/org/apache/pekko/io/InetAddressDnsResolver.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/InetAddressDnsResolver.scala
@@ -19,7 +19,6 @@ import java.net.Inet6Address
 import java.security.Security
 import java.util.concurrent.TimeUnit
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 
@@ -128,7 +127,7 @@ class InetAddressDnsResolver(cache: SimpleDnsCache, config: Config) extends Acto
             answer
           } catch {
             case _: UnknownHostException =>
-              val answer = DnsProtocol.Resolved(name, immutable.Seq.empty)
+              val answer = DnsProtocol.Resolved(name, Seq.empty)
               if (negativeCachePolicy != Never)
                 cache.put((name, ip), answer, negativeCachePolicy)
               answer
@@ -139,9 +138,9 @@ class InetAddressDnsResolver(cache: SimpleDnsCache, config: Config) extends Acto
 
   private def addressToRecords(
       name: String,
-      addresses: immutable.Seq[InetAddress],
+      addresses: Seq[InetAddress],
       ipv4: Boolean,
-      ipv6: Boolean): immutable.Seq[ResourceRecord] = {
+      ipv6: Boolean): Seq[ResourceRecord] = {
     addresses.collect {
       case a: Inet4Address if ipv4 => ARecord(name, Ttl.toTll(positiveCachePolicy), a)
       case a: Inet6Address if ipv6 => AAAARecord(name, Ttl.toTll(positiveCachePolicy), a)

--- a/actor/src/main/scala/org/apache/pekko/io/dns/internal/AsyncDnsResolver.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/internal/AsyncDnsResolver.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.io.dns.internal
 import java.net.{ Inet4Address, Inet6Address, InetAddress, InetSocketAddress }
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.concurrent.{ ExecutionContextExecutor, Future, Promise }
 import scala.concurrent.ExecutionContext.parasitic
 import scala.util.{ Failure, Success, Try }
@@ -176,7 +175,7 @@ private[pekko] object AsyncDnsResolver {
     isIpv4Address(name) || isIpv6Address(name)
 
   private val Empty =
-    Future.successful(Answer(-1, immutable.Seq.empty[ResourceRecord], immutable.Seq.empty[ResourceRecord]))
+    Future.successful(Answer(-1, Seq.empty[ResourceRecord], Seq.empty[ResourceRecord]))
 
   private[pekko] def failToResolve(name: String, nameServers: List[InetSocketAddress]): ResolveFailedException =
     ResolveFailedException(s"Failed to resolve $name with nameservers $nameServers")

--- a/actor/src/main/scala/org/apache/pekko/io/dns/internal/DnsMessage.scala
+++ b/actor/src/main/scala/org/apache/pekko/io/dns/internal/DnsMessage.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.io.dns.internal
 
 import scala.collection.IterableOnce
-import scala.collection.immutable.Seq
 import scala.util.{ Failure, Success, Try }
 
 import org.apache.pekko

--- a/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
+++ b/actor/src/main/scala/org/apache/pekko/japi/JavaAPI.scala
@@ -109,24 +109,24 @@ object Util {
   def classTag[T](clazz: Class[T]): ClassTag[T] = ClassTag(clazz)
 
   /**
-   * Returns an immutable.Seq representing the provided array of Classes,
+   * Returns an Seq representing the provided array of Classes,
    * an overloading of the generic immutableSeq in Util, to accommodate for erasure.
    */
-  def immutableSeq(arr: Array[Class[?]]): immutable.Seq[Class[?]] = immutableSeq[Class[?]](arr)
+  def immutableSeq(arr: Array[Class[?]]): Seq[Class[?]] = immutableSeq[Class[?]](arr)
 
   /**
    * Turns an array into an immutable Scala sequence (by copying it).
    */
-  def immutableSeq[T](arr: Array[T]): immutable.Seq[T] =
+  def immutableSeq[T](arr: Array[T]): Seq[T] =
     if ((arr ne null) && arr.length > 0) arr.toIndexedSeq else Nil
 
   /**
    * Turns a [[java.lang.Iterable]] into an immutable Scala sequence (by copying it).
    */
-  def immutableSeq[T](iterable: java.lang.Iterable[T]): immutable.Seq[T] =
+  def immutableSeq[T](iterable: java.lang.Iterable[T]): Seq[T] =
     iterable match {
-      case imm: immutable.Seq[?] => imm.asInstanceOf[immutable.Seq[T]]
-      case other                 =>
+      case imm: Seq[?] => imm.asInstanceOf[Seq[T]]
+      case other       =>
         val i = other.iterator()
         if (i.hasNext) {
           val builder = new immutable.VectorBuilder[T]
@@ -137,7 +137,7 @@ object Util {
         } else EmptyImmutableSeq
     }
 
-  def immutableSingletonSeq[T](value: T): immutable.Seq[T] = value :: Nil
+  def immutableSingletonSeq[T](value: T): Seq[T] = value :: Nil
 
   def javaArrayList[T](seq: Seq[T]): java.util.List[T] = {
     val size = seq.size

--- a/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/Serialization.scala
@@ -20,7 +20,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{ DynamicVariable, Failure, Try }
 import scala.util.Success
@@ -307,7 +306,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
   def serializerFor(clazz: Class[?]): Serializer =
     serializerMap.get(clazz) match {
       case null => // bindings are ordered from most specific to least specific
-        def unique(possibilities: immutable.Seq[(Class[?], Serializer)]): Boolean =
+        def unique(possibilities: Seq[(Class[?], Serializer)]): Boolean =
           possibilities.size == 1 || {
             val possibility = possibilities.head
             possibilities.forall(_._1.isAssignableFrom(possibility._1)) ||
@@ -318,7 +317,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
           bindings.filter {
             case (c, _) => c.isAssignableFrom(clazz)
           } match {
-            case immutable.Seq() =>
+            case Seq() =>
               throw new NotSerializableException(s"No configured serialization-bindings for class [${clazz.getName}]")
             case possibilities =>
               if (unique(possibilities))
@@ -432,7 +431,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
   /**
    * Programmatically defined serializers
    */
-  private val serializerDetails: immutable.Seq[SerializerDetails] =
+  private val serializerDetails: Seq[SerializerDetails] =
     (system.settings.setup.get[SerializationSetup] match {
       case None          => Vector.empty
       case Some(setting) => setting.createSerializers(system)
@@ -460,7 +459,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
    *  bindings is a Seq of tuple representing the mapping from Class to Serializer.
    *  It is primarily ordered by the most specific classes first, and secondly in the configured order.
    */
-  private[pekko] val bindings: immutable.Seq[ClassSerializer] = {
+  private[pekko] val bindings: Seq[ClassSerializer] = {
     val fromConfig = for {
       (className: String, alias: String) <- settings.SerializationBindings
       if alias != "none" && checkGoogleProtobuf(className)
@@ -508,7 +507,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
    * Sort so that subtypes always precede their supertypes, but without
    * obeying any order between unrelated subtypes (insert sort).
    */
-  private def sort(in: Iterable[ClassSerializer]): immutable.Seq[ClassSerializer] =
+  private def sort(in: Iterable[ClassSerializer]): Seq[ClassSerializer] =
     in
       .foldLeft(new ArrayBuffer[ClassSerializer](in.size)) { (buf, ca) =>
         buf.indexWhere(_._1.isAssignableFrom(ca._1)) match {
@@ -517,7 +516,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
         }
         buf
       }
-      .to(immutable.Seq)
+      .to(Seq)
 
   /**
    * serializerMap is a Map whose keys is the class that is serializable and values is the serializer

--- a/actor/src/main/scala/org/apache/pekko/serialization/SerializationSetup.scala
+++ b/actor/src/main/scala/org/apache/pekko/serialization/SerializationSetup.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.serialization
 
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 
 import org.apache.pekko
@@ -26,7 +25,7 @@ object SerializationSetup {
    * Scala API: Programmatic definition of serializers
    * @param createSerializers create pairs of serializer and the set of classes it should be used for
    */
-  def apply(createSerializers: ExtendedActorSystem => immutable.Seq[SerializerDetails]): SerializationSetup = {
+  def apply(createSerializers: ExtendedActorSystem => Seq[SerializerDetails]): SerializationSetup = {
     new SerializationSetup(createSerializers)
   }
 
@@ -43,7 +42,7 @@ object SerializationSetup {
 /**
  * Setup for the serialization subsystem, constructor is *Internal API*, use factories in [[SerializationSetup]]
  */
-final class SerializationSetup private (val createSerializers: ExtendedActorSystem => immutable.Seq[SerializerDetails])
+final class SerializationSetup private (val createSerializers: ExtendedActorSystem => Seq[SerializerDetails])
     extends Setup
 
 object SerializerDetails {
@@ -55,7 +54,7 @@ object SerializerDetails {
    * @param useFor A set of classes or superclasses to bind to the serializer, selection works just as if
    *               the classes, the alias and the serializer had been in the config.
    */
-  def apply(alias: String, serializer: Serializer, useFor: immutable.Seq[Class[?]]): SerializerDetails =
+  def apply(alias: String, serializer: Serializer, useFor: Seq[Class[?]]): SerializerDetails =
     new SerializerDetails(alias, serializer, useFor)
 
   /**
@@ -77,4 +76,4 @@ object SerializerDetails {
 final class SerializerDetails private (
     val alias: String,
     val serializer: Serializer,
-    val useFor: immutable.Seq[Class[?]])
+    val useFor: Seq[Class[?]])

--- a/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ByteString.scala
@@ -21,8 +21,8 @@ import java.util.Base64
 
 import scala.annotation.{ nowarn, tailrec, varargs }
 import scala.collection.{ immutable, mutable }
-import scala.collection.immutable.{ IndexedSeq, IndexedSeqOps, StrictOptimizedSeqOps, VectorBuilder }
-import scala.collection.mutable.{ Builder, WrappedArray }
+import scala.collection.immutable.{ ArraySeq, IndexedSeq, IndexedSeqOps, StrictOptimizedSeqOps, VectorBuilder }
+import scala.collection.mutable.Builder
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
@@ -161,11 +161,6 @@ object ByteString {
 
   /** Java API */
   def createBuilder: ByteStringBuilder = new ByteStringBuilder
-
-  // implicit val canBuildFrom: CanBuildFrom[TraversableOnce[Byte], Byte, ByteString] =
-  //   new CanBuildFrom[TraversableOnce[Byte], Byte, ByteString] {
-  //     override def apply(ignore: TraversableOnce[Byte]): ByteStringBuilder = new ByteStringBuilder
-  //   }
 
   private[pekko] object ByteString1C extends Companion {
     val empty = new ByteString1C(Array.emptyByteArray)
@@ -3269,9 +3264,11 @@ final class ByteStringBuilder extends Builder[Byte, ByteString] {
 
   override def addAll(xs: IterableOnce[Byte]): this.type = {
     xs match {
-      case bs: ByteString          => addAll(bs)
-      case xs: WrappedArray.ofByte =>
+      case bs: ByteString              => addAll(bs)
+      case xs: mutable.ArraySeq.ofByte =>
         if (xs.nonEmpty) putByteArrayUnsafe(xs.array.clone)
+      case xs: ArraySeq.ofByte =>
+        if (xs.nonEmpty) putByteArrayUnsafe(xs.unsafeArray.clone)
       case seq: (collection.IndexedSeq[Byte] @unchecked) if shouldResizeTempFor(seq.length) =>
         if (seq.nonEmpty) {
           val copied = Array.from(xs)

--- a/actor/src/main/scala/org/apache/pekko/util/Collections.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/Collections.scala
@@ -28,8 +28,8 @@ private[pekko] object Collections {
   }
 
   implicit class IterableOps[T](val iterable: java.lang.Iterable[T]) extends AnyVal {
-    def collectToImmutableSeq[R](pf: PartialFunction[T, R]): immutable.Seq[R] = {
-      val builder = immutable.Seq.newBuilder[R]
+    def collectToImmutableSeq[R](pf: PartialFunction[T, R]): Seq[R] = {
+      val builder = Seq.newBuilder[R]
       iterable.forEach((t: T) => {
         // 1. `applyOrElse` is faster than (`pf.isDefinedAt` and then `pf.apply`)
         // 2. using reference comparing here instead of pattern matching can generate less and quicker bytecode,
@@ -46,7 +46,7 @@ private[pekko] object Collections {
     }
   }
 
-  case object EmptyImmutableSeq extends immutable.Seq[Nothing] {
+  case object EmptyImmutableSeq extends Seq[Nothing] {
     override final def iterator = Iterator.empty
     override final def apply(idx: Int): Nothing = throw new java.lang.IndexOutOfBoundsException(idx.toString)
     override final def length: Int = 0

--- a/actor/src/main/scala/org/apache/pekko/util/FrequencyList.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/FrequencyList.scala
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.util
 
-import scala.collection.{ immutable, mutable }
+import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
 
 import org.apache.pekko
@@ -132,14 +132,14 @@ private[pekko] final class FrequencyList[A](dynamicAging: Boolean, clock: Option
 
   def mostToLeastFrequent: Iterator[A] = backwardIterator.map(_.value)
 
-  def removeLeastFrequent(n: Int): immutable.Seq[A] =
+  def removeLeastFrequent(n: Int): Seq[A] =
     if (n == 1) removeLeastFrequent() // optimised removal of just 1 node
     else forwardIterator.take(n).map(removeLeastFrequentNode).toList
 
-  def removeLeastFrequent(n: Int = 1, skip: OptionVal[A]): immutable.Seq[A] =
+  def removeLeastFrequent(n: Int = 1, skip: OptionVal[A]): Seq[A] =
     forwardIterator.filterNot(node => skip.contains(node.value)).take(n).map(removeLeastFrequentNode).toList
 
-  def removeLeastFrequent(): immutable.Seq[A] = frequency.getFirst match {
+  def removeLeastFrequent(): Seq[A] = frequency.getFirst match {
     case OptionVal.Some(least) =>
       least.nodes.getFirst match {
         case OptionVal.Some(first) => List(removeLeastFrequentNode(first))
@@ -148,14 +148,14 @@ private[pekko] final class FrequencyList[A](dynamicAging: Boolean, clock: Option
     case _ => Nil
   }
 
-  def removeMostFrequent(n: Int): immutable.Seq[A] =
+  def removeMostFrequent(n: Int): Seq[A] =
     if (n == 1) removeMostFrequent() // optimised removal of just 1 node
     else backwardIterator.take(n).map(removeNode).toList
 
-  def removeMostFrequent(n: Int = 1, skip: OptionVal[A]): immutable.Seq[A] =
+  def removeMostFrequent(n: Int = 1, skip: OptionVal[A]): Seq[A] =
     backwardIterator.filterNot(node => skip.contains(node.value)).take(n).map(removeNode).toList
 
-  def removeMostFrequent(): immutable.Seq[A] = frequency.getLast match {
+  def removeMostFrequent(): Seq[A] = frequency.getLast match {
     case OptionVal.Some(most) =>
       most.nodes.getLast match {
         case OptionVal.Some(last) => List(removeNode(last))
@@ -168,23 +168,23 @@ private[pekko] final class FrequencyList[A](dynamicAging: Boolean, clock: Option
 
   def overallMostToLeastRecent: Iterator[A] = overallRecency.backwardIterator.map(_.value)
 
-  def removeOverallLeastRecent(n: Int = 1): immutable.Seq[A] = {
+  def removeOverallLeastRecent(n: Int = 1): Seq[A] = {
     if (clock.isEmpty) throw new UnsupportedOperationException("Overall recency is not enabled for this FrequencyList")
     overallRecency.forwardIterator.take(n).map(removeNode).toList
   }
 
-  def removeOverallMostRecent(n: Int = 1): immutable.Seq[A] = {
+  def removeOverallMostRecent(n: Int = 1): Seq[A] = {
     if (clock.isEmpty) throw new UnsupportedOperationException("Overall recency is not enabled for this FrequencyList")
     overallRecency.backwardIterator.take(n).map(removeNode).toList
   }
 
-  def removeOverallLeastRecentOutside(duration: FiniteDuration): immutable.Seq[A] = {
+  def removeOverallLeastRecentOutside(duration: FiniteDuration): Seq[A] = {
     if (clock.isEmpty) throw new UnsupportedOperationException("Overall recency is not enabled for this FrequencyList")
     val min = clock.get.earlierTime(duration)
     overallRecency.forwardIterator.takeWhile(_.timestamp < min).map(removeNode).toList
   }
 
-  def removeOverallMostRecentWithin(duration: FiniteDuration): immutable.Seq[A] = {
+  def removeOverallMostRecentWithin(duration: FiniteDuration): Seq[A] = {
     if (clock.isEmpty) throw new UnsupportedOperationException("Overall recency is not enabled for this FrequencyList")
     val max = clock.get.earlierTime(duration)
     overallRecency.backwardIterator.takeWhile(_.timestamp > max).map(removeNode).toList

--- a/actor/src/main/scala/org/apache/pekko/util/ManifestInfo.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/ManifestInfo.scala
@@ -17,9 +17,6 @@ import java.io.IOException
 import java.util.jar.Attributes
 import java.util.jar.Manifest
 
-import scala.annotation.nowarn
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.actor.ClassicActorSystemProvider
@@ -75,10 +72,9 @@ object ManifestInfo extends ExtensionId[ManifestInfo] with ExtensionIdProvider {
   /** INTERNAL API */
   private[util] def checkSameVersion(
       productName: String,
-      dependencies: immutable.Seq[String],
+      dependencies: Seq[String],
       versions: Map[String, Version]): Option[String] = {
-    @nowarn("msg=deprecated")
-    val filteredVersions = versions.filterKeys(dependencies.toSet)
+    val filteredVersions = versions.filter { case (k, _) => dependencies.contains(k) }
     val values = filteredVersions.values.toSet
     if (values.size > 1) {
       val highestVersion = values.max
@@ -161,7 +157,7 @@ final class ManifestInfo(val system: ExtendedActorSystem) extends Extension {
    *
    * @return `true` if versions are the same
    */
-  def checkSameVersion(productName: String, dependencies: immutable.Seq[String], logWarning: Boolean): Boolean = {
+  def checkSameVersion(productName: String, dependencies: Seq[String], logWarning: Boolean): Boolean = {
     checkSameVersion(productName, dependencies, logWarning, throwException = system.settings.FailMixedVersions)
   }
 
@@ -175,7 +171,7 @@ final class ManifestInfo(val system: ExtendedActorSystem) extends Extension {
    */
   def checkSameVersion(
       productName: String,
-      dependencies: immutable.Seq[String],
+      dependencies: Seq[String],
       logWarning: Boolean,
       throwException: Boolean): Boolean = {
     ManifestInfo.checkSameVersion(productName, dependencies, versions) match {

--- a/actor/src/main/scala/org/apache/pekko/util/RecencyList.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/RecencyList.scala
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.util
 
-import scala.collection.{ immutable, mutable }
+import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
 
 import org.apache.pekko
@@ -94,36 +94,36 @@ private[pekko] final class RecencyList[A] private (clock: Clock) {
 
   def mostToLeastRecent: Iterator[A] = recency.backwardIterator.map(_.value)
 
-  def removeLeastRecent(n: Int): immutable.Seq[A] =
+  def removeLeastRecent(n: Int): Seq[A] =
     if (n == 1) removeLeastRecent() // optimised removal of just 1 node
     else recency.forwardIterator.take(n).map(removeNode).toList
 
-  def removeLeastRecent(n: Int, skip: Int): immutable.Seq[A] =
+  def removeLeastRecent(n: Int, skip: Int): Seq[A] =
     recency.forwardIterator.slice(skip, skip + n).map(removeNode).toList
 
-  def removeLeastRecent(): immutable.Seq[A] = recency.getFirst match {
+  def removeLeastRecent(): Seq[A] = recency.getFirst match {
     case OptionVal.Some(first) => List(removeNode(first))
     case _                     => Nil
   }
 
-  def removeMostRecent(n: Int): immutable.Seq[A] =
+  def removeMostRecent(n: Int): Seq[A] =
     if (n == 1) removeMostRecent() // optimised removal of just 1 node
     else recency.backwardIterator.take(n).map(removeNode).toList
 
-  def removeMostRecent(n: Int, skip: Int): immutable.Seq[A] =
+  def removeMostRecent(n: Int, skip: Int): Seq[A] =
     recency.backwardIterator.slice(skip, skip + n).map(removeNode).toList
 
-  def removeMostRecent(): immutable.Seq[A] = recency.getLast match {
+  def removeMostRecent(): Seq[A] = recency.getLast match {
     case OptionVal.Some(last) => List(removeNode(last))
     case _                    => Nil
   }
 
-  def removeLeastRecentOutside(duration: FiniteDuration): immutable.Seq[A] = {
+  def removeLeastRecentOutside(duration: FiniteDuration): Seq[A] = {
     val min = clock.earlierTime(duration)
     recency.forwardIterator.takeWhile(_.timestamp < min).map(removeNode).toList
   }
 
-  def removeMostRecentWithin(duration: FiniteDuration): immutable.Seq[A] = {
+  def removeMostRecentWithin(duration: FiniteDuration): Seq[A] = {
     val max = clock.earlierTime(duration)
     recency.backwardIterator.takeWhile(_.timestamp > max).map(removeNode).toList
   }

--- a/actor/src/main/scala/org/apache/pekko/util/Reflect.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/Reflect.scala
@@ -18,7 +18,6 @@ import java.lang.invoke.{ MethodHandle, MethodHandles, MethodType }
 import java.lang.reflect.{ Constructor, InvocationTargetException, Modifier, ParameterizedType, Type }
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.util.control.NonFatal
 
 import org.apache.pekko
@@ -76,7 +75,7 @@ private[pekko] object Reflect {
    * INTERNAL API
    * Calls findConstructor and invokes it with the given arguments.
    */
-  private[pekko] def instantiate[T](clazz: Class[T], args: immutable.Seq[Any]): T = {
+  private[pekko] def instantiate[T](clazz: Class[T], args: Seq[Any]): T = {
     val constructor = findConstructor(clazz, args)
     ensureInitialized(clazz)
     instantiate(constructorInvoker(constructor), argumentArray(args))
@@ -86,7 +85,7 @@ private[pekko] object Reflect {
    * INTERNAL API
    * Invokes the constructor with the given arguments.
    */
-  private[pekko] def instantiate[T](constructor: MethodHandle, args: immutable.Seq[Any]): T = {
+  private[pekko] def instantiate[T](constructor: MethodHandle, args: Seq[Any]): T = {
     ensureInitialized(constructor.`type`().returnType())
     instantiate(constructorInvoker(constructor), argumentArray(args))
   }
@@ -126,7 +125,7 @@ private[pekko] object Reflect {
       .asType(genericConstructorType)
 
   /** INTERNAL API */
-  private[pekko] def argumentArray(args: immutable.Seq[Any]): Array[AnyRef] =
+  private[pekko] def argumentArray(args: Seq[Any]): Array[AnyRef] =
     args.iterator.map(_.asInstanceOf[AnyRef]).toArray
 
   /**
@@ -134,7 +133,7 @@ private[pekko] object Reflect {
    * Implements a primitive form of overload resolution a.k.a. finding the
    * right constructor.
    */
-  private[pekko] def findConstructor[T](clazz: Class[T], args: immutable.Seq[Any]): MethodHandle = {
+  private[pekko] def findConstructor[T](clazz: Class[T], args: Seq[Any]): MethodHandle = {
     def error(msg: String): Nothing = {
       val argClasses = args.map(safeGetClass).mkString(", ")
       throw new IllegalArgumentException(s"$msg found on $clazz for arguments [$argClasses]")
@@ -145,7 +144,7 @@ private[pekko] object Reflect {
     findConstructorHandle(clazz, selectedConstructorType)
   }
 
-  private def findConstructorMethodTypeFromClassMetadata[T](clazz: Class[T], args: immutable.Seq[Any])
+  private def findConstructorMethodTypeFromClassMetadata[T](clazz: Class[T], args: Seq[Any])
       : Option[MethodType] = {
     def matches(parameterTypes: Array[Class[?]]): Boolean =
       parameterTypes.length == args.length &&

--- a/actor/src/main/scala/org/apache/pekko/util/SegmentedRecencyList.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/SegmentedRecencyList.scala
@@ -24,11 +24,11 @@ import pekko.annotation.InternalApi
  */
 @InternalApi
 private[pekko] object SegmentedRecencyList {
-  def empty[A](limits: immutable.Seq[Int]): SegmentedRecencyList[A] =
+  def empty[A](limits: Seq[Int]): SegmentedRecencyList[A] =
     new SegmentedRecencyList[A](limits, OptionVal.None)
 
   object withOverallRecency {
-    def empty[A](clock: Clock, limits: immutable.Seq[Int]): SegmentedRecencyList[A] =
+    def empty[A](clock: Clock, limits: Seq[Int]): SegmentedRecencyList[A] =
       new SegmentedRecencyList[A](limits, OptionVal.Some(clock))
   }
 
@@ -48,7 +48,7 @@ private[pekko] object SegmentedRecencyList {
  * Implemented using doubly-linked lists plus hash map for lookup, so that all operations are constant time.
  */
 @InternalApi
-private[pekko] final class SegmentedRecencyList[A](initialLimits: immutable.Seq[Int], clock: OptionVal[Clock]) {
+private[pekko] final class SegmentedRecencyList[A](initialLimits: Seq[Int], clock: OptionVal[Clock]) {
   import SegmentedRecencyList.Node
 
   private var limits: immutable.IndexedSeq[Int] = initialLimits.toIndexedSeq
@@ -104,7 +104,7 @@ private[pekko] final class SegmentedRecencyList[A](initialLimits: immutable.Seq[
 
   def leastToMostRecentOf(level: Int): Iterator[A] = segments(level).forwardIterator.map(_.value)
 
-  def removeLeastRecentOverLimit(): immutable.Seq[A] = {
+  def removeLeastRecentOverLimit(): Seq[A] = {
     if (size > totalLimit) {
       adjustProtectedLevels()
       val excess = size - totalLimit
@@ -113,18 +113,18 @@ private[pekko] final class SegmentedRecencyList[A](initialLimits: immutable.Seq[
     } else Nil
   }
 
-  def removeLeastRecent(): immutable.Seq[A] = segments(lowest).getFirst match {
+  def removeLeastRecent(): Seq[A] = segments(lowest).getFirst match {
     case OptionVal.Some(first) => List(removeNode(first))
     case _                     => Nil
   }
 
-  def removeOverallLeastRecentOutside(duration: FiniteDuration): immutable.Seq[A] = {
+  def removeOverallLeastRecentOutside(duration: FiniteDuration): Seq[A] = {
     if (clock.isEmpty) throw new UnsupportedOperationException("Overall recency is not enabled")
     val min = clock.get.earlierTime(duration)
     overallRecency.forwardIterator.takeWhile(_.timestamp < min).map(removeNode).toList
   }
 
-  def updateLimits(newLimits: immutable.Seq[Int]): Unit = {
+  def updateLimits(newLimits: Seq[Int]): Unit = {
     limits = newLimits.toIndexedSeq
     totalLimit = limits.sum
   }

--- a/actor/src/main/scala/org/apache/pekko/util/SubclassifiedIndex.scala
+++ b/actor/src/main/scala/org/apache/pekko/util/SubclassifiedIndex.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.util
 
-import scala.collection.immutable
-
 /**
  * Typeclass which describes a classification hierarchy. Observe the contract between `isEqual` and `isSubclass`!
  */
@@ -91,7 +89,7 @@ private[pekko] class SubclassifiedIndex[K, V] private (protected var values: Set
 
   import SubclassifiedIndex._
 
-  type Changes = immutable.Seq[(K, Set[V])]
+  type Changes = Seq[(K, Set[V])]
 
   protected var subkeys = Vector.empty[Nonroot[K, V]]
 
@@ -229,5 +227,5 @@ private[pekko] class SubclassifiedIndex[K, V] private (protected var values: Set
       .foldLeft(emptyMergeMap[K, V]) {
         case (m, (k, s)) => m.updated(k, m(k) ++ s)
       }
-      .to(immutable.Seq)
+      .to(Seq)
 }

--- a/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/ClusterMetricsExtension.scala
+++ b/cluster-metrics/src/main/scala/org/apache/pekko/cluster/metrics/ClusterMetricsExtension.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.cluster.metrics
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor.ActorRef
 import pekko.actor.ActorSystem
@@ -60,7 +58,7 @@ class ClusterMetricsExtension(system: ExtendedActorSystem) extends Extension {
   private[metrics] val strategy = system.dynamicAccess
     .createInstanceFor[SupervisorStrategy](
       SupervisorStrategyProvider,
-      immutable.Seq(classOf[Config] -> SupervisorStrategyConfiguration))
+      Seq(classOf[Config] -> SupervisorStrategyConfiguration))
     .getOrElse {
       val log: LoggingAdapter = Logging(system, classOf[ClusterMetricsExtension])
       log.error("Configured strategy provider {} failed to load, using default {}.",

--- a/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
+++ b/cluster-metrics/src/test/scala/org/apache/pekko/cluster/metrics/MetricSpec.scala
@@ -27,34 +27,27 @@ import pekko.testkit.PekkoSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-@nowarn
 class MetricNumericConverterSpec extends AnyWordSpec with Matchers with MetricNumericConverter {
 
   "MetricNumericConverter" must {
 
     "convert" in {
-      convertNumber(0).isLeft should ===(true)
-      convertNumber(1).left.get should ===(1)
-      convertNumber(1L).isLeft should ===(true)
-      convertNumber(0.0).isRight should ===(true)
+      convertNumber(0) should ===(Left(0L))
+      convertNumber(1) should ===(Left(1L))
+      convertNumber(1L) should ===(Left(1L))
+      convertNumber(0.0) should ===(Right(0.0))
     }
 
     "convert java.math.BigInteger and java.math.BigDecimal" in {
-      convertNumber(java.math.BigInteger.valueOf(42)).isLeft should ===(true)
-      convertNumber(java.math.BigInteger.valueOf(42)).left.get should ===(42L)
-      convertNumber(new java.math.BigDecimal("3.14")).isRight should ===(true)
-      convertNumber(new java.math.BigDecimal("3.14")).right.get should ===(3.14 +- 0.0001)
+      convertNumber(java.math.BigInteger.valueOf(42)) should ===(Left(42L))
+      convertNumber(new java.math.BigDecimal("3.14")).toOption.get should ===(3.14 +- 0.0001)
     }
 
     "convert any Number subtype" in {
-      convertNumber(42.toShort).isLeft should ===(true)
-      convertNumber(42.toShort).left.get should ===(42L)
-      convertNumber(7.toByte).isLeft should ===(true)
-      convertNumber(7.toByte).left.get should ===(7L)
-      convertNumber(new java.util.concurrent.atomic.AtomicInteger(99)).isLeft should ===(true)
-      convertNumber(new java.util.concurrent.atomic.AtomicInteger(99)).left.get should ===(99L)
-      convertNumber(new java.util.concurrent.atomic.AtomicLong(1234L)).isLeft should ===(true)
-      convertNumber(new java.util.concurrent.atomic.AtomicLong(1234L)).left.get should ===(1234L)
+      convertNumber(42.toShort) should ===(Left(42L))
+      convertNumber(7.toByte) should ===(Left(7L))
+      convertNumber(new java.util.concurrent.atomic.AtomicInteger(99)) should ===(Left(99L))
+      convertNumber(new java.util.concurrent.atomic.AtomicLong(1234L)) should ===(Left(1234L))
     }
 
     "define a metric with java.math.BigInteger and java.math.BigDecimal values" in {

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.cluster.sharding.typed
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.jdk.DurationConverters._
 
@@ -328,16 +327,16 @@ object ClusterShardingSettings {
             settings.proportions)
       }
 
-      final class SegmentedSettings(val levels: Int, val proportions: immutable.Seq[Double]) {
+      final class SegmentedSettings(val levels: Int, val proportions: Seq[Double]) {
 
         def withLevels(levels: Int): SegmentedSettings = copy(levels = levels)
 
-        def withProportions(proportions: immutable.Seq[Double]): SegmentedSettings = copy(proportions = proportions)
+        def withProportions(proportions: Seq[Double]): SegmentedSettings = copy(proportions = proportions)
 
         def withProportions(proportions: java.util.List[java.lang.Double]): SegmentedSettings =
           copy(proportions = immutableSeq(proportions).map(_.toDouble))
 
-        private def copy(levels: Int = levels, proportions: immutable.Seq[Double] = proportions): SegmentedSettings =
+        private def copy(levels: Int = levels, proportions: Seq[Double] = proportions): SegmentedSettings =
           new SegmentedSettings(levels, proportions)
       }
     }
@@ -349,7 +348,7 @@ object ClusterShardingSettings {
       def withSegmented(levels: Int): LeastRecentlyUsedSettings =
         copy(segmentedSettings = Some(new SegmentedSettings(levels, Nil)))
 
-      def withSegmented(proportions: immutable.Seq[Double]): LeastRecentlyUsedSettings =
+      def withSegmented(proportions: Seq[Double]): LeastRecentlyUsedSettings =
         copy(segmentedSettings = Some(new SegmentedSettings(proportions.size, proportions)))
 
       def withSegmentedProportions(proportions: java.util.List[java.lang.Double]): LeastRecentlyUsedSettings =

--- a/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ReplicatedEntityProvider.scala
+++ b/cluster-sharding-typed/src/main/scala/org/apache/pekko/cluster/sharding/typed/ReplicatedEntityProvider.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.cluster.sharding.typed
 
 import java.util.{ Set => JSet }
 
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
@@ -152,7 +151,7 @@ object ReplicatedEntityProvider {
  * @tparam M The type of messages the replicated entity accepts
  */
 final class ReplicatedEntityProvider[M] private (
-    val replicas: immutable.Seq[(ReplicatedEntity[M], String)],
+    val replicas: Seq[(ReplicatedEntity[M], String)],
     val directReplication: Boolean) {
 
   /**

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ClusterShardingSettings.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ClusterShardingSettings.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.cluster.sharding
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.jdk.DurationConverters._
 
@@ -284,16 +283,16 @@ object ClusterShardingSettings {
         }
       }
 
-      final class SegmentedSettings(val levels: Int, val proportions: immutable.Seq[Double]) {
+      final class SegmentedSettings(val levels: Int, val proportions: Seq[Double]) {
 
         def withLevels(levels: Int): SegmentedSettings = copy(levels = levels)
 
-        def withProportions(proportions: immutable.Seq[Double]): SegmentedSettings = copy(proportions = proportions)
+        def withProportions(proportions: Seq[Double]): SegmentedSettings = copy(proportions = proportions)
 
         def withProportions(proportions: java.util.List[java.lang.Double]): SegmentedSettings =
           copy(proportions = immutableSeq(proportions).map(_.toDouble))
 
-        private def copy(levels: Int = levels, proportions: immutable.Seq[Double] = proportions): SegmentedSettings =
+        private def copy(levels: Int = levels, proportions: Seq[Double] = proportions): SegmentedSettings =
           new SegmentedSettings(levels, proportions)
       }
     }
@@ -305,7 +304,7 @@ object ClusterShardingSettings {
       def withSegmented(levels: Int): LeastRecentlyUsedSettings =
         copy(segmentedSettings = Some(new SegmentedSettings(levels, Nil)))
 
-      def withSegmented(proportions: immutable.Seq[Double]): LeastRecentlyUsedSettings =
+      def withSegmented(proportions: Seq[Double]): LeastRecentlyUsedSettings =
         copy(segmentedSettings = Some(new SegmentedSettings(proportions.size, proportions)))
 
       def withSegmentedProportions(proportions: java.util.List[java.lang.Double]): LeastRecentlyUsedSettings =
@@ -614,7 +613,7 @@ object ClusterShardingSettings {
   @InternalApi
   private[pekko] case class LeastRecentlyUsedPassivationStrategy(
       limit: Int,
-      segmented: immutable.Seq[Double],
+      segmented: Seq[Double],
       idle: Option[IdlePassivationStrategy])
       extends PassivationStrategy
 

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardCoordinator.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardCoordinator.scala
@@ -378,7 +378,7 @@ object ShardCoordinator {
     /**
      * One or more sent to region directly after registration to speed up new shard startup.
      */
-    final case class ShardHomes(homes: Map[ActorRef, immutable.Seq[ShardId]])
+    final case class ShardHomes(homes: Map[ActorRef, Seq[ShardId]])
         extends CoordinatorMessage
         with DeadLetterSuppression
 

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/ShardRegion.scala
@@ -1086,7 +1086,7 @@ private[pekko] class ShardRegion(
    *
    * Logs a warning if any of the group timed out.
    *
-   * To check subset unresponsive: {{{ queryShards[T](shards.filterKeys(u.contains), shardQuery) }}}
+   * To check subset unresponsive: {{{ queryShards[T](shards.filter { case (id, _) => u.contains(id) }, shardQuery) }}}
    */
   def queryShards[T: ClassTag](shards: Map[ShardId, ActorRef], msg: Any): Future[ShardsQueryResult[T]] = {
     implicit val timeout: Timeout = settings.shardRegionQueryTimeout

--- a/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/internal/EntityPassivationStrategy.scala
+++ b/cluster-sharding/src/main/scala/org/apache/pekko/cluster/sharding/internal/EntityPassivationStrategy.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.cluster.sharding.internal
 
-import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 
 import org.apache.pekko
@@ -31,10 +30,10 @@ import pekko.util.OptionVal
  */
 @InternalApi
 private[pekko] object EntityPassivationStrategy {
-  type PassivateEntities = immutable.Seq[EntityId]
+  type PassivateEntities = Seq[EntityId]
 
   object PassivateEntities {
-    val none: PassivateEntities = immutable.Seq.empty[EntityId]
+    val none: PassivateEntities = Seq.empty[EntityId]
   }
 
   def apply(settings: ClusterShardingSettings, clock: () => Clock): EntityPassivationStrategy = {
@@ -252,7 +251,7 @@ private[pekko] final class LeastRecentlyUsedEntityPassivationStrategy(
 @InternalApi
 private[pekko] final class SegmentedLeastRecentlyUsedEntityPassivationStrategy(
     initialLimit: Int,
-    proportions: immutable.Seq[Double],
+    proportions: Seq[Double],
     idleCheck: Option[IdleCheck],
     clock: () => Clock)
     extends LimitBasedEntityPassivationStrategy(initialLimit) {
@@ -494,7 +493,7 @@ private[pekko] final class LeastRecentlyUsedReplacementPolicy(initialLimit: Int,
 @InternalApi
 private[pekko] final class SegmentedLeastRecentlyUsedReplacementPolicy(
     initialLimit: Int,
-    proportions: immutable.Seq[Double],
+    proportions: Seq[Double],
     idleEnabled: Boolean,
     clock: () => Clock)
     extends ActiveEntities {
@@ -502,7 +501,7 @@ private[pekko] final class SegmentedLeastRecentlyUsedReplacementPolicy(
   import EntityPassivationStrategy.PassivateEntities
 
   private var limit = initialLimit
-  private def segmentLimits: immutable.Seq[Int] = {
+  private def segmentLimits: Seq[Int] = {
     // assign the first segment with the leftover, to have an accurate total limit
     val higherLimits = proportions.drop(1).map(p => (p * limit).toInt)
     (limit - higherLimits.sum) +: higherLimits

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/simulator/Simulator.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/simulator/Simulator.scala
@@ -175,7 +175,7 @@ object Simulator {
   sealed trait Event
   final case class Accessed(regionId: RegionId, shardId: ShardId, entityId: EntityId) extends Event
   final case class Activated(regionId: RegionId, shardId: ShardId, entityId: EntityId) extends Event
-  final case class Passivated(regionId: RegionId, shardId: ShardId, entityIds: immutable.Seq[EntityId]) extends Event
+  final case class Passivated(regionId: RegionId, shardId: ShardId, entityIds: Seq[EntityId]) extends Event
 
   def simulate(simulation: Simulation)(implicit system: ActorSystem): Future[ShardingStats] =
     if (simulation.strategyCreator.requiresPreprocessing) runWithPreprocessing(simulation) else run(simulation)
@@ -261,14 +261,14 @@ object Simulator {
   final class ShardState(regionId: RegionId, shardId: ShardId, strategy: SimulatedStrategy) {
     private val activeEntities = mutable.Set.empty[EntityId]
 
-    def updated(activeShards: Int): immutable.Seq[Event] = {
+    def updated(activeShards: Int): Seq[Event] = {
       val passivateEntities = strategy.shardsUpdated(activeShards)
       passivateEntities.foreach(activeEntities.remove)
       if (passivateEntities.isEmpty) Nil
       else List(Passivated(regionId, shardId, passivateEntities))
     }
 
-    def accessed(entityId: EntityId): immutable.Seq[Event] = {
+    def accessed(entityId: EntityId): Seq[Event] = {
       val changes = if (activeEntities.contains(entityId)) {
         strategy.entityTouched(entityId)
         Nil
@@ -286,13 +286,13 @@ object Simulator {
   }
 
   sealed trait SimulatedStrategy {
-    def shardsUpdated(activeShards: Int): immutable.Seq[EntityId]
-    def entityTouched(id: EntityId): immutable.Seq[EntityId]
+    def shardsUpdated(activeShards: Int): Seq[EntityId]
+    def entityTouched(id: EntityId): Seq[EntityId]
   }
 
   final class PassivationStrategy(strategy: EntityPassivationStrategy) extends SimulatedStrategy {
-    override def shardsUpdated(activeShards: Int): immutable.Seq[EntityId] = strategy.shardsUpdated(activeShards)
-    override def entityTouched(id: EntityId): immutable.Seq[EntityId] = strategy.entityTouched(id)
+    override def shardsUpdated(activeShards: Int): Seq[EntityId] = strategy.shardsUpdated(activeShards)
+    override def entityTouched(id: EntityId): Seq[EntityId] = strategy.entityTouched(id)
   }
 
   sealed trait StrategyCreator {
@@ -308,7 +308,7 @@ object Simulator {
 
   final class LeastRecentlyUsedStrategyCreator(
       perRegionLimit: Int,
-      segmented: immutable.Seq[Double],
+      segmented: Seq[Double],
       clock: () => Clock)
       extends PassivationStrategyCreator {
     override def create(shardId: ShardId): SimulatedStrategy =
@@ -445,12 +445,12 @@ object Simulator {
     private val nextAccess = mutable.TreeMap.empty[AccessTime, EntityId]
     private var never: AccessTime = Int.MaxValue
 
-    override def shardsUpdated(activeShards: Int): immutable.Seq[EntityId] = {
+    override def shardsUpdated(activeShards: Int): Seq[EntityId] = {
       perShardLimit = perRegionLimit / activeShards
       passivateExcessEntities()
     }
 
-    override def entityTouched(id: EntityId): immutable.Seq[EntityId] = {
+    override def entityTouched(id: EntityId): Seq[EntityId] = {
       nextAccess -= recorder.previousAccess(id)
       recorder.nextAccess(id) match {
         case OptionVal.Some(access) =>
@@ -462,7 +462,7 @@ object Simulator {
       passivateExcessEntities()
     }
 
-    private def passivateExcessEntities(): immutable.Seq[EntityId] = {
+    private def passivateExcessEntities(): Seq[EntityId] = {
       val passivated = mutable.ListBuffer.empty[EntityId]
       while (nextAccess.size > perShardLimit) {
         nextAccess.remove(nextAccess.lastKey).foreach(passivated.+=)

--- a/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/simulator/SimulatorSettings.scala
+++ b/cluster-sharding/src/test/scala/org/apache/pekko/cluster/sharding/passivation/simulator/SimulatorSettings.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.cluster.sharding.passivation.simulator
 
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 
 import org.apache.pekko
@@ -22,7 +21,7 @@ import pekko.util.Helpers.toRootLowerCase
 
 import com.typesafe.config.Config
 
-final case class SimulatorSettings(runs: immutable.Seq[SimulatorSettings.RunSettings], printDetailedStats: Boolean)
+final case class SimulatorSettings(runs: Seq[SimulatorSettings.RunSettings], printDetailedStats: Boolean)
 
 object SimulatorSettings {
   def apply(testConfig: Config): SimulatorSettings = {
@@ -57,7 +56,7 @@ object SimulatorSettings {
 
   object StrategySettings {
     final case class Optimal(perRegionLimit: Int) extends StrategySettings
-    final case class LeastRecentlyUsed(perRegionLimit: Int, segmented: immutable.Seq[Double]) extends StrategySettings
+    final case class LeastRecentlyUsed(perRegionLimit: Int, segmented: Seq[Double]) extends StrategySettings
     final case class MostRecentlyUsed(perRegionLimit: Int) extends StrategySettings
     final case class LeastFrequentlyUsed(perRegionLimit: Int, dynamicAging: Boolean) extends StrategySettings
     case object NoStrategy extends StrategySettings

--- a/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/Cluster.scala
+++ b/cluster-typed/src/main/scala/org/apache/pekko/cluster/typed/Cluster.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.cluster.typed
 
 import java.util.concurrent.CompletionStage
 
-import scala.collection.immutable
 import scala.concurrent.Future
 
 import org.apache.pekko
@@ -115,7 +114,7 @@ object Join {
  * When it has successfully joined it must be restarted to be able to join another
  * cluster or to join the same cluster again.
  */
-final case class JoinSeedNodes(seedNodes: immutable.Seq[Address]) extends ClusterCommand {
+final case class JoinSeedNodes(seedNodes: Seq[Address]) extends ClusterCommand {
   seedNodes.foreach(_.checkHostCharacters())
 
   /**

--- a/cluster-typed/src/test/scala/org/apache/pekko/cluster/typed/ClusterApiSpec.scala
+++ b/cluster-typed/src/test/scala/org/apache/pekko/cluster/typed/ClusterApiSpec.scala
@@ -56,7 +56,7 @@ class ClusterApiSpec extends ScalaTestWithActorTestKit(ClusterApiSpec.config) wi
     "fail fast in a join attempt if invalid chars are in host names, e.g. docker host given name" in {
       val address = Address("pekko", "sys", Some("in_valid"), Some(0))
       intercept[IllegalArgumentException](Join(address))
-      intercept[IllegalArgumentException](JoinSeedNodes(scala.collection.immutable.Seq(address)))
+      intercept[IllegalArgumentException](JoinSeedNodes(Seq(address)))
     }
 
     "join a cluster and observe events from both sides" in {

--- a/cluster/src/main/scala/org/apache/pekko/cluster/Cluster.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/Cluster.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.annotation.varargs
-import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext }
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -184,8 +183,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
       system.dynamicAccess
         .createInstanceFor[Scheduler](
           system.settings.SchedulerClass,
-          immutable
-            .Seq(classOf[Config] -> cfg, classOf[LoggingAdapter] -> log, classOf[ThreadFactory] -> threadFactory))
+          Seq(classOf[Config] -> cfg, classOf[LoggingAdapter] -> log, classOf[ThreadFactory] -> threadFactory))
         .get
     } else {
       // delegate to system.scheduler, but don't close over system
@@ -357,7 +355,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    * When it has successfully joined it must be restarted to be able to join another
    * cluster or to join the same cluster again.
    */
-  def joinSeedNodes(seedNodes: immutable.Seq[Address]): Unit = {
+  def joinSeedNodes(seedNodes: Seq[Address]): Unit = {
     seedNodes.foreach(_.checkHostCharacters())
     clusterCore ! InternalClusterAction.JoinSeedNodes(seedNodes.toVector.map(fillLocal))
   }

--- a/cluster/src/main/scala/org/apache/pekko/cluster/ClusterEvent.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/ClusterEvent.scala
@@ -447,7 +447,7 @@ object ClusterEvent {
   @InternalApi
   private[cluster] def diffUnreachable(
       oldState: MembershipState,
-      newState: MembershipState): immutable.Seq[UnreachableMember] =
+      newState: MembershipState): Seq[UnreachableMember] =
     if (newState eq oldState) Nil
     else {
       val newGossip = newState.latestGossip
@@ -466,7 +466,7 @@ object ClusterEvent {
   @InternalApi
   private[cluster] def diffReachable(
       oldState: MembershipState,
-      newState: MembershipState): immutable.Seq[ReachableMember] =
+      newState: MembershipState): Seq[ReachableMember] =
     if (newState eq oldState) Nil
     else {
       val newGossip = newState.latestGossip
@@ -499,7 +499,7 @@ object ClusterEvent {
   @InternalApi
   private[cluster] def diffUnreachableDataCenter(
       oldState: MembershipState,
-      newState: MembershipState): immutable.Seq[UnreachableDataCenter] = {
+      newState: MembershipState): Seq[UnreachableDataCenter] = {
     if (newState eq oldState) Nil
     else {
       val otherDcs = (oldState.latestGossip.allDataCenters
@@ -518,7 +518,7 @@ object ClusterEvent {
   @InternalApi
   private[cluster] def diffReachableDataCenter(
       oldState: MembershipState,
-      newState: MembershipState): immutable.Seq[ReachableDataCenter] = {
+      newState: MembershipState): Seq[ReachableDataCenter] = {
     if (newState eq oldState) Nil
     else {
       val otherDcs = (oldState.latestGossip.allDataCenters
@@ -537,7 +537,7 @@ object ClusterEvent {
   @InternalApi
   private[cluster] def diffMemberEvents(
       oldState: MembershipState,
-      newState: MembershipState): immutable.Seq[MemberEvent] =
+      newState: MembershipState): Seq[MemberEvent] =
     if (newState eq oldState) Nil
     else {
       val oldGossip = oldState.latestGossip
@@ -573,7 +573,7 @@ object ClusterEvent {
   @InternalApi
   private[cluster] def diffLeader(
       oldState: MembershipState,
-      newState: MembershipState): immutable.Seq[LeaderChanged] = {
+      newState: MembershipState): Seq[LeaderChanged] = {
     val newLeader = newState.leader
     if (newLeader != oldState.leader) List(LeaderChanged(newLeader.map(_.address)))
     else Nil
@@ -595,7 +595,7 @@ object ClusterEvent {
    * INTERNAL API
    */
   @InternalApi
-  private[cluster] def diffSeen(oldState: MembershipState, newState: MembershipState): immutable.Seq[SeenChanged] =
+  private[cluster] def diffSeen(oldState: MembershipState, newState: MembershipState): Seq[SeenChanged] =
     if (oldState eq newState) Nil
     else {
       val newConvergence = newState.convergence(Set.empty)
@@ -611,7 +611,7 @@ object ClusterEvent {
   @InternalApi
   private[cluster] def diffReachability(
       oldState: MembershipState,
-      newState: MembershipState): immutable.Seq[ReachabilityChanged] =
+      newState: MembershipState): Seq[ReachabilityChanged] =
     if (newState.overview.reachability eq oldState.overview.reachability) Nil
     else List(ReachabilityChanged(newState.overview.reachability))
 
@@ -621,7 +621,7 @@ object ClusterEvent {
   @InternalApi
   private[cluster] def diffTombstones(
       oldState: MembershipState,
-      newState: MembershipState): immutable.Seq[MemberTombstonesChanged] =
+      newState: MembershipState): Seq[MemberTombstonesChanged] =
     if (newState.latestGossip.tombstones == oldState.latestGossip.tombstones) Nil
     else MemberTombstonesChanged(newState.latestGossip.tombstones.keySet) :: Nil
 

--- a/cluster/src/main/scala/org/apache/pekko/cluster/Reachability.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/Reachability.scala
@@ -27,7 +27,7 @@ private[cluster] object Reachability {
   def apply(records: immutable.IndexedSeq[Record], versions: Map[UniqueAddress, Long]): Reachability =
     new Reachability(records, versions)
 
-  def create(records: immutable.Seq[Record], versions: Map[UniqueAddress, Long]): Reachability = records match {
+  def create(records: Seq[Record], versions: Map[UniqueAddress, Long]): Reachability = records match {
     case r: (immutable.IndexedSeq[Record] @unchecked) => apply(r, versions)
     case _                                            => apply(records.toVector, versions)
   }

--- a/cluster/src/main/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/protobuf/ClusterMessageSerializer.scala
@@ -355,7 +355,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
    * usual, because the parse is deferred and runs on the cluster daemon rather than on a
    * deserialization thread.
    */
-  private def lookup[T](mapping: immutable.Seq[T], index: Int, what: String): T =
+  private def lookup[T](mapping: Seq[T], index: Int, what: String): T =
     if (index < 0 || index >= mapping.size)
       throw new NotSerializableException(
         s"Cluster message refers to $what index [$index], but only [${mapping.size}] were sent")
@@ -574,7 +574,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
     Gossip(members, overview, vectorClockFromProto(gossip.getVersion, hashMapping), tombstones)
   }
 
-  private def vectorClockFromProto(version: cm.VectorClock, hashMapping: immutable.Seq[String]) = {
+  private def vectorClockFromProto(version: cm.VectorClock, hashMapping: Seq[String]) = {
     VectorClock(scala.collection.immutable.TreeMap.from(version.getVersionsList.asScala.iterator.map(v =>
       (VectorClock.Node.fromHash(lookup(hashMapping, v.getHashIndex, "hash")), v.getTimestamp))))
   }

--- a/cluster/src/main/scala/org/apache/pekko/cluster/routing/ClusterRouterConfig.scala
+++ b/cluster/src/main/scala/org/apache/pekko/cluster/routing/ClusterRouterConfig.scala
@@ -49,7 +49,7 @@ object ClusterRouterGroupSettings {
   @varargs
   def apply(
       totalInstances: Int,
-      routeesPaths: immutable.Seq[String],
+      routeesPaths: Seq[String],
       allowLocalRoutees: Boolean,
       useRoles: String*): ClusterRouterGroupSettings =
     new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles.toSet)
@@ -65,12 +65,12 @@ object ClusterRouterGroupSettings {
 
   def apply(
       totalInstances: Int,
-      routeesPaths: immutable.Seq[String],
+      routeesPaths: Seq[String],
       allowLocalRoutees: Boolean,
       useRoles: Set[String]): ClusterRouterGroupSettings =
     new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRoles)
 
-  def unapply(settings: ClusterRouterGroupSettings): Option[(Int, immutable.Seq[String], Boolean, Set[String])] =
+  def unapply(settings: ClusterRouterGroupSettings): Option[(Int, Seq[String], Boolean, Set[String])] =
     Some((settings.totalInstances, settings.routeesPaths, settings.allowLocalRoutees, settings.useRoles))
 }
 
@@ -80,7 +80,7 @@ object ClusterRouterGroupSettings {
 @SerialVersionUID(1L)
 final class ClusterRouterGroupSettings(
     val totalInstances: Int,
-    val routeesPaths: immutable.Seq[String],
+    val routeesPaths: Seq[String],
     val allowLocalRoutees: Boolean,
     val useRoles: Set[String])
     extends Product

--- a/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/MultiNodeClusterSpec.scala
+++ b/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/MultiNodeClusterSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.cluster
 
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.implicitConversions
@@ -285,7 +284,7 @@ abstract class MultiNodeClusterSpec(multiNodeconfig: MultiNodeConfig)
    * be determined from the `RoleName`.
    */
   def assertLeader(nodesInCluster: RoleName*): Unit =
-    if (nodesInCluster.contains(myself)) assertLeaderIn(nodesInCluster.to(immutable.Seq))
+    if (nodesInCluster.contains(myself)) assertLeaderIn(nodesInCluster.to(Seq))
 
   /**
    * Assert that the cluster has elected the correct leader
@@ -298,7 +297,7 @@ abstract class MultiNodeClusterSpec(multiNodeconfig: MultiNodeConfig)
    * member with status Up or Leaving and that information can't
    * be determined from the `RoleName`.
    */
-  def assertLeaderIn(nodesInCluster: immutable.Seq[RoleName]): Unit =
+  def assertLeaderIn(nodesInCluster: Seq[RoleName]): Unit =
     if (nodesInCluster.contains(myself)) {
       nodesInCluster.length should not be 0
       val expectedLeader = roleOfLeader(nodesInCluster)
@@ -389,7 +388,7 @@ abstract class MultiNodeClusterSpec(multiNodeconfig: MultiNodeConfig)
    * member with status Up or Leaving and that information can't
    * be determined from the `RoleName`.
    */
-  def roleOfLeader(nodesInCluster: immutable.Seq[RoleName] = roles): RoleName = {
+  def roleOfLeader(nodesInCluster: Seq[RoleName] = roles): RoleName = {
     nodesInCluster.length should not be 0
     nodesInCluster.sorted.head
   }

--- a/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/UnreachableNodeJoinsAgainSpec.scala
+++ b/cluster/src/multi-jvm/scala/org/apache/pekko/cluster/UnreachableNodeJoinsAgainSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.cluster
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -55,7 +54,7 @@ abstract class UnreachableNodeJoinsAgainSpec extends MultiNodeClusterSpec(Unreac
 
   muteMarkingAsUnreachable()
 
-  def allBut(role: RoleName, roles: immutable.Seq[RoleName] = roles): immutable.Seq[RoleName] = {
+  def allBut(role: RoleName, roles: Seq[RoleName] = roles): Seq[RoleName] = {
     roles.filterNot(_ == role)
   }
 

--- a/cluster/src/test/scala/org/apache/pekko/cluster/ClusterSpec.scala
+++ b/cluster/src/test/scala/org/apache/pekko/cluster/ClusterSpec.scala
@@ -87,15 +87,15 @@ class ClusterSpec extends PekkoSpec(ClusterSpec.config) with ImplicitSender {
     }
 
     "fail fast in a join if invalid chars in host names, e.g. docker host given name" in {
-      val addresses = scala.collection.immutable
-        .Seq(Address("pekko", "sys", Some("in_valid"), Some(0)), Address("pekko", "sys", Some("invalid._org"), Some(0)))
+      val addresses =
+        Seq(Address("pekko", "sys", Some("in_valid"), Some(0)), Address("pekko", "sys", Some("invalid._org"), Some(0)))
 
       addresses.foreach(a => intercept[IllegalArgumentException](cluster.join(a)))
       intercept[IllegalArgumentException](cluster.joinSeedNodes(addresses))
     }
 
     "not fail fast to attempt a join with valid chars in host names" in {
-      val addresses = scala.collection.immutable.Seq(
+      val addresses = Seq(
         Address("pekko", "sys", Some("localhost"), Some(0)),
         Address("pekko", "sys", Some("is_valid.org"), Some(0)),
         Address("pekko", "sys", Some("fu.is_valid.org"), Some(0)),

--- a/coordination/src/main/scala/org/apache/pekko/coordination/lease/scaladsl/LeaseProvider.scala
+++ b/coordination/src/main/scala/org/apache/pekko/coordination/lease/scaladsl/LeaseProvider.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.coordination.lease.scaladsl
 
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }
 
@@ -108,11 +107,11 @@ final class LeaseProvider(system: ExtendedActorSystem) extends Extension {
     val dynamicAccess = system.dynamicAccess
     dynamicAccess.createInstanceFor[T](
       fqcn,
-      immutable.Seq((classOf[LeaseSettings], leaseSettings), (classOf[ExtendedActorSystem], system))) match {
+      Seq((classOf[LeaseSettings], leaseSettings), (classOf[ExtendedActorSystem], system))) match {
       case s: Success[T] =>
         s
       case Failure(_: NoSuchMethodException) =>
-        dynamicAccess.createInstanceFor[T](fqcn, immutable.Seq((classOf[LeaseSettings], leaseSettings)))
+        dynamicAccess.createInstanceFor[T](fqcn, Seq((classOf[LeaseSettings], leaseSettings)))
       case f: Failure[?] =>
         f
     }

--- a/discovery/src/main/scala/org/apache/pekko/discovery/ServiceDiscovery.scala
+++ b/discovery/src/main/scala/org/apache/pekko/discovery/ServiceDiscovery.scala
@@ -18,7 +18,6 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.TimeUnit
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.DurationConverters._
@@ -40,15 +39,15 @@ object ServiceDiscovery {
   final class DiscoveryTimeoutException(reason: String) extends RuntimeException(reason)
 
   object Resolved {
-    def apply(serviceName: String, addresses: immutable.Seq[ResolvedTarget]): Resolved =
+    def apply(serviceName: String, addresses: Seq[ResolvedTarget]): Resolved =
       new Resolved(serviceName, addresses)
 
-    def unapply(resolved: Resolved): Option[(String, immutable.Seq[ResolvedTarget])] =
+    def unapply(resolved: Resolved): Option[(String, Seq[ResolvedTarget])] =
       Some((resolved.serviceName, resolved.addresses))
   }
 
   /** Result of a successful resolve request */
-  final class Resolved(val serviceName: String, val addresses: immutable.Seq[ResolvedTarget])
+  final class Resolved(val serviceName: String, val addresses: Seq[ResolvedTarget])
       extends DeadLetterSuppression
       with NoSerializationVerificationNeeded {
 

--- a/discovery/src/test/scala/org/apache/pekko/discovery/aggregate/AggregateServiceDiscoverySpec.scala
+++ b/discovery/src/test/scala/org/apache/pekko/discovery/aggregate/AggregateServiceDiscoverySpec.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.discovery.aggregate
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -38,11 +37,11 @@ class StubbedServiceDiscovery(@nowarn("msg=never used") system: ExtendedActorSys
       Future.successful(
         Resolved(
           query.serviceName,
-          immutable.Seq(ResolvedTarget(host = "stubbed1", port = Some(1234), address = None))))
+          Seq(ResolvedTarget(host = "stubbed1", port = Some(1234), address = None))))
     } else if (query.serviceName == "fail") {
       Future.failed(new RuntimeException("No resolving for you!"))
     } else {
-      Future.successful(Resolved(query.serviceName, immutable.Seq.empty))
+      Future.successful(Resolved(query.serviceName, Seq.empty))
     }
   }
 }
@@ -107,14 +106,14 @@ class AggregateServiceDiscoverySpec
       val results = discovery.lookup("stubbed", 100.millis).futureValue
       results shouldEqual Resolved(
         "stubbed",
-        immutable.Seq(ResolvedTarget(host = "stubbed1", port = Some(1234), address = None)))
+        Seq(ResolvedTarget(host = "stubbed1", port = Some(1234), address = None)))
     }
 
     "move onto the next if no resolved targets" in {
       val results = discovery.lookup("config1", 100.millis).futureValue
       results shouldEqual Resolved(
         "config1",
-        immutable.Seq(
+        Seq(
           ResolvedTarget(host = "cat", port = Some(1233), address = None),
           ResolvedTarget(host = "dog", port = Some(1234), address = None)))
     }
@@ -124,7 +123,7 @@ class AggregateServiceDiscoverySpec
       // Stub fails then result comes from config
       results shouldEqual Resolved(
         "fail",
-        immutable.Seq(ResolvedTarget(host = "from-config", port = None, address = None)))
+        Seq(ResolvedTarget(host = "from-config", port = None, address = None)))
     }
   }
 

--- a/discovery/src/test/scala/org/apache/pekko/discovery/config/ConfigServiceDiscoverySpec.scala
+++ b/discovery/src/test/scala/org/apache/pekko/discovery/config/ConfigServiceDiscoverySpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.discovery.config
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -77,19 +76,19 @@ class ConfigServiceDiscoverySpec
     "load from config" in {
       val result = discovery.lookup("service1", 100.millis).futureValue
       result.serviceName shouldEqual "service1"
-      result.addresses shouldEqual immutable.Seq(
+      result.addresses shouldEqual Seq(
         ResolvedTarget(host = "cat", port = Some(1233), address = None),
         ResolvedTarget(host = "dog", port = None, address = None))
     }
     "return no resolved targets if no endpoints" in {
       val result = discovery.lookup("service2.domain.com", 100.millis).futureValue
       result.serviceName shouldEqual "service2.domain.com"
-      result.addresses shouldEqual immutable.Seq.empty
+      result.addresses shouldEqual Seq.empty
     }
     "return no resolved targets if not in config" in {
       val result = discovery.lookup("dontexist", 100.millis).futureValue
       result.serviceName shouldEqual "dontexist"
-      result.addresses shouldEqual immutable.Seq.empty
+      result.addresses shouldEqual Seq.empty
     }
   }
 }

--- a/discovery/src/test/scala/org/apache/pekko/discovery/config/ConfigServicesParserSpec.scala
+++ b/discovery/src/test/scala/org/apache/pekko/discovery/config/ConfigServicesParserSpec.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.discovery.config
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
 import pekko.discovery.config.ConfigServicesParserSpec._
@@ -55,10 +53,10 @@ class ConfigServicesParserSpec extends AnyWordSpec with Matchers {
 
       result("service1") shouldEqual Resolved(
         "service1",
-        immutable.Seq(
+        Seq(
           ResolvedTarget(host = "cat", port = Some(1233), address = None),
           ResolvedTarget(host = "dog", port = None, address = None)))
-      result("service2") shouldEqual Resolved("service2", immutable.Seq())
+      result("service2") shouldEqual Resolved("service2", Seq())
     }
   }
 }

--- a/docs/src/main/paradox/stream/operators/Sink/seq.md
+++ b/docs/src/main/paradox/stream/operators/Sink/seq.md
@@ -6,7 +6,7 @@ Collect values emitted from the stream into a collection.
 
 ## Signature
 
-@apidoc[Sink.seq](Sink$) { scala="#seq[T]:org.apache.pekko.stream.scaladsl.Sink[T,scala.concurrent.Future[scala.collection.immutable.Seq[T]]]" java="#seq()" }
+@apidoc[Sink.seq](Sink$) { scala="#seq[T]:org.apache.pekko.stream.scaladsl.Sink[T,scala.concurrent.Future[Seq[T]]]" java="#seq()" }
 
 
 ## Description

--- a/docs/src/main/paradox/stream/operators/Sink/takeLast.md
+++ b/docs/src/main/paradox/stream/operators/Sink/takeLast.md
@@ -6,12 +6,12 @@ Collect the last `n` values emitted from the stream into a collection.
 
 ## Signature
 
-@apidoc[Sink.takeLast](Sink$) { scala="#takeLast[T](n:Int):org.apache.pekko.stream.scaladsl.Sink[T,scala.concurrent.Future[scala.collection.immutable.Seq[T]]]" java="#takeLast(int)" }
+@apidoc[Sink.takeLast](Sink$) { scala="#takeLast[T](n:Int):org.apache.pekko.stream.scaladsl.Sink[T,scala.concurrent.Future[Seq[T]]]" java="#takeLast(int)" }
 
 
 ## Description
 
-Materializes into a @scala[`Future`] @java[`CompletionStage`] of @scala[`immutable.Seq[T]`] @java[`List<In>`] containing the last `n` collected elements when the stream completes.
+Materializes into a @scala[`Future`] @java[`CompletionStage`] of @scala[`Seq[T]`] @java[`List<In>`] containing the last `n` collected elements when the stream completes.
 If the stream completes before signaling at least n elements, the @scala[`Future`] @java[`CompletionStage`]  will complete with the number
 of elements taken at that point. 
 If the stream never completes, the @scala[`Future`] @java[`CompletionStage`] will never complete.

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/flatMapPrefix.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/flatMapPrefix.md
@@ -6,8 +6,8 @@ Use the first `n` elements from the stream to determine how to process the rest.
 
 ## Signature
 
-@apidoc[Source.flatMapPrefix](Source) { scala="#flatMapPrefix[Out2,Mat2](n:Int)(f:scala.collection.immutable.Seq[Out]=&gt;org.apache.pekko.stream.scaladsl.Flow[Out,Out2,Mat2]):FlowOps.this.Repr[Out2]" java="#flatMapPrefix(int,org.apache.pekko.japi.function.Function)" }
-@apidoc[Flow.flatMapPrefix](Flow) { scala="#flatMapPrefix[Out2,Mat2](n:Int)(f:scala.collection.immutable.Seq[Out]=&gt;org.apache.pekko.stream.scaladsl.Flow[Out,Out2,Mat2]):FlowOps.this.Repr[Out2]" java="#flatMapPrefix(int,org.apache.pekko.japi.function.Function)" }
+@apidoc[Source.flatMapPrefix](Source) { scala="#flatMapPrefix[Out2,Mat2](n:Int)(f:Seq[Out]=&gt;org.apache.pekko.stream.scaladsl.Flow[Out,Out2,Mat2]):FlowOps.this.Repr[Out2]" java="#flatMapPrefix(int,org.apache.pekko.japi.function.Function)" }
+@apidoc[Flow.flatMapPrefix](Flow) { scala="#flatMapPrefix[Out2,Mat2](n:Int)(f:Seq[Out]=&gt;org.apache.pekko.stream.scaladsl.Flow[Out,Out2,Mat2]):FlowOps.this.Repr[Out2]" java="#flatMapPrefix(int,org.apache.pekko.japi.function.Function)" }
 
 
 ## Description

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/grouped.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/grouped.md
@@ -6,8 +6,8 @@ Accumulate incoming events until the specified number of elements have been accu
 
 ## Signature
 
-@apidoc[Source.grouped](Source) { scala="#grouped(n:Int):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#grouped(int)" }
-@apidoc[Flow.grouped](Flow) { scala="#grouped(n:Int):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#grouped(int)" }
+@apidoc[Source.grouped](Source) { scala="#grouped(n:Int):FlowOps.this.Repr[Seq[Out]]" java="#grouped(int)" }
+@apidoc[Flow.grouped](Flow) { scala="#grouped(n:Int):FlowOps.this.Repr[Seq[Out]]" java="#grouped(int)" }
 
 
 ## Description

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentBy.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentBy.md
@@ -6,8 +6,8 @@ Partitions this stream into chunks by a delimiter function.
 
 ## Signature
 
-@apidoc[Source.groupedAdjacentBy](Source) { scala="#groupedAdjacentBy(f:Out=&gt;T):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedAdjacentBy(org.apache.pekko.japi.function.Function)" }
-@apidoc[Flow.groupedAdjacentBy](Flow) { scala="#groupedAdjacentBy(f:Out=&gt;T):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedAdjacentBy(org.apache.pekko.japi.function.Function)" }
+@apidoc[Source.groupedAdjacentBy](Source) { scala="#groupedAdjacentBy[T](f:Out=&gt;T):FlowOps.this.Repr[Seq[Out]]" java="#groupedAdjacentBy(org.apache.pekko.japi.function.Function)" }
+@apidoc[Flow.groupedAdjacentBy](Flow) { scala="#groupedAdjacentBy[T](f:Out=&gt;T):FlowOps.this.Repr[Seq[Out]]" java="#groupedAdjacentBy(org.apache.pekko.japi.function.Function)" }
 
 
 ## Description

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentByWeighted.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedAdjacentByWeighted.md
@@ -6,8 +6,8 @@ Partitions this stream into chunks by a delimiter function and a weight limit.
 
 ## Signature
 
-@apidoc[Source.groupedAdjacentByWeighted](Source) { scala="#groupedAdjacentByWeighted(f:Out=&gt;T,maxWeight:Long)(costFn:Out=&gt;Long):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedAdjacentBy(org.apache.pekko.japi.function.Function,long,org.apache.pekko.japi.function.Function)" }
-@apidoc[Flow.groupedAdjacentByWeighted](Flow) { scala="#groupedAdjacentByWeighted(f:Out=&gt;T,maxWeight:Long)(costFn:Out=&gt;Long):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedAdjacentBy(org.apache.pekko.japi.function.Function,long,org.apache.pekko.japi.function.Function)" }
+@apidoc[Source.groupedAdjacentByWeighted](Source) { scala="#groupedAdjacentByWeighted[T](f:Out=&gt;T,maxWeight:Long)(costFn:Out=&gt;Long):FlowOps.this.Repr[Seq[Out]]" java="#groupedAdjacentBy(org.apache.pekko.japi.function.Function,long,org.apache.pekko.japi.function.Function)" }
+@apidoc[Flow.groupedAdjacentByWeighted](Flow) { scala="#groupedAdjacentByWeighted[T](f:Out=&gt;T,maxWeight:Long)(costFn:Out=&gt;Long):FlowOps.this.Repr[Seq[Out]]" java="#groupedAdjacentBy(org.apache.pekko.japi.function.Function,long,org.apache.pekko.japi.function.Function)" }
 
 ## Description
 

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeighted.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeighted.md
@@ -6,8 +6,8 @@ Accumulate incoming events until the combined weight of elements is greater than
 
 ## Signature
 
-@apidoc[Source.groupedWeighted](Source) { scala="#groupedWeighted(minWeight:Long)(costFn:Out=&gt;Long):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWeighted(long,org.apache.pekko.japi.function.Function)" }
-@apidoc[Flow.groupedWeighted](Flow) { scala="#groupedWeighted(minWeight:Long)(costFn:Out=&gt;Long):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWeighted(long,org.apache.pekko.japi.function.Function)" }
+@apidoc[Source.groupedWeighted](Source) { scala="#groupedWeighted(minWeight:Long)(costFn:Out=&gt;Long):FlowOps.this.Repr[Seq[Out]]" java="#groupedWeighted(long,org.apache.pekko.japi.function.Function)" }
+@apidoc[Flow.groupedWeighted](Flow) { scala="#groupedWeighted(minWeight:Long)(costFn:Out=&gt;Long):FlowOps.this.Repr[Seq[Out]]" java="#groupedWeighted(long,org.apache.pekko.japi.function.Function)" }
 
 
 ## Description

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeightedWithin.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeightedWithin.md
@@ -6,8 +6,8 @@ Chunk up this stream into groups of elements received within a time window, or l
 
 ## Signature
 
-@apidoc[Source.groupedWeightedWithin](Source) { scala="#groupedWeightedWithin(maxWeight:Long,d:scala.concurrent.duration.FiniteDuration)(costFn:Out=&gt;Long):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWeightedWithin(long,org.apache.pekko.japi.function.Function,java.time.Duration)" }
-@apidoc[Flow.groupedWeightedWithin](Flow) { scala="#groupedWeightedWithin(maxWeight:Long,d:scala.concurrent.duration.FiniteDuration)(costFn:Out=&gt;Long):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWeightedWithin(long,org.apache.pekko.japi.function.Function,java.time.Duration)" }
+@apidoc[Source.groupedWeightedWithin](Source) { scala="#groupedWeightedWithin(maxWeight:Long,d:scala.concurrent.duration.FiniteDuration)(costFn:Out=&gt;Long):FlowOps.this.Repr[Seq[Out]]" java="#groupedWeightedWithin(long,org.apache.pekko.japi.function.Function,java.time.Duration)" }
+@apidoc[Flow.groupedWeightedWithin](Flow) { scala="#groupedWeightedWithin(maxWeight:Long,d:scala.concurrent.duration.FiniteDuration)(costFn:Out=&gt;Long):FlowOps.this.Repr[Seq[Out]]" java="#groupedWeightedWithin(long,org.apache.pekko.japi.function.Function,java.time.Duration)" }
 
 
 ## Description

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWithin.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWithin.md
@@ -6,8 +6,8 @@ Chunk up this stream into groups of elements received within a time window, or l
 
 ## Signature
 
-@apidoc[Source.groupedWithin](Source) { scala="#groupedWithin(n:Int,d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWithin(int,java.time.Duration)" }
-@apidoc[Flow.groupedWithin](Flow) { scala="#groupedWithin(n:Int,d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWithin(int,java.time.Duration)" }
+@apidoc[Source.groupedWithin](Source) { scala="#groupedWithin(n:Int,d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Seq[Out]]" java="#groupedWithin(int,java.time.Duration)" }
+@apidoc[Flow.groupedWithin](Flow) { scala="#groupedWithin(n:Int,d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Seq[Out]]" java="#groupedWithin(int,java.time.Duration)" }
 
 
 ## Description

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/mergeAll.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/mergeAll.md
@@ -6,8 +6,8 @@ Merge multiple sources.
 
 ## Signature
 
-@apidoc[Source.mergeAll](Source) { scala="#mergeAll[U&gt;:Out,M](those:immutable.Seq[org.apache.pekko.stream.Graph[org.apache.pekko.stream.SourceShape[U],M]],eagerComplete:Boolean):FlowOps.this.Repr[U]" java="#mergeAll(java.util.List,boolean)" }
-@apidoc[Flow.mergeAll](Flow) { scala="#mergeAll[U&gt;:Out,M](those:immutable.Seq[org.apache.pekko.stream.Graph[org.apache.pekko.stream.SourceShape[U],M]],eagerComplete:Boolean):FlowOps.this.Repr[U]" java="#mergeAll(java.util.List,boolean)" }
+@apidoc[Source.mergeAll](Source) { scala="#mergeAll[U&gt;:Out](those:Seq[org.apache.pekko.stream.Graph[org.apache.pekko.stream.SourceShape[U],_]],eagerComplete:Boolean):FlowOps.this.Repr[U]" java="#mergeAll(java.util.List,boolean)" }
+@apidoc[Flow.mergeAll](Flow) { scala="#mergeAll[U&gt;:Out](those:Seq[org.apache.pekko.stream.Graph[org.apache.pekko.stream.SourceShape[U],_]],eagerComplete:Boolean):FlowOps.this.Repr[U]" java="#mergeAll(java.util.List,boolean)" }
 
 ## Description
 

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/mergeLatest.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/mergeLatest.md
@@ -6,7 +6,7 @@ Merge multiple sources.
 
 ## Signature
 
-@apidoc[Flow.mergeLatest](Flow) { scala="#mergeLatest[U%3E:Out,M](that:org.apache.pekko.stream.Graph[org.apache.pekko.stream.SourceShape[U],M],eagerComplete:Boolean):FlowOps.this.Repr[scala.collection.immutable.Seq[U]]" java="#mergeLatest(org.apache.pekko.stream.Graph,boolean)" } 
+@apidoc[Flow.mergeLatest](Flow) { scala="#mergeLatest[U%3E:Out,M](that:org.apache.pekko.stream.Graph[org.apache.pekko.stream.SourceShape[U],M],eagerComplete:Boolean):FlowOps.this.Repr[Seq[U]]" java="#mergeLatest(org.apache.pekko.stream.Graph,boolean)" } 
 
 ## Description
 

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/prefixAndTail.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/prefixAndTail.md
@@ -6,8 +6,8 @@ Take up to *n* elements from the stream (less than *n* only if the upstream comp
 
 ## Signature
 
-@apidoc[Source.prefixAndTail](Source) { scala="#prefixAndTail[U&gt;:Out](n:Int):FlowOps.this.Repr[(scala.collection.immutable.Seq[Out],org.apache.pekko.stream.scaladsl.Source[U,org.apache.pekko.NotUsed])]" java="#prefixAndTail(int)" }
-@apidoc[Flow.prefixAndTail](Flow) { scala="#prefixAndTail[U&gt;:Out](n:Int):FlowOps.this.Repr[(scala.collection.immutable.Seq[Out],org.apache.pekko.stream.scaladsl.Source[U,org.apache.pekko.NotUsed])]" java="#prefixAndTail(int)" }
+@apidoc[Source.prefixAndTail](Source) { scala="#prefixAndTail[U&gt;:Out](n:Int):FlowOps.this.Repr[(Seq[Out],org.apache.pekko.stream.scaladsl.Source[U,org.apache.pekko.NotUsed])]" java="#prefixAndTail(int)" }
+@apidoc[Flow.prefixAndTail](Flow) { scala="#prefixAndTail[U&gt;:Out](n:Int):FlowOps.this.Repr[(Seq[Out],org.apache.pekko.stream.scaladsl.Source[U,org.apache.pekko.NotUsed])]" java="#prefixAndTail(int)" }
 
 
 ## Description

--- a/docs/src/main/paradox/stream/operators/Source-or-Flow/sliding.md
+++ b/docs/src/main/paradox/stream/operators/Source-or-Flow/sliding.md
@@ -6,7 +6,7 @@ Provide a sliding window over the incoming stream and pass the windows as groups
 
 ## Signature
 
-@apidoc[Flow.sliding](Flow) { scala="#sliding(n:Int,step:Int):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#sliding(int,int)" } 
+@apidoc[Flow.sliding](Flow) { scala="#sliding(n:Int,step:Int):FlowOps.this.Repr[Seq[Out]]" java="#sliding(int,int)" } 
 
 ## Description
 

--- a/docs/src/main/paradox/stream/operators/Source/from.md
+++ b/docs/src/main/paradox/stream/operators/Source/from.md
@@ -1,6 +1,6 @@
 # @scala[Source.apply]@java[Source.from]
 
-Stream the values of an @scala[`immutable.Seq`]@java[`Iterable`].
+Stream the values of an @scala[`Seq`]@java[`Iterable`].
 
 @ref[Source operators](../index.md#source-operators)
 
@@ -20,7 +20,7 @@ Stream the values of an @scala[`immutable.Seq`]@java[`Iterable`].
 
 ## Description
 
-Stream the values of an @scala[`immutable.Seq`]@java[`Iterable`]. @java[Make sure the `Iterable` is immutable or at least not modified after being used
+Stream the values of an @scala[`Seq`]@java[`Iterable`]. @java[Make sure the `Iterable` is immutable or at least not modified after being used
 as a source. Otherwise the stream may fail with `ConcurrentModificationException` or other more subtle errors may occur.]
 
 ## Examples

--- a/docs/src/main/paradox/stream/operators/Source/mergePrioritizedN.md
+++ b/docs/src/main/paradox/stream/operators/Source/mergePrioritizedN.md
@@ -6,7 +6,7 @@ Merge multiple sources with priorities.
 
 ## Signature
 
-@apidoc[Source.mergePrioritizedN](Source$) { scala="#mergePrioritizedN[T](sourcesAndPriorities:Seq[(org.apache.pekko.stream.scaladsl.Source[T,_],Int)],eagerComplete:Boolean):org.apache.pekko.stream.scaladsl.Source[T,org.apache.pekko.NotUsed]" java="#mergePrioritized[T](sourcesAndPriorities:java.util.List[Pair[Source[T,_%3C:Any],java.lang.Integer]],eagerComplete:Boolean):javadsl.Source[T,NotUsed]" }
+@apidoc[Source.mergePrioritizedN](Source$) { scala="#mergePrioritizedN[T](sourcesAndPriorities:Seq[(org.apache.pekko.stream.scaladsl.Source[T,_],Int)],eagerComplete:Boolean):org.apache.pekko.stream.scaladsl.Source[T,org.apache.pekko.NotUsed]" java="#mergePrioritizedN(java.util.List,boolean)" }
 
 ## Description
 

--- a/docs/src/main/paradox/stream/operators/Source/mergePrioritizedN.md
+++ b/docs/src/main/paradox/stream/operators/Source/mergePrioritizedN.md
@@ -6,7 +6,7 @@ Merge multiple sources with priorities.
 
 ## Signature
 
-@apidoc[Source.mergePrioritizedN](Source) { scala="#mergePrioritizedN[T](sourcesAndPriorities:immutable.Seq[(Source[T,_],Int)],eagerComplete:Boolean):Source[T,NotUsed]" java="#mergePrioritized[T](sourcesAndPriorities:java.util.List[Pair[Source[T,_%3C:Any],java.lang.Integer]],eagerComplete:Boolean):javadsl.Source[T,NotUsed]" }
+@apidoc[Source.mergePrioritizedN](Source$) { scala="#mergePrioritizedN[T](sourcesAndPriorities:Seq[(org.apache.pekko.stream.scaladsl.Source[T,_],Int)],eagerComplete:Boolean):org.apache.pekko.stream.scaladsl.Source[T,org.apache.pekko.NotUsed]" java="#mergePrioritized[T](sourcesAndPriorities:java.util.List[Pair[Source[T,_%3C:Any],java.lang.Integer]],eagerComplete:Boolean):javadsl.Source[T,NotUsed]" }
 
 ## Description
 

--- a/docs/src/main/paradox/stream/operators/Source/zipN.md
+++ b/docs/src/main/paradox/stream/operators/Source/zipN.md
@@ -6,7 +6,7 @@ Combine the elements of multiple sources into a source of sequences of value.
 
 ## Signature
 
-@apidoc[Source.zipN](Source$) { scala="#zipN[T](sources:scala.collection.immutable.Seq[org.apache.pekko.stream.scaladsl.Source[T,_]]):org.apache.pekko.stream.scaladsl.Source[scala.collection.immutable.Seq[T],org.apache.pekko.NotUsed]" java="#zipN(java.util.List)" } 
+@apidoc[Source.zipN](Source$) { scala="#zipN[T](sources:Seq[org.apache.pekko.stream.scaladsl.Source[T,_]]):org.apache.pekko.stream.scaladsl.Source[Seq[T],org.apache.pekko.NotUsed]" java="#zipN(java.util.List)" } 
 
 ## Description
 

--- a/docs/src/main/paradox/stream/operators/Source/zipWithN.md
+++ b/docs/src/main/paradox/stream/operators/Source/zipWithN.md
@@ -6,7 +6,7 @@ Combine the elements of multiple streams into a stream of sequences using a comb
 
 ## Signature
 
-@apidoc[Source.zipWithN](Source$) { scala="#zipWithN[T,O](zipper:scala.collection.immutable.Seq[T]=&gt;O)(sources:scala.collection.immutable.Seq[org.apache.pekko.stream.scaladsl.Source[T,_]]):org.apache.pekko.stream.scaladsl.Source[O,org.apache.pekko.NotUsed]" java="#zipWithN(org.apache.pekko.japi.function.Function,java.util.List)" }
+@apidoc[Source.zipWithN](Source$) { scala="#zipWithN[T,O](zipper:Seq[T]=&gt;O)(sources:Seq[org.apache.pekko.stream.scaladsl.Source[T,_]]):org.apache.pekko.stream.scaladsl.Source[O,org.apache.pekko.NotUsed]" java="#zipWithN(org.apache.pekko.japi.function.Function,java.util.List)" }
 
 ## Description
 

--- a/docs/src/main/paradox/stream/operators/index.md
+++ b/docs/src/main/paradox/stream/operators/index.md
@@ -15,7 +15,7 @@ These built-in sources are available from @scala[`org.apache.pekko.stream.scalad
 |Source|<a name="cycle"></a>@ref[cycle](Source/cycle.md)|Stream iterator in cycled manner.|
 |Source|<a name="empty"></a>@ref[empty](Source/empty.md)|Complete right away without ever emitting any elements.|
 |Source|<a name="failed"></a>@ref[failed](Source/failed.md)|Fail directly with a user specified exception.|
-|Source|<a name="from"></a>@ref[@scala[apply]@java[from]](Source/from.md)|Stream the values of an @scala[`immutable.Seq`]@java[`Iterable`].|
+|Source|<a name="from"></a>@ref[@scala[apply]@java[from]](Source/from.md)|Stream the values of an @scala[`Seq`]@java[`Iterable`].|
 |Source|<a name="fromarray"></a>@ref[fromArray](Source/fromArray.md)|Stream the values of an `array`.|
 |Source|<a name="fromiterator"></a>@ref[fromIterator](Source/fromIterator.md)|Stream the values from an `Iterator`, requesting the next value when there is demand.|
 |Source|<a name="fromjavastream"></a>@ref[fromJavaStream](Source/fromJavaStream.md)|Stream the values from a Java 8 `Stream`, requesting the next value when there is demand.|

--- a/docs/src/main/paradox/stream/stream-cookbook.md
+++ b/docs/src/main/paradox/stream/stream-cookbook.md
@@ -77,7 +77,7 @@ instead; e.g. `Source.unfold` or `Source.unfoldResource`.
 all the nested elements inside the sequences separately.
 
 The `mapConcat` operation can be used to implement a one-to-many transformation of elements using a mapper function
-in the form of @scala[`In => immutable.Seq[Out]`] @java[`In -> List<Out>`]. In this case we want to map a @scala[`Seq`] @java[`List`] of elements to the elements in the
+in the form of @scala[`In => Seq[Out]`] @java[`In -> List<Out>`]. In this case we want to map a @scala[`Seq`] @java[`List`] of elements to the elements in the
 collection itself, so we can call @scala[`mapConcat(identity)`] @java[`mapConcat(l -> l)`].
 
 Scala

--- a/docs/src/test/scala/docs/actor/FSMDocSpec.scala
+++ b/docs/src/test/scala/docs/actor/FSMDocSpec.scala
@@ -19,7 +19,6 @@ import pekko.util.ByteString
 
 //#test-code
 import pekko.actor.Props
-import scala.collection.immutable
 
 object FSMDocSpec {
   // messages and data types
@@ -32,7 +31,7 @@ object FSMDocSpec {
   case object Flush
 
   // sent events
-  final case class Batch(obj: immutable.Seq[Any])
+  final case class Batch(obj: Seq[Any])
   // #simple-events
   // #simple-state
   // states
@@ -42,7 +41,7 @@ object FSMDocSpec {
 
   sealed trait Data
   case object Uninitialized extends Data
-  final case class Todo(target: ActorRef, queue: immutable.Seq[Any]) extends Data
+  final case class Todo(target: ActorRef, queue: Seq[Any]) extends Data
   // #simple-state
   // #test-code
 }
@@ -223,12 +222,12 @@ class FSMDocSpec extends MyFavoriteTestFrameWorkPlusPekkoTestKit {
       buncher ! SetTarget(testActor)
       buncher ! Queue(42)
       buncher ! Queue(43)
-      expectMsg(Batch(immutable.Seq(42, 43)))
+      expectMsg(Batch(Seq(42, 43)))
       buncher ! Queue(44)
       buncher ! Flush
       buncher ! Queue(45)
-      expectMsg(Batch(immutable.Seq(44)))
-      expectMsg(Batch(immutable.Seq(45)))
+      expectMsg(Batch(Seq(44)))
+      expectMsg(Batch(Seq(45)))
     }
 
     "not batch if uninitialized" in {

--- a/docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
@@ -13,7 +13,6 @@
 
 package docs.persistence
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Try
@@ -164,7 +163,7 @@ trait SharedLeveldbPluginDocSpec {
 
 class MyJournal extends AsyncWriteJournal {
   // #sync-journal-plugin-api
-  def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] =
+  def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] =
     Future.fromTry(Try {
       // blocking call here
       ???

--- a/docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
+++ b/docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
@@ -22,7 +22,6 @@ import pekko.stream.javadsl
 import pekko.testkit.PekkoSpec
 import pekko.util.Timeout
 import org.reactivestreams.Subscriber
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
@@ -160,7 +159,7 @@ object PersistenceQueryDocSpec {
     def convertToReadSideTypes(in: Any): Any = ???
 
     object ReactiveStreamsCompatibleDBDriver {
-      def batchWriter: Subscriber[immutable.Seq[Any]] = ???
+      def batchWriter: Subscriber[Seq[Any]] = ???
     }
 
     // #projection-into-different-store-rs
@@ -168,7 +167,7 @@ object PersistenceQueryDocSpec {
 
     val readJournal =
       PersistenceQuery(system).readJournalFor[MyScaladslReadJournal](JournalId)
-    val dbBatchWriter: Subscriber[immutable.Seq[Any]] =
+    val dbBatchWriter: Subscriber[Seq[Any]] =
       ReactiveStreamsCompatibleDBDriver.batchWriter
 
     // Using an example (Reactive Streams) Database driver

--- a/docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
@@ -19,7 +19,6 @@ import pekko.stream._
 import pekko.stream.scaladsl._
 import pekko.testkit.PekkoSpec
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContext
@@ -111,9 +110,9 @@ class GraphDSLDocSpec extends PekkoSpec {
 
       // It is important to provide the list of all input and output
       // ports with a stable order. Duplicates are not allowed.
-      override val inlets: immutable.Seq[Inlet[?]] =
+      override val inlets: Seq[Inlet[?]] =
         jobsIn :: priorityJobsIn :: Nil
-      override val outlets: immutable.Seq[Outlet[?]] =
+      override val outlets: Seq[Outlet[?]] =
         resultsOut :: Nil
 
       // A Shape must be able to create a copy of itself. Basically

--- a/docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
@@ -522,7 +522,7 @@ class GraphStageDocSpec extends PekkoSpec {
               override def onUpstreamFinish(): Unit = {
                 if (buffer.nonEmpty) {
                   // emit the rest if possible
-                  emitMultiple(out, buffer.toIterator)
+                  emitMultiple(out, buffer.iterator)
                 }
                 completeStage()
               }

--- a/docs/src/test/scala/docs/stream/KillSwitchDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/KillSwitchDocSpec.scala
@@ -31,7 +31,7 @@ class KillSwitchDocSpec extends PekkoSpec with CompileOnlySpec {
 
       // format: OFF
       //#unique-shutdown
-      val countingSrc = Source(Stream.from(1)).delay(1.second, DelayOverflowStrategy.backpressure)
+      val countingSrc = Source(LazyList.from(1)).delay(1.second, DelayOverflowStrategy.backpressure)
       val lastSnk = Sink.last[Int]
 
       val (killSwitch, last) = countingSrc
@@ -52,7 +52,7 @@ class KillSwitchDocSpec extends PekkoSpec with CompileOnlySpec {
 
       // format: OFF
       //#unique-abort
-      val countingSrc = Source(Stream.from(1)).delay(1.second, DelayOverflowStrategy.backpressure)
+      val countingSrc = Source(LazyList.from(1)).delay(1.second, DelayOverflowStrategy.backpressure)
       val lastSnk = Sink.last[Int]
 
       val (killSwitch, last) = countingSrc
@@ -73,7 +73,7 @@ class KillSwitchDocSpec extends PekkoSpec with CompileOnlySpec {
     "control graph completion with shutdown" in compileOnlySpec {
       // format: OFF
       //#shared-shutdown
-      val countingSrc = Source(Stream.from(1)).delay(1.second, DelayOverflowStrategy.backpressure)
+      val countingSrc = Source(LazyList.from(1)).delay(1.second, DelayOverflowStrategy.backpressure)
       val lastSnk = Sink.last[Int]
       val sharedKillSwitch = KillSwitches.shared("my-kill-switch")
 
@@ -100,7 +100,7 @@ class KillSwitchDocSpec extends PekkoSpec with CompileOnlySpec {
 
       // format: OFF
       //#shared-abort
-      val countingSrc = Source(Stream.from(1)).delay(1.second)
+      val countingSrc = Source(LazyList.from(1)).delay(1.second)
       val lastSnk = Sink.last[Int]
       val sharedKillSwitch = KillSwitches.shared("my-kill-switch")
 

--- a/docs/src/test/scala/docs/stream/RateTransformationDocSpec.scala
+++ b/docs/src/test/scala/docs/stream/RateTransformationDocSpec.scala
@@ -20,7 +20,6 @@ import pekko.stream.testkit.scaladsl._
 import scala.util.Random
 import scala.math._
 import scala.concurrent.duration._
-import scala.collection.immutable
 import pekko.testkit.{ PekkoSpec, TestLatch }
 
 import scala.concurrent.Await
@@ -29,7 +28,7 @@ class RateTransformationDocSpec extends PekkoSpec {
 
   "conflate should summarize" in {
     // #conflate-summarize
-    val statsFlow = Flow[Double].conflateWithSeed(immutable.Seq(_))(_ :+ _).map { s =>
+    val statsFlow = Flow[Double].conflateWithSeed(Seq(_))(_ :+ _).map { s =>
       val μ = s.sum / s.size
       val se = s.map(x => pow(x - μ, 2))
       val σ = sqrt(se.sum / se.size)
@@ -51,7 +50,7 @@ class RateTransformationDocSpec extends PekkoSpec {
     // #conflate-sample
     val p = 0.01
     val sampleFlow = Flow[Double]
-      .conflateWithSeed(immutable.Seq(_)) {
+      .conflateWithSeed(Seq(_)) {
         case (acc, elem) if Random.nextDouble() < p => acc :+ elem
         case (acc, _)                               => acc
       }

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeCollectingMetrics.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeCollectingMetrics.scala
@@ -24,7 +24,7 @@ class RecipeCollectingMetrics extends RecipeSpec {
       //      val tickPub = TestPublisher.manualProbe[Tick]()
       //      val reportTicks = Source.fromPublisher(tickPub)
       //      val loadUpdates = Source.fromPublisher(loadPub)
-      //      val futureSink = Sink.head[immutable.Seq[String]]
+      //      val futureSink = Sink.head[Seq[String]]
       //      val sink = Flow[String].grouped(10).to(futureSink)
       //
       //      //#periodic-metrics-collection

--- a/docs/src/test/scala/docs/stream/cookbook/RecipeMultiGroupBy.scala
+++ b/docs/src/test/scala/docs/stream/cookbook/RecipeMultiGroupBy.scala
@@ -17,7 +17,6 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.scaladsl.{ Sink, Source }
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -36,7 +35,7 @@ class RecipeMultiGroupBy extends RecipeSpec {
       }
 
       // #multi-groupby
-      val topicMapper: (Message) => immutable.Seq[Topic] = extractTopics
+      val topicMapper: (Message) => Seq[Topic] = extractTopics
 
       val messageAndTopic: Source[(Message, Topic), NotUsed] = elems.mapConcat { (msg: Message) =>
         val topicsForMessage = topicMapper(msg)

--- a/docs/src/test/scala/docs/stream/operators/WithContextSpec.scala
+++ b/docs/src/test/scala/docs/stream/operators/WithContextSpec.scala
@@ -24,10 +24,9 @@ class WithContextSpec extends PekkoSpec {
     import pekko.NotUsed
     import pekko.stream.scaladsl.Source
     import pekko.stream.scaladsl.SourceWithContext
-    import scala.collection.immutable
 
     // values with their contexts as tuples
-    val values: immutable.Seq[(String, Int)] = immutable.Seq("eins" -> 1, "zwei" -> 2, "drei" -> 3)
+    val values: Seq[(String, Int)] = Seq("eins" -> 1, "zwei" -> 2, "drei" -> 3)
 
     // a regular source with the tuples as elements
     val source: Source[(String, Int), NotUsed] = Source(values)
@@ -45,7 +44,7 @@ class WithContextSpec extends PekkoSpec {
     // running the source and asserting the outcome
     import org.apache.pekko.stream.scaladsl.Sink
     val result = mapped.runWith(Sink.seq)
-    result.futureValue should contain theSameElementsInOrderAs immutable.Seq("snie" -> 1, "iewz" -> 2, "ierd" -> 3)
+    result.futureValue should contain theSameElementsInOrderAs Seq("snie" -> 1, "iewz" -> 2, "ierd" -> 3)
     // #asSourceWithContext
   }
 
@@ -81,13 +80,12 @@ class WithContextSpec extends PekkoSpec {
     // running the flow with some sample data and asserting the outcome
     import pekko.stream.scaladsl.Source
     import pekko.stream.scaladsl.Sink
-    import scala.collection.immutable
 
-    val values: immutable.Seq[(String, Int)] = immutable.Seq("eins" -> 1, "zwei" -> 2, "drei" -> 3)
+    val values: Seq[(String, Int)] = Seq("eins" -> 1, "zwei" -> 2, "drei" -> 3)
     val source = Source(values).asSourceWithContext(_._2).map(_._1)
 
     val result = source.via(mapped).runWith(Sink.seq)
-    result.futureValue should contain theSameElementsInOrderAs immutable.Seq("snie" -> 1, "iewz" -> 2, "ierd" -> 3)
+    result.futureValue should contain theSameElementsInOrderAs Seq("snie" -> 1, "iewz" -> 2, "ierd" -> 3)
     // #asFlowWithContext
   }
 
@@ -98,10 +96,9 @@ class WithContextSpec extends PekkoSpec {
     import pekko.stream.scaladsl.Sink
     import pekko.stream.scaladsl.Source
     import pekko.stream.scaladsl.SourceWithContext
-    import scala.collection.immutable
 
-    val values: immutable.Seq[(String, Int)] =
-      immutable.Seq("eins" -> 1, "eins" -> 2, "zwei" -> 3, "drei" -> 4)
+    val values: Seq[(String, Int)] =
+      Seq("eins" -> 1, "eins" -> 2, "zwei" -> 3, "drei" -> 4)
 
     val filtered: SourceWithContext[String, Int, NotUsed] =
       Source(values)
@@ -112,7 +109,7 @@ class WithContextSpec extends PekkoSpec {
         .take(2)
 
     val result = filtered.runWith(Sink.seq)
-    result.futureValue should contain theSameElementsInOrderAs immutable.Seq("EINS" -> 1, "DREI" -> 4)
+    result.futureValue should contain theSameElementsInOrderAs Seq("EINS" -> 1, "DREI" -> 4)
     // #withContextOperators
   }
 }

--- a/docs/src/test/scala/docs/stream/operators/converters/StreamConvertersToJava.scala
+++ b/docs/src/test/scala/docs/stream/operators/converters/StreamConvertersToJava.scala
@@ -27,7 +27,6 @@ import pekko.stream.scaladsl.StreamConverters
 import pekko.testkit.PekkoSpec
 import org.scalatest.concurrent.Futures
 
-import scala.collection.immutable
 import scala.concurrent.Future
 
 class StreamConvertersToJava extends PekkoSpec with Futures {
@@ -47,9 +46,9 @@ class StreamConvertersToJava extends PekkoSpec with Futures {
     // #fromJavaStream
     def factory(): IntStream = IntStream.rangeClosed(0, 9)
     val source: Source[Int, NotUsed] = StreamConverters.fromJavaStream(() => factory()).map(_.intValue())
-    val sink: Sink[Int, Future[immutable.Seq[Int]]] = Sink.seq[Int]
+    val sink: Sink[Int, Future[Seq[Int]]] = Sink.seq[Int]
 
-    val futureInts: Future[immutable.Seq[Int]] = source.toMat(sink)(Keep.right).run()
+    val futureInts: Future[Seq[Int]] = source.toMat(sink)(Keep.right).run()
 
     // #fromJavaStream
     whenReady(futureInts) { ints =>

--- a/docs/src/test/scala/docs/testkit/TestKitUsageSpec.scala
+++ b/docs/src/test/scala/docs/testkit/TestKitUsageSpec.scala
@@ -29,7 +29,6 @@ import pekko.actor.ActorSystem
 import pekko.actor.Props
 import pekko.testkit.{ DefaultTimeout, ImplicitSender, TestActors, TestKit }
 import scala.concurrent.duration._
-import scala.collection.immutable
 
 /**
  * a Test to show some TestKit examples
@@ -48,8 +47,8 @@ class TestKitUsageSpec
   val filterRef = system.actorOf(Props(classOf[FilteringActor], testActor))
   val randomHead = Random.nextInt(6)
   val randomTail = Random.nextInt(10)
-  val headList = immutable.Seq().padTo(randomHead, "0")
-  val tailList = immutable.Seq().padTo(randomTail, "1")
+  val headList = Seq().padTo(randomHead, "0")
+  val tailList = Seq().padTo(randomTail, "1")
   val seqRef =
     system.actorOf(Props(classOf[SequencingActor], testActor, headList, tailList))
 
@@ -146,7 +145,7 @@ object TestKitUsageSpec {
    * like to test that the interesting value is received and that you can't
    * be bothered with the rest
    */
-  class SequencingActor(next: ActorRef, head: immutable.Seq[String], tail: immutable.Seq[String]) extends Actor {
+  class SequencingActor(next: ActorRef, head: Seq[String], tail: Seq[String]) extends Actor {
     def receive = {
       case msg => {
         head.foreach { next ! _ }

--- a/docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
+++ b/docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
@@ -25,7 +25,6 @@ import pekko.testkit.TestProbe
 
 //#imports-test-probe
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
@@ -137,14 +136,14 @@ class TestKitDocSpec extends PekkoSpec with DefaultTimeout with ImplicitSender {
     // #test-expect
     val hello: String = expectMsg("hello")
     val any: String = expectMsgAnyOf("hello", "world")
-    val all: immutable.Seq[String] = expectMsgAllOf("hello", "world")
+    val all: Seq[String] = expectMsgAllOf("hello", "world")
     val i: Int = expectMsgType[Int]
     expectNoMessage(200.millis)
     // #test-expect
     testActor.tell("receveN-1", ActorRef.noSender)
     testActor.tell("receveN-2", ActorRef.noSender)
     // #test-expect
-    val two: immutable.Seq[AnyRef] = receiveN(2)
+    val two: Seq[AnyRef] = receiveN(2)
     // #test-expect
     assert("hello" == hello)
     assert("hello" == any)

--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testconductor/Player.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.reflect.classTag
@@ -105,13 +104,13 @@ trait Player { this: TestConductorExt =>
    * Enter the named barriers, one after the other, in the order given. Will
    * throw an exception in case of timeouts or other errors.
    */
-  def enter(name: String*): Unit = enter(Settings.BarrierTimeout, name.to(immutable.Seq))
+  def enter(name: String*): Unit = enter(Settings.BarrierTimeout, name.to(Seq))
 
   /**
    * Enter the named barriers, one after the other, in the order given. Will
    * throw an exception in case of timeouts or other errors.
    */
-  def enter(timeout: Timeout, name: immutable.Seq[String]): Unit = {
+  def enter(timeout: Timeout, name: Seq[String]): Unit = {
     system.log.debug("entering barriers " + name.mkString("(", ", ", ")"))
     val stop = Deadline.now + timeout.duration
     name.foreach { b =>

--- a/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testkit/MultiNodeSpec.scala
+++ b/multi-node-testkit/src/main/scala/org/apache/pekko/remote/testkit/MultiNodeSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.remote.testkit
 
 import java.net.{ InetAddress, InetSocketAddress }
 
-import scala.collection.immutable
 import scala.concurrent.{ Await, Awaitable }
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
@@ -46,7 +45,7 @@ abstract class MultiNodeConfig {
   private var _commonConf: Option[Config] = None
   private var _nodeConf = Map[RoleName, Config]()
   private var _roles = Vector[RoleName]()
-  private var _deployments = Map[RoleName, immutable.Seq[String]]()
+  private var _deployments = Map[RoleName, Seq[String]]()
   private var _allDeploy = Vector[String]()
   private var _testTransport = false
 
@@ -131,10 +130,10 @@ abstract class MultiNodeConfig {
     configs.reduceLeft(_.withFallback(_))
   }
 
-  private[testkit] def deployments(node: RoleName): immutable.Seq[String] =
+  private[testkit] def deployments(node: RoleName): Seq[String] =
     (_deployments.get(node).getOrElse(Nil)) ++ _allDeploy
 
-  private[testkit] def roles: immutable.Seq[RoleName] = _roles
+  private[testkit] def roles: Seq[RoleName] = _roles
 
 }
 
@@ -313,7 +312,7 @@ object MultiNodeSpec {
 abstract class MultiNodeSpec(
     val myself: RoleName,
     _system: ActorSystem,
-    _roles: immutable.Seq[RoleName],
+    _roles: Seq[RoleName],
     deployments: RoleName => Seq[String])
     extends TestKit(_system)
     with MultiNodeSpecCallbacks {
@@ -397,7 +396,7 @@ abstract class MultiNodeSpec(
   /**
    * All registered roles
    */
-  def roles: immutable.Seq[RoleName] = _roles
+  def roles: Seq[RoleName] = _roles
 
   /**
    * TO BE DEFINED BY USER: Defines the number of participants required for starting the test. This
@@ -443,7 +442,7 @@ abstract class MultiNodeSpec(
   def enterBarrier(name: String*): Unit =
     testConductor.enter(
       Timeout.durationToTimeout(remainingOr(testConductor.Settings.BarrierTimeout.duration)),
-      name.to(immutable.Seq))
+      name.to(Seq))
 
   /**
    * Enter the named barriers in the order given. Use the remaining duration from
@@ -453,7 +452,7 @@ abstract class MultiNodeSpec(
    * which uses the configuration entry "pekko.test.timefactor".
    */
   def enterBarrier(max: FiniteDuration, name: String*): Unit =
-    testConductor.enter(Timeout.durationToTimeout(remainingOr(max.dilated)), name.to(immutable.Seq))
+    testConductor.enter(Timeout.durationToTimeout(remainingOr(max.dilated)), name.to(Seq))
 
   /**
    * Query the controller for the transport address of the given node (by role name) and

--- a/osgi/src/test/scala/org/apache/pekko/osgi/ActorSystemActivatorTest.scala
+++ b/osgi/src/test/scala/org/apache/pekko/osgi/ActorSystemActivatorTest.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.osgi
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -45,7 +44,7 @@ class PingPongActorSystemActivatorTest extends AnyWordSpec with Matchers with Po
 
   import ActorSystemActivatorTest._
 
-  val testBundles: immutable.Seq[BundleDescriptor] = buildTestBundles(
+  val testBundles: Seq[BundleDescriptor] = buildTestBundles(
     List(bundle(TEST_BUNDLE_NAME).withActivator(classOf[PingPongActorSystemActivator])))
 
   "PingPongActorSystemActivator" must {
@@ -78,7 +77,7 @@ class RuntimeNameActorSystemActivatorTest extends AnyWordSpec with Matchers with
 
   import ActorSystemActivatorTest._
 
-  val testBundles: immutable.Seq[BundleDescriptor] =
+  val testBundles: Seq[BundleDescriptor] =
     buildTestBundles(List(bundle(TEST_BUNDLE_NAME).withActivator(classOf[RuntimeNameActorSystemActivator])))
 
   "RuntimeNameActorSystemActivator" must {

--- a/osgi/src/test/scala/org/apache/pekko/osgi/PojoSRTestSupport.scala
+++ b/osgi/src/test/scala/org/apache/pekko/osgi/PojoSRTestSupport.scala
@@ -19,7 +19,6 @@ import java.util.{ Date, HashMap, ServiceLoader, UUID }
 import java.util.jar.JarInputStream
 
 import scala.annotation.{ nowarn, tailrec }
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
@@ -42,7 +41,7 @@ trait PojoSRTestSupport extends Suite with BeforeAndAfterAll {
    * All bundles being found on the test classpath are automatically installed and started in the PojoSR runtime.
    * Implement this to define the extra bundles that should be available for testing.
    */
-  def testBundles: immutable.Seq[BundleDescriptor]
+  def testBundles: Seq[BundleDescriptor]
 
   val bufferedLoadingErrors = new ByteArrayOutputStream()
 
@@ -106,7 +105,7 @@ trait PojoSRTestSupport extends Suite with BeforeAndAfterAll {
     poll(wait, Deadline.now + MaxWaitDuration)
   }
 
-  protected def buildTestBundles(builders: immutable.Seq[BundleDescriptorBuilder]): immutable.Seq[BundleDescriptor] =
+  protected def buildTestBundles(builders: Seq[BundleDescriptorBuilder]): Seq[BundleDescriptor] =
     builders.map(_.build)
 
   def filterErrors()(block: => Unit): Unit =

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/CurrentEventsBySliceQuery.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/CurrentEventsBySliceQuery.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.query.typed.scaladsl
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.ApiMayChange
@@ -45,5 +43,5 @@ trait CurrentEventsBySliceQuery extends ReadJournal {
 
   def sliceForPersistenceId(persistenceId: String): Int
 
-  def sliceRanges(numberOfRanges: Int): immutable.Seq[Range]
+  def sliceRanges(numberOfRanges: Int): Seq[Range]
 }

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/CurrentEventsBySliceStartingFromSnapshotsQuery.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/CurrentEventsBySliceStartingFromSnapshotsQuery.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.query.typed.scaladsl
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.ApiMayChange
@@ -49,5 +47,5 @@ trait CurrentEventsBySliceStartingFromSnapshotsQuery extends ReadJournal {
 
   def sliceForPersistenceId(persistenceId: String): Int
 
-  def sliceRanges(numberOfRanges: Int): immutable.Seq[Range]
+  def sliceRanges(numberOfRanges: Int): Seq[Range]
 }

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/DurableStateStoreBySliceQuery.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/DurableStateStoreBySliceQuery.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.query.typed.scaladsl
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.ApiMayChange
@@ -78,6 +76,6 @@ trait DurableStateStoreBySliceQuery[A] extends DurableStateStore[A] {
 
   def sliceForPersistenceId(persistenceId: String): Int
 
-  def sliceRanges(numberOfRanges: Int): immutable.Seq[Range]
+  def sliceRanges(numberOfRanges: Int): Seq[Range]
 
 }

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/EventsBySliceFirehoseQuery.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/EventsBySliceFirehoseQuery.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.persistence.query.typed.scaladsl
 import java.time.Instant
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.Future
 
 import com.typesafe.config.Config
@@ -89,7 +88,7 @@ final class EventsBySliceFirehoseQuery(system: ExtendedActorSystem, config: Conf
   override def sliceForPersistenceId(persistenceId: String): Int =
     persistenceExt.sliceForPersistenceId(persistenceId)
 
-  override def sliceRanges(numberOfRanges: Int): immutable.Seq[Range] =
+  override def sliceRanges(numberOfRanges: Int): Seq[Range] =
     persistenceExt.sliceRanges(numberOfRanges)
 
   override def timestampOf(persistenceId: String, sequenceNr: Long): Future[Option[Instant]] = {

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/EventsBySliceQuery.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/EventsBySliceQuery.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.query.typed.scaladsl
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.ApiMayChange
@@ -70,6 +68,6 @@ trait EventsBySliceQuery extends ReadJournal {
 
   def sliceForPersistenceId(persistenceId: String): Int
 
-  def sliceRanges(numberOfRanges: Int): immutable.Seq[Range]
+  def sliceRanges(numberOfRanges: Int): Seq[Range]
 
 }

--- a/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/EventsBySliceStartingFromSnapshotsQuery.scala
+++ b/persistence-query/src/main/scala/org/apache/pekko/persistence/query/typed/scaladsl/EventsBySliceStartingFromSnapshotsQuery.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.query.typed.scaladsl
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.ApiMayChange
@@ -50,6 +48,6 @@ trait EventsBySliceStartingFromSnapshotsQuery extends ReadJournal {
 
   def sliceForPersistenceId(persistenceId: String): Int
 
-  def sliceRanges(numberOfRanges: Int): immutable.Seq[Range]
+  def sliceRanges(numberOfRanges: Int): Seq[Range]
 
 }

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/journal/JournalPerfSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/journal/JournalPerfSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.journal
 
 import java.nio.charset.StandardCharsets
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -140,7 +139,7 @@ abstract class JournalPerfSpec(config: Config)
   def benchActor(replyAfter: Int): ActorRef =
     system.actorOf(Props(classOf[BenchActor], pid, testProbe.ref, replyAfter))
 
-  def feedAndExpectLast(actor: ActorRef, mode: String, cmnds: immutable.Seq[Int]): Unit = {
+  def feedAndExpectLast(actor: ActorRef, mode: String, cmnds: Seq[Int]): Unit = {
     cmnds.foreach { c =>
       actor ! Cmd(mode, c)
     }

--- a/persistence-tck/src/main/scala/org/apache/pekko/persistence/snapshot/SnapshotStoreSpec.scala
+++ b/persistence-tck/src/main/scala/org/apache/pekko/persistence/snapshot/SnapshotStoreSpec.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.snapshot
 
-import scala.collection.immutable.Seq
-
 import org.apache.pekko
 import pekko.actor._
 import pekko.persistence._

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/EventStorage.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/EventStorage.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.testkit
 
 import java.util.{ List => JList }
 
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
 
@@ -36,16 +35,16 @@ private[testkit] trait EventStorage extends TestKitStorage[JournalOperation, Per
   import EventStorage._
 
   def addAny(key: String, elem: Any): Unit =
-    addAny(key, immutable.Seq(elem))
+    addAny(key, Seq(elem))
 
-  def addAny(key: String, elems: immutable.Seq[Any]): Unit =
+  def addAny(key: String, elems: Seq[Any]): Unit =
     // need to use `updateExisting` because `mapAny` reads latest seqnum
     // and therefore must be done at the same time with the update, not before
     updateOrSetNew(key, v => v ++ mapAny(key, elems).toVector)
 
   override def reprToSeqNum(repr: PersistentRepr): Long = repr.sequenceNr
 
-  def add(elems: immutable.Seq[PersistentRepr]): Unit =
+  def add(elems: Seq[PersistentRepr]): Unit =
     elems.groupBy(_.persistenceId).foreach { gr =>
       add(gr._1, gr._2)
     }
@@ -55,7 +54,7 @@ private[testkit] trait EventStorage extends TestKitStorage[JournalOperation, Per
   /**
    * @throws Exception from StorageFailure in the current writing policy
    */
-  def tryAdd(elems: immutable.Seq[PersistentRepr]): Try[Unit] = {
+  def tryAdd(elems: Seq[PersistentRepr]): Try[Unit] = {
     val grouped = elems.groupBy(_.persistenceId)
 
     val processed = grouped.map {
@@ -90,7 +89,7 @@ private[testkit] trait EventStorage extends TestKitStorage[JournalOperation, Per
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long,
-      max: Long): immutable.Seq[PersistentRepr] = {
+      max: Long): Seq[PersistentRepr] = {
     val batch = read(persistenceId, fromSequenceNr, toSequenceNr, max)
     currentPolicy.tryProcess(persistenceId, ReadEvents(batch)) match {
       case ProcessingSuccess  => batch
@@ -99,7 +98,7 @@ private[testkit] trait EventStorage extends TestKitStorage[JournalOperation, Per
     }
   }
 
-  def tryReadByTag(tag: String): immutable.Seq[PersistentRepr] = {
+  def tryReadByTag(tag: String): Seq[PersistentRepr] = {
     val batch = readAll()
       .filter(repr =>
         repr.payload match {
@@ -116,7 +115,7 @@ private[testkit] trait EventStorage extends TestKitStorage[JournalOperation, Per
     }
   }
 
-  def tryRead(processId: String, predicate: PersistentRepr => Boolean): immutable.Seq[PersistentRepr] = {
+  def tryRead(processId: String, predicate: PersistentRepr => Boolean): Seq[PersistentRepr] = {
     import EventStorage.persistentReprOrdering
     val batch = readAll().filter(predicate).toVector.sorted
 
@@ -156,7 +155,7 @@ private[testkit] trait EventStorage extends TestKitStorage[JournalOperation, Per
 
   }
 
-  private def mapAny(key: String, elems: immutable.Seq[Any]): immutable.Seq[PersistentRepr] = {
+  private def mapAny(key: String, elems: Seq[Any]): Seq[PersistentRepr] = {
     val sn = getHighestSeqNumber(key) + 1
     elems.zipWithIndex.map(p => PersistentRepr(p._1, p._2 + sn, key))
   }
@@ -190,7 +189,7 @@ sealed trait JournalOperation
 /**
  * Read from journal operation with events that were read.
  */
-final case class ReadEvents(batch: immutable.Seq[Any]) extends JournalOperation {
+final case class ReadEvents(batch: Seq[Any]) extends JournalOperation {
 
   def getBatch(): JList[Any] = batch.asJava
 
@@ -199,7 +198,7 @@ final case class ReadEvents(batch: immutable.Seq[Any]) extends JournalOperation 
 /**
  * Write in journal operation with events to be written.
  */
-final case class WriteEvents(batch: immutable.Seq[Any]) extends JournalOperation {
+final case class WriteEvents(batch: Seq[Any]) extends JournalOperation {
 
   def getBatch(): JList[Any] = batch.asJava
 

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/PersistenceTestKitPlugin.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/PersistenceTestKitPlugin.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.persistence.testkit
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.Try
 
@@ -45,7 +44,7 @@ class PersistenceTestKitPlugin(@nowarn("msg=never used") cfg: Config, cfgPath: S
   }
   private val eventStream = context.system.eventStream
 
-  override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     Future.fromTry(Try(messages.map(aw => {
       val timestamp = CurrentTime.now()
       val data = aw.payload.map(pl =>

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.testkit.internal
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
@@ -47,7 +46,7 @@ import pekko.stream.scaladsl.Sink
 @InternalApi private[pekko] object EventSourcedBehaviorTestKitImpl {
   final case class CommandResultImpl[Command, Event, State, Reply](
       command: Command,
-      events: immutable.Seq[Event],
+      events: Seq[Event],
       state: State,
       replyOption: Option[Reply])
       extends CommandResultWithReply[Command, Event, State, Reply] {
@@ -187,7 +186,7 @@ import pekko.stream.scaladsl.Sink
     }
   }
 
-  private def getEvents(fromSeqNr: Long): immutable.Seq[Event] = {
+  private def getEvents(fromSeqNr: Long): Seq[Event] = {
     implicit val sys: ActorSystem[?] = system
     val result =
       queries.currentEventsByPersistenceId(persistenceId.id, fromSeqNr, toSequenceNr = Long.MaxValue).runWith(Sink.seq)
@@ -213,7 +212,7 @@ import pekko.stream.scaladsl.Sink
     }
   }
 
-  private def postCommandCheck(newEvents: immutable.Seq[Event], newState: State, reply: Option[Any]): Unit = {
+  private def postCommandCheck(newEvents: Seq[Event], newState: State, reply: Option[Any]): Unit = {
     if (serializationSettings.enabled) {
       if (serializationSettings.verifyEvents) {
         newEvents.foreach(verifySerializationAndThrow(_, "Event"))
@@ -269,7 +268,7 @@ import pekko.stream.scaladsl.Sink
         case _         => throw new IllegalArgumentException("Cannot initialize from state when snapshots are not used.")
       }
     }
-    persistenceTestKit.persistForRecovery(persistenceId.id, collection.immutable.Seq.empty ++ events)
+    persistenceTestKit.persistForRecovery(persistenceId.id, Seq.empty ++ events)
 
     restart()
   }

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/PersistenceProbeImpl.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/PersistenceProbeImpl.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.persistence.testkit.internal
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
@@ -139,7 +138,7 @@ private[pekko] object PersistenceProbeImpl {
       }
 
       @tailrec
-      def applyEffects(curEffect: EffectImpl[Event, State], sideEffects: immutable.Seq[SideEffect[State]]): Unit =
+      def applyEffects(curEffect: EffectImpl[Event, State], sideEffects: Seq[SideEffect[State]]): Unit =
         curEffect match {
           case CompositeEffect(eff: EffectImpl[Event, State], se) =>
             applyEffects(eff, se ++ sideEffects)
@@ -181,7 +180,7 @@ private[pekko] object PersistenceProbeImpl {
             Behaviors.stopped
         }
 
-      def sideEffect(sideEffects: immutable.Seq[SideEffect[State]]): Unit =
+      def sideEffect(sideEffects: Seq[SideEffect[State]]): Unit =
         sideEffects.iterator.foreach { effect =>
           effect match {
             case _: Stop.type       => shouldStop = true
@@ -254,7 +253,7 @@ private[pekko] object PersistenceProbeImpl {
       }
 
       @tailrec
-      def applyEffects(curEffect: EffectImpl[State], sideEffects: immutable.Seq[SideEffect[State]]): Unit =
+      def applyEffects(curEffect: EffectImpl[State], sideEffects: Seq[SideEffect[State]]): Unit =
         curEffect match {
           case CompositeEffect(eff: EffectImpl[?], se) =>
             applyEffects(eff.asInstanceOf[EffectImpl[State]], se ++ sideEffects)
@@ -275,7 +274,7 @@ private[pekko] object PersistenceProbeImpl {
             Behaviors.stopped
         }
 
-      def sideEffect(sideEffects: immutable.Seq[SideEffect[State]]): Unit =
+      def sideEffect(sideEffects: Seq[SideEffect[State]]): Unit =
         sideEffects.iterator.foreach { effect =>
           effect match {
             case _: Stop.type       => shouldStop = true

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/TestKitStorage.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/internal/TestKitStorage.scala
@@ -15,8 +15,6 @@ package org.apache.pekko.persistence.testkit.internal
 
 import java.util.concurrent.atomic.AtomicReference
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.persistence.testkit.ProcessingPolicy
@@ -94,7 +92,7 @@ sealed trait InMemStorage[K, R] extends InternalReprSupport[R] {
   /**
    * Adds elements ordered by seqnum, sets new seqnum as max(old, max(newElemsSeqNums)))
    */
-  def add(key: K, elems: immutable.Seq[R]): Unit =
+  def add(key: K, elems: Seq[R]): Unit =
     updateOrSetNew(key, v => v ++ elems)
 
   /**
@@ -141,7 +139,7 @@ sealed trait InMemStorage[K, R] extends InternalReprSupport[R] {
   /**
    * Reads elems within the range of seqnums.
    */
-  def read(key: K, fromInclusive: Long, toInclusive: Long, maxNumber: Long): immutable.Seq[R] = lock.synchronized {
+  def read(key: K, fromInclusive: Long, toInclusive: Long, maxNumber: Long): Seq[R] = lock.synchronized {
     read(key)
       .getOrElse(Vector.empty)
       .dropWhile(reprToSeqNum(_) < fromInclusive)
@@ -167,9 +165,9 @@ sealed trait InMemStorage[K, R] extends InternalReprSupport[R] {
     eventsMap.keys.foreach(removePreservingSeqNumber)
   }
 
-  def keys(): immutable.Seq[K] = eventsMap.keys.toList
+  def keys(): Seq[K] = eventsMap.keys.toList
 
-  private def getLastSeqNumber(elems: immutable.Seq[R]): Long =
+  private def getLastSeqNumber(elems: Seq[R]): Long =
     elems.lastOption.map(reprToSeqNum).getOrElse(0L)
 
 }

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/query/scaladsl/PersistenceTestKitReadJournal.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/query/scaladsl/PersistenceTestKitReadJournal.scala
@@ -16,7 +16,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.NotUsed
@@ -200,7 +199,7 @@ final class PersistenceTestKitReadJournal(system: ExtendedActorSystem, @nowarn("
   override def sliceForPersistenceId(persistenceId: String): Int =
     persistence.sliceForPersistenceId(persistenceId)
 
-  override def sliceRanges(numberOfRanges: Int): immutable.Seq[Range] =
+  override def sliceRanges(numberOfRanges: Int): Seq[Range] =
     persistence.sliceRanges(numberOfRanges)
 
   /**

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.testkit.scaladsl
 
-import scala.collection.immutable
 import scala.reflect.ClassTag
 
 import org.apache.pekko
@@ -138,7 +137,7 @@ object EventSourcedBehaviorTestKit {
      * In many cases only one event is emitted and then it's more convenient to use [[CommandResult.event]]
      * or [[CommandResult.eventOfType]].
      */
-    def events: immutable.Seq[Event]
+    def events: Seq[Event]
 
     /**
      * `true` if no events were emitted by the command.

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/PersistenceTestKit.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/PersistenceTestKit.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.testkit.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
@@ -311,12 +310,12 @@ private[testkit] trait PersistenceTestKitOps[S, P]
   /**
    * Persist `snapshots` into storage in order.
    */
-  def persistForRecovery(persistenceId: String, events: immutable.Seq[Any]): Unit
+  def persistForRecovery(persistenceId: String, events: Seq[Any]): Unit
 
   /**
    * Retrieve all snapshots saved in storage by persistence id.
    */
-  def persistedInStorage(persistenceId: String): immutable.Seq[Any]
+  def persistedInStorage(persistenceId: String): Seq[Any]
 
 }
 
@@ -382,7 +381,7 @@ class SnapshotTestKit(system: ActorSystem)
   /**
    * Persist `elems` pairs of (snapshot metadata, snapshot payload) into storage.
    */
-  def persistForRecovery(persistenceId: String, elems: immutable.Seq[(SnapshotMeta, Any)]): Unit =
+  def persistForRecovery(persistenceId: String, elems: Seq[(SnapshotMeta, Any)]): Unit =
     elems.foreach {
       case (m, p) =>
         storage.add(persistenceId, (SnapshotMetadata(persistenceId, m.sequenceNr, m.timestamp), p))
@@ -393,12 +392,12 @@ class SnapshotTestKit(system: ActorSystem)
    * Persist a pair of (snapshot metadata, snapshot payload) into storage.
    */
   def persistForRecovery(persistenceId: String, elem: (SnapshotMeta, Any)): Unit =
-    persistForRecovery(persistenceId, immutable.Seq(elem))
+    persistForRecovery(persistenceId, Seq(elem))
 
   /**
    * Retrieve snapshots and their metadata from storage by persistence id.
    */
-  def persistedInStorage(persistenceId: String): immutable.Seq[(SnapshotMeta, Any)] =
+  def persistedInStorage(persistenceId: String): Seq[(SnapshotMeta, Any)] =
     storage
       .read(persistenceId)
       .map(_.map(m => (SnapshotMeta(m._1.sequenceNr, m._1.timestamp), m._2)))
@@ -510,12 +509,12 @@ class PersistenceTestKit(system: ActorSystem)
   override def failNextNDeletes(persistenceId: String, n: Int, cause: Throwable): Unit =
     failNextNOpsCond((pid, op) => pid == persistenceId && op.isInstanceOf[DeleteEvents], n, cause)
 
-  def persistForRecovery(persistenceId: String, events: immutable.Seq[Any]): Unit = {
+  def persistForRecovery(persistenceId: String, events: Seq[Any]): Unit = {
     storage.addAny(persistenceId, events)
     addToIndex(persistenceId, events.size)
   }
 
-  def persistedInStorage(persistenceId: String): immutable.Seq[Any] =
+  def persistedInStorage(persistenceId: String): Seq[Any] =
     storage.read(persistenceId).getOrElse(List.empty).map(reprToAny)
 
   override private[testkit] def reprToAny(repr: PersistentRepr): Any = repr.payload match {

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/TestOps.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/scaladsl/TestOps.scala
@@ -220,25 +220,25 @@ private[testkit] trait ExpectOps[U] {
    * Receive for `max` time next `n` events/snapshots that have been persisted in the storage.
    */
   def receivePersisted[A](persistenceId: String, n: Int, max: FiniteDuration)(
-      implicit t: ClassTag[A]): immutable.Seq[A] =
+      implicit t: ClassTag[A]): Seq[A] =
     receivePersisted(persistenceId, n, t.runtimeClass.asInstanceOf[Class[A]], max)
 
   /**
    * Receive next `n` events/snapshots that have been persisted in the storage.
    */
-  def receivePersisted[A](persistenceId: String, n: Int)(implicit t: ClassTag[A]): immutable.Seq[A] =
+  def receivePersisted[A](persistenceId: String, n: Int)(implicit t: ClassTag[A]): Seq[A] =
     receivePersisted(persistenceId, n, t.runtimeClass.asInstanceOf[Class[A]], maxTimeout)
 
   /**
    * Receive next `n` events/snapshots that have been persisted in the storage.
    */
-  def receivePersisted[A](persistenceId: String, n: Int, cla: Class[A]): immutable.Seq[A] =
+  def receivePersisted[A](persistenceId: String, n: Int, cla: Class[A]): Seq[A] =
     receivePersisted(persistenceId, n, cla, maxTimeout)
 
   /**
    * Receive for `max` time next `n` events/snapshots that have been persisted in the storage.
    */
-  def receivePersisted[A](persistenceId: String, n: Int, cla: Class[A], max: FiniteDuration): immutable.Seq[A] = {
+  def receivePersisted[A](persistenceId: String, n: Int, cla: Class[A], max: FiniteDuration): Seq[A] = {
     val nextInd = nextIndex(persistenceId)
     val bt = BoxedType(cla)
     val res =
@@ -259,7 +259,7 @@ private[testkit] trait ExpectOps[U] {
         interval = pollInterval)
 
     setIndex(persistenceId, nextInd + n)
-    res.asInstanceOf[immutable.Seq[A]]
+    res.asInstanceOf[Seq[A]]
   }
 
 }

--- a/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
+++ b/persistence-testkit/src/main/scala/org/apache/pekko/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.testkit.state.scaladsl
 
 import java.util.concurrent.atomic.AtomicLong
 
-import scala.collection.immutable
 import scala.concurrent.Future
 
 import org.apache.pekko
@@ -196,7 +195,7 @@ class PersistenceTestKitDurableStateStore[A](val system: ExtendedActorSystem)
   override def sliceForPersistenceId(persistenceId: String): Int =
     persistence.sliceForPersistenceId(persistenceId)
 
-  override def sliceRanges(numberOfRanges: Int): immutable.Seq[Range] =
+  override def sliceRanges(numberOfRanges: Int): Seq[Range] =
     persistence.sliceRanges(numberOfRanges)
 
   override def currentPersistenceIds(afterId: Option[String], limit: Long): Source[String, NotUsed] =

--- a/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/query/EventsBySliceSpec.scala
+++ b/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/query/EventsBySliceSpec.scala
@@ -17,7 +17,6 @@
 
 package org.apache.pekko.persistence.testkit.query
 
-import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 import org.apache.pekko

--- a/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/query/EventsByTagSpec.scala
+++ b/persistence-testkit/src/test/scala/org/apache/pekko/persistence/testkit/query/EventsByTagSpec.scala
@@ -17,7 +17,6 @@
 
 package org.apache.pekko.persistence.testkit.query
 
-import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 import org.apache.pekko

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.typed.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Try
@@ -47,7 +46,7 @@ class ChaosJournal extends InmemJournal {
   var failRecovery = true
   var reject = true
 
-  override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     val pid = messages.head.persistenceId
     counts = counts.updated(pid, counts.getOrElse(pid, 0) + 1)
     if (pid == "fail-first-2" && counts(pid) <= 2) {

--- a/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSignalSpec.scala
+++ b/persistence-typed-tests/src/test/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehaviorSignalSpec.scala
@@ -17,7 +17,6 @@
 
 package org.apache.pekko.persistence.typed.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Try
@@ -42,7 +41,7 @@ import com.typesafe.config.ConfigFactory
 
 // Custom journal that checks event flags to determine whether to reject or fail writes
 class SignalTestJournal extends InmemJournal {
-  override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     // Check if any of the events have the shouldReject or shouldFail flag set
     val shouldReject = messages.exists { atomicWrite =>
       atomicWrite.payload.exists { persistentRepr =>

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/EventAdapter.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/EventAdapter.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.persistence.typed
 
 import scala.annotation.varargs
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
@@ -78,7 +77,7 @@ abstract class EventAdapter[E, P] {
 
 /** Not for user extension */
 @DoNotInherit sealed trait EventSeq[+A] {
-  def events: immutable.Seq[A]
+  def events: Seq[A]
   def isEmpty: Boolean = events.isEmpty
   def nonEmpty: Boolean = events.nonEmpty
   def size: Int
@@ -98,24 +97,24 @@ object EventSeq {
   }
 
   /** Scala API */
-  final def apply[A](events: immutable.Seq[A]): EventSeq[A] = EventsSeq(events)
+  final def apply[A](events: Seq[A]): EventSeq[A] = EventsSeq(events)
 
 }
 
 /** INTERNAL API */
 @InternalApi private[pekko] final case class SingleEventSeq[A](event: A) extends EventSeq[A] {
-  override def events: immutable.Seq[A] = List(event)
+  override def events: Seq[A] = List(event)
   override def size: Int = 1
 }
 
 /** INTERNAL API */
 @InternalApi private[pekko] case object EmptyEventSeq extends EventSeq[Nothing] {
-  override def events: immutable.Seq[Nothing] = Nil
+  override def events: Seq[Nothing] = Nil
   override def size: Int = 0
 }
 
 /** INTERNAL API */
-@InternalApi private[pekko] final case class EventsSeq[A](override val events: immutable.Seq[A]) extends EventSeq[A] {
+@InternalApi private[pekko] final case class EventsSeq[A](override val events: Seq[A]) extends EventSeq[A] {
   override def size: Int = events.size
 }
 

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EffectImpl.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/EffectImpl.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.typed.internal
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor.typed.ActorRef
 import pekko.annotation.InternalApi
@@ -29,7 +27,7 @@ private[pekko] abstract class EffectImpl[+Event, State]
     with scaladsl.ReplyEffect[Event, State]
     with scaladsl.EffectBuilder[Event, State] {
   /* All events that will be persisted in this effect */
-  override def events: immutable.Seq[Event] = Nil
+  override def events: Seq[Event] = Nil
 
   override def thenRun(chainedEffect: State => Unit): EffectImpl[Event, State] =
     CompositeEffect(this, new Callback[State](chainedEffect))
@@ -62,10 +60,10 @@ private[pekko] object CompositeEffect {
 @InternalApi
 private[pekko] final case class CompositeEffect[Event, State](
     persistingEffect: scaladsl.EffectBuilder[Event, State],
-    _sideEffects: immutable.Seq[SideEffect[State]])
+    _sideEffects: Seq[SideEffect[State]])
     extends EffectImpl[Event, State] {
 
-  override val events: immutable.Seq[Event] = persistingEffect.events
+  override val events: Seq[Event] = persistingEffect.events
 
   override def toString: String =
     s"CompositeEffect($persistingEffect, sideEffects: ${_sideEffects.size})"
@@ -85,7 +83,7 @@ private[pekko] final case class Persist[Event, State](event: Event) extends Effe
 
 /** INTERNAL API */
 @InternalApi
-private[pekko] final case class PersistAll[Event, State](override val events: immutable.Seq[Event])
+private[pekko] final case class PersistAll[Event, State](override val events: Seq[Event])
     extends EffectImpl[Event, State] {
 
   override def toString: String = s"PersistAll(${events.map(_.getClass.getName).mkString(",")})"

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ExternalInteractions.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ExternalInteractions.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.persistence.typed.internal
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.actor.ActorRef
@@ -96,7 +95,7 @@ private[pekko] trait JournalInteractions[C, E, S] {
       ctx: ActorContext[?],
       cmd: Any,
       state: Running.RunningState[S, C],
-      events: immutable.Seq[EventToPersist]): Running.RunningState[S, C] = {
+      events: Seq[EventToPersist]): Running.RunningState[S, C] = {
     if (events.nonEmpty) {
       var newState = state
 
@@ -131,7 +130,7 @@ private[pekko] trait JournalInteractions[C, E, S] {
   private[pekko] def onWritesInitiated(
       @nowarn("msg=never used") ctx: ActorContext[?],
       @nowarn("msg=never used") cmd: Any,
-      @nowarn("msg=never used") repr: immutable.Seq[PersistentRepr]): Unit = ()
+      @nowarn("msg=never used") repr: Seq[PersistentRepr]): Unit = ()
 
   protected def replayEvents(fromSeqNr: Long, toSeqNr: Long): Unit = {
     setup.internalLogger.debug2("Replaying events: from: {}, to: {}", fromSeqNr, toSeqNr)

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ReplayingEvents.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/ReplayingEvents.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.persistence.typed.internal
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
@@ -325,7 +324,7 @@ private[pekko] final class ReplayingEvents[C, E, S](
         setup.retention match {
           case criteria: SnapshotCountRetentionCriteriaImpl if criteria.snapshotEveryNEvents <= state.eventsReplayed =>
             internalSaveSnapshot(initialRunningState)
-            new running.StoringSnapshot(initialRunningState, immutable.Seq.empty, SnapshotWithoutRetention)
+            new running.StoringSnapshot(initialRunningState, Seq.empty, SnapshotWithoutRetention)
           case _ =>
             tryUnstashOne(new running.HandlingCommands(initialRunningState))
         }

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/Running.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/internal/Running.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.nowarn
 import scala.annotation.tailrec
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.actor.UnhandledMessage
@@ -537,7 +536,7 @@ private[pekko] object Running {
     private def handleEventPersist(
         event: E,
         cmd: Any,
-        sideEffects: immutable.Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
+        sideEffects: Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
       try {
         // apply the event before persist so that validation exception is handled before persisting
         // the invalid event, in case such validation is implemented in the event handler.
@@ -593,9 +592,9 @@ private[pekko] object Running {
     }
 
     private def handleEventPersistAll(
-        events: immutable.Seq[E],
+        events: Seq[E],
         cmd: Any,
-        sideEffects: immutable.Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
+        sideEffects: Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
       if (events.nonEmpty) {
         try {
           // apply the event before persist so that validation exception is handled before persisting
@@ -664,7 +663,7 @@ private[pekko] object Running {
         msg: Any,
         state: RunningState[S, C],
         effect: Effect[E, S],
-        sideEffects: immutable.Seq[SideEffect[S]] = Nil): (Behavior[InternalProtocol], Boolean) = {
+        sideEffects: Seq[SideEffect[S]] = Nil): (Behavior[InternalProtocol], Boolean) = {
       if (setup.internalLogger.isDebugEnabled && !effect.isInstanceOf[CompositeEffect[?, ?]])
         setup.internalLogger.debugN(
           "Handled command [{}], resulting effect: [{}], side effects: [{}]",
@@ -723,7 +722,7 @@ private[pekko] object Running {
       numberOfEvents: Int,
       shouldSnapshotAfterPersist: SnapshotAfterPersist,
       shouldPublish: Boolean,
-      sideEffects: immutable.Seq[SideEffect[S]]): Behavior[InternalProtocol] = {
+      sideEffects: Seq[SideEffect[S]]): Behavior[InternalProtocol] = {
     setup.setMdcPhase(PersistenceMdc.PersistingEvents)
     new PersistingEvents(state, visibleState, numberOfEvents, shouldSnapshotAfterPersist, shouldPublish, sideEffects)
   }
@@ -735,7 +734,7 @@ private[pekko] object Running {
       numberOfEvents: Int,
       shouldSnapshotAfterPersist: SnapshotAfterPersist,
       shouldPublish: Boolean,
-      var sideEffects: immutable.Seq[SideEffect[S]],
+      var sideEffects: Seq[SideEffect[S]],
       persistStartTime: Long = System.nanoTime())
       extends AbstractBehavior[InternalProtocol](setup.context)
       with WithSeqNrAccessible {
@@ -900,7 +899,7 @@ private[pekko] object Running {
   /** INTERNAL API */
   @InternalApi private[pekko] class StoringSnapshot(
       state: RunningState[S, C],
-      sideEffects: immutable.Seq[SideEffect[S]],
+      sideEffects: Seq[SideEffect[S]],
       snapshotReason: SnapshotAfterPersist)
       extends AbstractBehavior[InternalProtocol](setup.context)
       with WithSeqNrAccessible {
@@ -1007,7 +1006,7 @@ private[pekko] object Running {
 
   // --------------------------
 
-  def applySideEffects(effects: immutable.Seq[SideEffect[S]], state: RunningState[S, C]): Behavior[InternalProtocol] = {
+  def applySideEffects(effects: Seq[SideEffect[S]], state: RunningState[S, C]): Behavior[InternalProtocol] = {
     var behavior: Behavior[InternalProtocol] = new HandlingCommands(state)
     val it = effects.iterator
 

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/EffectImpl.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/EffectImpl.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.typed.state.internal
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor.typed.ActorRef
 import pekko.annotation.InternalApi
@@ -60,7 +58,7 @@ private[pekko] object CompositeEffect {
 @InternalApi
 private[pekko] final case class CompositeEffect[State](
     persistingEffect: scaladsl.EffectBuilder[State],
-    _sideEffects: immutable.Seq[SideEffect[State]])
+    _sideEffects: Seq[SideEffect[State]])
     extends EffectImpl[State] {
 
   override val state: Option[State] = persistingEffect.state

--- a/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/Running.scala
+++ b/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/internal/Running.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.typed.state.internal
 
 import scala.annotation.nowarn
 import scala.annotation.tailrec
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.actor.UnhandledMessage
@@ -201,7 +200,7 @@ private[pekko] object Running {
     private def handlePersist(
         newState: S,
         cmd: Any,
-        sideEffects: immutable.Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
+        sideEffects: Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
       _currentRevision = state.revision + 1
 
       val stateAfterApply = state.applyState(setup, newState)
@@ -215,7 +214,7 @@ private[pekko] object Running {
 
     private def handleDelete(
         cmd: Any,
-        sideEffects: immutable.Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
+        sideEffects: Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
       _currentRevision = state.revision + 1
 
       val nextState = internalDelete(setup.context, cmd, state)
@@ -227,7 +226,7 @@ private[pekko] object Running {
         msg: Any,
         state: RunningState[S, C],
         effect: Effect[S],
-        sideEffects: immutable.Seq[SideEffect[S]] = Nil): (Behavior[InternalProtocol], Boolean) = {
+        sideEffects: Seq[SideEffect[S]] = Nil): (Behavior[InternalProtocol], Boolean) = {
       if (setup.internalLogger.isDebugEnabled && !effect.isInstanceOf[CompositeEffect[?]])
         setup.internalLogger.debugN(
           "Handled command [{}], resulting effect: [{}], side effects: [{}]",
@@ -278,7 +277,7 @@ private[pekko] object Running {
   def persistingState(
       state: RunningState[S, C],
       visibleState: RunningState[S, C], // previous state until write success
-      sideEffects: immutable.Seq[SideEffect[S]]): Behavior[InternalProtocol] = {
+      sideEffects: Seq[SideEffect[S]]): Behavior[InternalProtocol] = {
     setup.setMdcPhase(PersistenceMdc.PersistingState)
     new PersistingState(state, visibleState, sideEffects)
   }
@@ -287,7 +286,7 @@ private[pekko] object Running {
   @InternalApi private[pekko] class PersistingState(
       var state: RunningState[S, C],
       var visibleState: RunningState[S, C], // previous state until write success
-      var sideEffects: immutable.Seq[SideEffect[S]],
+      var sideEffects: Seq[SideEffect[S]],
       persistStartTime: Long = System.nanoTime())
       extends AbstractBehavior[InternalProtocol](setup.context)
       with WithRevisionAccessible {
@@ -372,7 +371,7 @@ private[pekko] object Running {
 
   // ===============================================
 
-  def applySideEffects(effects: immutable.Seq[SideEffect[S]], state: RunningState[S, C]): Behavior[InternalProtocol] = {
+  def applySideEffects(effects: Seq[SideEffect[S]], state: RunningState[S, C]): Behavior[InternalProtocol] = {
     var behavior: Behavior[InternalProtocol] = new HandlingCommands(state)
     val it = effects.iterator
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala
@@ -34,7 +34,7 @@ object AtLeastOnceDelivery {
   @SerialVersionUID(1L)
   case class AtLeastOnceDeliverySnapshot(
       currentDeliveryId: Long,
-      unconfirmedDeliveries: immutable.Seq[UnconfirmedDelivery])
+      unconfirmedDeliveries: Seq[UnconfirmedDelivery])
       extends Message {
 
     /**
@@ -51,7 +51,7 @@ object AtLeastOnceDelivery {
    * @see [[AtLeastOnceDeliveryLike#warnAfterNumberOfUnconfirmedAttempts]]
    */
   @SerialVersionUID(1L)
-  case class UnconfirmedWarning(unconfirmedDeliveries: immutable.Seq[UnconfirmedDelivery]) {
+  case class UnconfirmedWarning(unconfirmedDeliveries: Seq[UnconfirmedDelivery]) {
 
     /**
      * Java API

--- a/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala
@@ -17,7 +17,6 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
@@ -421,7 +420,7 @@ private[persistence] trait Eventsourced
    * Internal API
    */
   @InternalApi
-  final private[pekko] def internalPersistAll[A](events: immutable.Seq[A])(handler: A => Unit): Unit = {
+  final private[pekko] def internalPersistAll[A](events: Seq[A])(handler: A => Unit): Unit = {
     if (recoveryRunning)
       throw new IllegalStateException(
         "Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.")
@@ -469,7 +468,7 @@ private[persistence] trait Eventsourced
    * Internal API
    */
   @InternalApi
-  final private[pekko] def internalPersistAllAsync[A](events: immutable.Seq[A])(handler: A => Unit): Unit = {
+  final private[pekko] def internalPersistAllAsync[A](events: Seq[A])(handler: A => Unit): Unit = {
     if (recoveryRunning)
       throw new IllegalStateException(
         "Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.")

--- a/persistence/src/main/scala/org/apache/pekko/persistence/JournalProtocol.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/JournalProtocol.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor._
 
@@ -48,7 +46,7 @@ private[persistence] object JournalProtocol {
    * @param persistentActor write requester.
    */
   final case class WriteMessages(
-      messages: immutable.Seq[PersistentEnvelope],
+      messages: Seq[PersistentEnvelope],
       persistentActor: ActorRef,
       actorInstanceId: Int)
       extends Request

--- a/persistence/src/main/scala/org/apache/pekko/persistence/PersistencePlugin.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/PersistencePlugin.scala
@@ -86,7 +86,7 @@ private[pekko] abstract class PersistencePlugin[ScalaDsl, JavaDsl, T](system: Ex
     log.debug("Create plugin: {} {}", configPath, pluginClassName)
     val pluginClass = system.dynamicAccess.getClassFor[AnyRef](pluginClassName).get
 
-    def instantiate(args: collection.immutable.Seq[(Class[?], AnyRef)]) =
+    def instantiate(args: Seq[(Class[?], AnyRef)]) =
       system.dynamicAccess.createInstanceFor[T](pluginClass, args)
 
     instantiate(

--- a/persistence/src/main/scala/org/apache/pekko/persistence/Persistent.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/Persistent.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor.{ ActorRef, NoSerializationVerificationNeeded }
 import pekko.annotation.DoNotInherit
@@ -46,7 +44,7 @@ object AtomicWrite {
   def apply(event: PersistentRepr): AtomicWrite = apply(List(event))
 }
 
-final case class AtomicWrite(payload: immutable.Seq[PersistentRepr]) extends PersistentEnvelope with Message {
+final case class AtomicWrite(payload: Seq[PersistentRepr]) extends PersistentEnvelope with Message {
   require(payload.nonEmpty, "payload of AtomicWrite must not be empty!")
   private var _highestSequenceNr: Long = payload.head.sequenceNr
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/PersistentActor.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/PersistentActor.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence
 
 import java.lang.{ Iterable => JIterable }
 
-import scala.collection.immutable
 import scala.util.control.NoStackTrace
 
 import org.apache.pekko
@@ -215,7 +214,7 @@ trait PersistentActor extends Eventsourced with PersistenceIdentity {
    * @param events events to be persisted
    * @param handler handler for each persisted `events`
    */
-  def persistAll[A](events: immutable.Seq[A])(handler: A => Unit): Unit = {
+  def persistAll[A](events: Seq[A])(handler: A => Unit): Unit = {
     internalPersistAll(events)(handler)
   }
 
@@ -254,7 +253,7 @@ trait PersistentActor extends Eventsourced with PersistenceIdentity {
    * @param events events to be persisted
    * @param handler handler for each persisted `events`
    */
-  def persistAllAsync[A](events: immutable.Seq[A])(handler: A => Unit): Unit = {
+  def persistAllAsync[A](events: Seq[A])(handler: A => Unit): Unit = {
     internalPersistAllAsync(events)(handler)
   }
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSM.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSM.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.fsm
 
 import scala.annotation.nowarn
 import scala.annotation.varargs
-import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
@@ -148,7 +147,7 @@ trait PersistentFSM[S <: FSMState, D, E] extends PersistentActor with Persistent
    * Persist FSM State and FSM State Data
    */
   override private[pekko] def applyState(nextState: State): Unit = {
-    var eventsToPersist: immutable.Seq[Any] = nextState.domainEvents.toList
+    var eventsToPersist: Seq[Any] = nextState.domainEvents.toList
 
     // Prevent StateChangeEvent persistence when staying in the same state, except when state defines a timeout
     if (nextState.notifies || nextState.timeout.nonEmpty) {

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/AsyncWriteJournal.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/AsyncWriteJournal.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.persistence.journal
 
 import java.util.concurrent.atomic.AtomicLong
 
-import scala.collection.{ immutable, mutable }
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -446,7 +446,7 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
    * failure.
    *
    * The journal can also signal that it rejects individual messages (`AtomicWrite`) by
-   * the returned `immutable.Seq[Try[Unit]]`. It is possible but not mandatory to reduce
+   * the returned `Seq[Try[Unit]]`. It is possible but not mandatory to reduce
    * number of allocations by returning `Future.successful(Nil)` for the happy path,
    * i.e. when no messages are rejected. Otherwise the returned `Seq` must have as many elements
    * as the input `messages` `Seq`. Each `Try` element signals if the corresponding
@@ -481,7 +481,7 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
    *
    * This call is protected with a circuit-breaker.
    */
-  def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]]
+  def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]]
 
   /**
    * Plugin API: asynchronously deletes all persistent messages up to `toSequenceNr`

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/AsyncWriteProxy.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/AsyncWriteProxy.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.journal
 
-import scala.collection.immutable
 import scala.concurrent._
 import scala.concurrent.duration.Duration
 import scala.util.Try
@@ -67,9 +66,9 @@ private[persistence] trait AsyncWriteProxy extends AsyncWriteJournal with Stash 
 
   implicit def timeout: Timeout
 
-  def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] =
+  def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] =
     store match {
-      case Some(s) => (s ? WriteMessages(messages)).mapTo[immutable.Seq[Try[Unit]]]
+      case Some(s) => (s ? WriteMessages(messages)).mapTo[Seq[Try[Unit]]]
       case None    => storeNotInitialized
     }
 
@@ -117,7 +116,7 @@ private[persistence] object AsyncWriteProxy {
  */
 private[persistence] object AsyncWriteTarget {
   @SerialVersionUID(1L)
-  final case class WriteMessages(messages: immutable.Seq[AtomicWrite])
+  final case class WriteMessages(messages: Seq[AtomicWrite])
 
   @SerialVersionUID(1L)
   final case class DeleteMessagesTo(persistenceId: String, toSequenceNr: Long)

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapter.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapter.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.persistence.journal
 
 import scala.annotation.varargs
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
@@ -98,7 +97,7 @@ trait ReadEventAdapter {
 
 /** Not for user extension */
 @DoNotInherit sealed abstract class EventSeq {
-  def events: immutable.Seq[Any]
+  def events: Seq[Any]
 }
 object EventSeq {
 
@@ -113,7 +112,7 @@ object EventSeq {
   final def apply(events: Any*): EventSeq = EventsSeq(events.toList)
 }
 final case class SingleEventSeq(event: Any) extends EventSeq { // TODO try to make it a value class, would save allocations
-  override val events: immutable.Seq[Any] = List(event)
+  override val events: Seq[Any] = List(event)
   override def toString = s"SingleEventSeq($event)"
 }
 
@@ -123,7 +122,7 @@ object EmptyEventSeq extends EmptyEventSeq {
   override def events = Nil
 }
 
-final case class EventsSeq[E](events: immutable.Seq[E]) extends EventSeq
+final case class EventsSeq[E](events: Seq[E]) extends EventSeq
 
 /** No-op model adapter which passes through the incoming events as-is. */
 case object IdentityEventAdapter extends EventAdapter {

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapters.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapters.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.persistence.journal
 import java.util
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.immutable
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.util.Try
@@ -32,7 +31,7 @@ import com.typesafe.config.Config
  */
 class EventAdapters(
     map: ConcurrentHashMap[Class[?], EventAdapter],
-    bindings: immutable.Seq[(Class[?], EventAdapter)],
+    bindings: Seq[(Class[?], EventAdapter)],
     log: LoggingAdapter) {
 
   /**
@@ -69,7 +68,7 @@ class EventAdapters(
 /** INTERNAL API */
 private[pekko] object EventAdapters {
   type Name = String
-  type BoundAdapters = immutable.Seq[String]
+  type BoundAdapters = Seq[String]
   type FQN = String
   type ClassHandler = (Class[?], EventAdapter)
 
@@ -102,7 +101,7 @@ private[pekko] object EventAdapters {
 
     // bindings is a Seq of tuple representing the mapping from Class to handler.
     // It is primarily ordered by the most specific classes first, and secondly in the configured order.
-    val bindings: immutable.Seq[ClassHandler] = {
+    val bindings: Seq[ClassHandler] = {
       val bs =
         for ((k: FQN, as: BoundAdapters) <- adapterBindings)
           yield
@@ -135,7 +134,7 @@ private[pekko] object EventAdapters {
   }
 
   /** INTERNAL API */
-  private[pekko] case class CombinedReadEventAdapter(adapters: immutable.Seq[EventAdapter]) extends EventAdapter {
+  private[pekko] case class CombinedReadEventAdapter(adapters: Seq[EventAdapter]) extends EventAdapter {
     private def onlyReadSideException =
       new IllegalStateException("CombinedReadEventAdapter must not be used when writing (creating manifests) events!")
     override def manifest(event: Any): String = throw onlyReadSideException
@@ -161,7 +160,7 @@ private[pekko] object EventAdapters {
    * Sort so that subtypes always precede their supertypes, but without
    * obeying any order between unrelated subtypes (insert sort).
    */
-  private def sort[T](in: Iterable[(Class[?], T)]): immutable.Seq[(Class[?], T)] =
+  private def sort[T](in: Iterable[(Class[?], T)]): Seq[(Class[?], T)] =
     in.foldLeft(new ArrayBuffer[(Class[?], T)](in.size)) { (buf, ca) =>
       buf.indexWhere(_._1.isAssignableFrom(ca._1)) match {
         case -1 => buf.append(ca)
@@ -169,7 +168,7 @@ private[pekko] object EventAdapters {
       }
       buf
     }
-      .to(immutable.Seq)
+      .to(Seq)
 
   private final def configToMap(config: Config, path: String): Map[String, String] = {
     import scala.jdk.CollectionConverters._
@@ -178,7 +177,7 @@ private[pekko] object EventAdapters {
     } else Map.empty
   }
 
-  private final def configToListMap(config: Config, path: String): Map[String, immutable.Seq[String]] = {
+  private final def configToListMap(config: Config, path: String): Map[String, Seq[String]] = {
     import scala.jdk.CollectionConverters._
     if (config.hasPath(path)) {
       config.getConfig(path).root.unwrapped.asScala.toMap.map {

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/WriteJournalBase.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/WriteJournalBase.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.persistence.journal
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor.Actor
 import pekko.persistence.{ Persistence, PersistentEnvelope, PersistentRepr }
@@ -26,7 +24,7 @@ private[pekko] trait WriteJournalBase {
   val persistence = Persistence(context.system)
   private val eventAdapters = persistence.adaptersFor(self)
 
-  protected def preparePersistentBatch(rb: immutable.Seq[PersistentEnvelope]): immutable.Seq[AtomicWrite] =
+  protected def preparePersistentBatch(rb: Seq[PersistentEnvelope]): Seq[AtomicWrite] =
     rb.collect { // collect instead of flatMap to avoid Some allocations
       case a: AtomicWrite =>
         // don't store sender
@@ -34,7 +32,7 @@ private[pekko] trait WriteJournalBase {
     }
 
   /** INTERNAL API */
-  private[pekko] final def adaptFromJournal(repr: PersistentRepr): immutable.Seq[PersistentRepr] =
+  private[pekko] final def adaptFromJournal(repr: PersistentRepr): Seq[PersistentRepr] =
     eventAdapters.get(repr.payload.getClass).fromJournal(repr.payload, repr.manifest).events.map { adaptedPayload =>
       repr.withPayload(adaptedPayload)
     }

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/inmem/InmemJournal.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/inmem/InmemJournal.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.journal.inmem
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.jdk.DurationConverters._
@@ -90,7 +89,7 @@ object InmemJournal {
 
   private val eventStream = context.system.eventStream
 
-  override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     try {
       for (w <- messages; p <- w.payload) {
         val payload = p.payload match {
@@ -190,7 +189,7 @@ object InmemJournal {
     case None     => messages
   }
 
-  def read(pid: String, fromSnr: Long, toSnr: Long, max: Long): immutable.Seq[(PersistentRepr, OptionVal[Any])] =
+  def read(pid: String, fromSnr: Long, toSnr: Long, max: Long): Seq[(PersistentRepr, OptionVal[Any])] =
     messages.get(pid) match {
       case Some(ms) => ms.filter(m => m._1.sequenceNr >= fromSnr && m._1.sequenceNr <= toSnr).take(safeLongToInt(max))
       case None     => Nil

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/japi/AsyncWriteJournal.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/japi/AsyncWriteJournal.scala
@@ -32,7 +32,7 @@ import pekko.util.ConstantFun.scalaAnyToUnit
 abstract class AsyncWriteJournal extends AsyncRecovery with SAsyncWriteJournal with AsyncWritePlugin {
   import SAsyncWriteJournal.successUnit
 
-  final def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] =
+  final def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] =
     doAsyncWriteMessages(messages.asJava).asScala.map { results =>
       results.asScala.iterator
         .map { r =>

--- a/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/LeveldbStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/journal/leveldb/LeveldbStore.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.journal.leveldb
 
 import java.io.File
 
-import scala.collection.immutable
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
@@ -84,7 +83,7 @@ private[persistence] trait LeveldbStore
 
   import Key._
 
-  def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+  def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     var persistenceIds = Set.empty[String]
     var allTags = Set.empty[String]
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/local/LocalSnapshotStore.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/local/LocalSnapshotStore.scala
@@ -104,12 +104,12 @@ private[persistence] class LocalSnapshotStore(config: Config) extends SnapshotSt
     case _: DeleteSnapshotsFailure     => // ignore
   }
 
-  private def snapshotFiles(metadata: SnapshotMetadata): immutable.Seq[File] = {
+  private def snapshotFiles(metadata: SnapshotMetadata): Seq[File] = {
     snapshotDir().listFiles(new SnapshotSeqNrFilenameFilter(metadata)).toVector
   }
 
   @scala.annotation.tailrec
-  private def load(metadata: immutable.Seq[SnapshotMetadata]): Try[Option[SelectedSnapshot]] =
+  private def load(metadata: Seq[SnapshotMetadata]): Try[Option[SelectedSnapshot]] =
     metadata.lastOption match {
       case None     => Success(None) // no snapshots stored
       case Some(md) =>
@@ -162,7 +162,7 @@ private[persistence] class LocalSnapshotStore(config: Config) extends SnapshotSt
 
   private def snapshotMetadatas(
       persistenceId: String,
-      criteria: SnapshotSelectionCriteria): immutable.Seq[SnapshotMetadata] = {
+      criteria: SnapshotSelectionCriteria): Seq[SnapshotMetadata] = {
     val files = snapshotDir().listFiles(new SnapshotFilenameFilter(persistenceId))
     if (files eq null) Nil // if the dir was removed
     else {

--- a/persistence/src/test/scala/org/apache/pekko/persistence/EventSourcedActorFailureSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/EventSourcedActorFailureSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.{ Failure, Try }
 import scala.util.control.NoStackTrace
@@ -32,7 +31,7 @@ object EventSourcedActorFailureSpec {
 
   class FailingInmemJournal extends InmemJournal {
 
-    override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+    override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
       if (isWrong(messages)) throw new SimulatedException("Simulated Store failure")
       else {
         val ser = checkSerializable(messages)
@@ -57,7 +56,7 @@ object EventSourcedActorFailureSpec {
       }
     }
 
-    def isWrong(messages: immutable.Seq[AtomicWrite]): Boolean =
+    def isWrong(messages: Seq[AtomicWrite]): Boolean =
       messages.exists { a =>
         a.payload.exists {
           case PersistentRepr(Evt(s: String), _) => s.contains("wrong")
@@ -65,7 +64,7 @@ object EventSourcedActorFailureSpec {
         }
       }
 
-    def checkSerializable(messages: immutable.Seq[AtomicWrite]): immutable.Seq[Try[Unit]] =
+    def checkSerializable(messages: Seq[AtomicWrite]): Seq[Try[Unit]] =
       messages.collect {
         case a: AtomicWrite =>
           a.payload.collectFirst {

--- a/persistence/src/test/scala/org/apache/pekko/persistence/PersistenceSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/PersistenceSpec.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.persistence
 import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.control.NoStackTrace
 
@@ -120,8 +119,8 @@ case object GetState
 trait PersistenceMatchers {
 
   /** Use this matcher to verify in-order execution of independent "streams" of events */
-  final class IndependentlyOrdered(prefixes: immutable.Seq[String]) extends Matcher[immutable.Seq[Any]] {
-    override def apply(_left: immutable.Seq[Any]) = {
+  final class IndependentlyOrdered(prefixes: Seq[String]) extends Matcher[Seq[Any]] {
+    override def apply(_left: Seq[Any]) = {
       val left = _left.map(_.toString)
       val mapped = left.groupBy(l => prefixes.indexWhere(p => l.startsWith(p))) - -1 // ignore other messages
       val results =

--- a/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorReplayBatchingSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorReplayBatchingSpec.scala
@@ -17,7 +17,6 @@
 
 package org.apache.pekko.persistence
 
-import scala.collection.immutable
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.Try
@@ -79,7 +78,7 @@ final class RestartingReplayJournal extends AsyncWriteJournal {
   }
 
   override def asyncWriteMessages(
-      messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = Future.successful(Nil)
+      messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = Future.successful(Nil)
 
   override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] =
     Future.successful(())

--- a/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/PersistentActorSpec.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.persistence
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.annotation.nowarn
-import scala.collection.immutable.Seq
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Random

--- a/persistence/src/test/scala/org/apache/pekko/persistence/journal/AsyncWriteJournalResponseOrderSpec.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/journal/AsyncWriteJournalResponseOrderSpec.scala
@@ -17,7 +17,7 @@
 
 package org.apache.pekko.persistence.journal
 
-import scala.collection.{ immutable, mutable }
+import scala.collection.mutable
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.Try
 
@@ -130,7 +130,7 @@ private object AsyncWriteJournalResponseOrderSpec {
         }
     }
 
-    override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+    override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
       val responsePromise = Promise[Unit]()
       pendingOps.put(messages.head.persistenceId.toInt, responsePromise)
       responsePromise.future.map(_ => Vector.empty)

--- a/persistence/src/test/scala/org/apache/pekko/persistence/journal/SteppingInmemJournal.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/journal/SteppingInmemJournal.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.persistence.journal
 
-import scala.collection.immutable.Seq
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.Try

--- a/persistence/src/test/scala/org/apache/pekko/persistence/journal/chaos/ChaosJournal.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/journal/chaos/ChaosJournal.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.persistence.journal.chaos
 
 import java.util.concurrent.ThreadLocalRandom
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -50,7 +49,7 @@ class ChaosJournal extends AsyncWriteJournal {
 
   def random = ThreadLocalRandom.current
 
-  override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] =
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] =
     try Future.successful {
         if (shouldFail(writeFailureRate)) throw new WriteFailedException(messages.flatMap(_.payload))
         else

--- a/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/RemoteSettings.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.remote
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -193,7 +192,7 @@ final class RemoteSettings(val config: Config) {
     WatchFailureDetectorConfig.getMillisDuration("expected-response-after")
   }.requiring(_ > Duration.Zero, "watch-failure-detector.expected-response-after > 0")
 
-  val Transports: immutable.Seq[(String, immutable.Seq[String], Config)] = transportNames.map { name =>
+  val Transports: Seq[(String, Seq[String], Config)] = transportNames.map { name =>
     val transportConfig = transportConfigFor(name)
     (
       transportConfig.getString("transport-class"),
@@ -229,7 +228,7 @@ final class RemoteSettings(val config: Config) {
     set
   }
 
-  private def transportNames: immutable.Seq[String] =
+  private def transportNames: Seq[String] =
     immutableSeq(getStringList("pekko.remote.classic.enabled-transports"))
 
   private def transportConfigFor(transportName: String): Config = getConfig(transportName)

--- a/remote/src/main/scala/org/apache/pekko/remote/Remoting.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/Remoting.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeoutException
 
 import scala.annotation.nowarn
 import scala.collection.immutable
-import scala.collection.immutable.{ HashMap, Seq }
+import scala.collection.immutable.HashMap
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
@@ -688,7 +688,7 @@ private[remote] class EndpointManager(conf: Config, log: LoggingAdapter)
 
   val accepting: Receive = {
     case ManagementCommand(cmd) =>
-      val allStatuses: immutable.Seq[Future[Boolean]] =
+      val allStatuses: Seq[Future[Boolean]] =
         transportMapping.values.iterator.map(transport => transport.managementCommand(cmd)).to(immutable.IndexedSeq)
       Future.foldLeft(allStatuses)(true)(_ && _).map(ManagementCommandAck.apply).pipeTo(sender())
 

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/ArterySettings.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/ArterySettings.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.remote.artery
 import java.net.InetAddress
 import java.nio.charset.StandardCharsets
 
-import scala.collection.immutable
 import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -120,7 +119,7 @@ private[pekko] final class ArterySettings private (config: Config) {
     import config._
 
     val TestMode: Boolean = getBoolean("test-mode")
-    private val tcpMagicList: immutable.Seq[String] = {
+    private val tcpMagicList: Seq[String] = {
       val list = getStringList("tcp-magic").asScala.toSeq
       require(list.nonEmpty, "tcp-magic must not be empty")
       list
@@ -134,7 +133,7 @@ private[pekko] final class ArterySettings private (config: Config) {
     }
     // A Seq rather than a Set: a Set hashes its members, and hashing a ByteString walks all its
     // bytes, where comparing this handful of 4-byte values is a couple of cheap equality checks.
-    val TcpMagicValues: immutable.Seq[ByteString] = {
+    val TcpMagicValues: Seq[ByteString] = {
       tcpMagicList.map { s =>
         val bytes = ByteString(s.getBytes(StandardCharsets.UTF_8))
         require(bytes.length >= 4,

--- a/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/TcpFraming.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/artery/tcp/TcpFraming.scala
@@ -17,8 +17,6 @@ package tcp
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.Attributes
@@ -78,7 +76,7 @@ import pekko.util.ByteString
  * INTERNAL API
  */
 @InternalApi private[pekko] class TcpFraming(
-    acceptedMagic: immutable.Seq[ByteString] = List(TcpFraming.DefaultMagic),
+    acceptedMagic: Seq[ByteString] = List(TcpFraming.DefaultMagic),
     flightRecorder: RemotingFlightRecorder = NoOpRemotingFlightRecorder,
     maximumFrameSize: Int = Int.MaxValue,
     maximumLargeFrameSize: Int = Int.MaxValue)

--- a/remote/src/main/scala/org/apache/pekko/remote/transport/AbstractTransportAdapter.scala
+++ b/remote/src/main/scala/org/apache/pekko/remote/transport/AbstractTransportAdapter.scala
@@ -44,7 +44,7 @@ class TransportAdapters(system: ExtendedActorSystem) extends Extension {
   private val adaptersTable: Map[String, TransportAdapterProvider] = for ((name, fqn) <- settings.Adapters) yield {
     name ->
     system.dynamicAccess
-      .createInstanceFor[TransportAdapterProvider](fqn, immutable.Seq.empty)
+      .createInstanceFor[TransportAdapterProvider](fqn, Seq.empty)
       .recover {
         case e => throw new IllegalArgumentException(s"Cannot instantiate transport adapter [$fqn]", e)
       }

--- a/remote/src/test/scala/org/apache/pekko/remote/RemoteRouterSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/RemoteRouterSpec.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.remote
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor._
 import pekko.remote.routing._
@@ -107,7 +105,7 @@ class RemoteRouterSpec extends PekkoSpec(s"""
     shutdown(masterSystem)
   }
 
-  def collectRouteePaths(probe: TestProbe, router: ActorRef, n: Int): immutable.Seq[ActorPath] = {
+  def collectRouteePaths(probe: TestProbe, router: ActorRef, n: Int): Seq[ActorPath] = {
     for (i <- 1 to n) yield {
       val msg = i.toString
       router.tell(msg, probe.ref)

--- a/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteRouterSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/artery/RemoteRouterSpec.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.remote.artery
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.actor._
 import pekko.remote.{ RARP, RemoteScope }
@@ -97,7 +95,7 @@ class RemoteRouterSpec
     shutdown(masterSystem)
   }
 
-  def collectRouteePaths(probe: TestProbe, router: ActorRef, n: Int): immutable.Seq[ActorPath] = {
+  def collectRouteePaths(probe: TestProbe, router: ActorRef, n: Int): Seq[ActorPath] = {
     for (i <- 1 to n) yield {
       val msg = i.toString
       router.tell(msg, probe.ref)

--- a/remote/src/test/scala/org/apache/pekko/remote/classic/ActorsLeakSpec.scala
+++ b/remote/src/test/scala/org/apache/pekko/remote/classic/ActorsLeakSpec.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.remote.classic
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -47,7 +46,7 @@ object ActorsLeakSpec {
        pekko.actor.warn-about-java-serializer-usage = off
       """)
 
-  def collectLiveActors(root: Option[ActorRef]): immutable.Seq[ActorRef] = {
+  def collectLiveActors(root: Option[ActorRef]): Seq[ActorRef] = {
 
     def recurse(node: ActorRef): List[ActorRef] = {
       val children: List[ActorRef] = node match {
@@ -68,7 +67,7 @@ object ActorsLeakSpec {
 
     root match {
       case Some(node) => recurse(node)
-      case None       => immutable.Seq.empty
+      case None       => Seq.empty
     }
   }
 

--- a/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson/src/main/scala/org/apache/pekko/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -17,7 +17,6 @@ import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.jdk.OptionConverters._
 import scala.util.{ Failure, Success }
 
@@ -245,7 +244,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       objectMapperFactory: JacksonObjectMapperFactory,
       config: Config): Unit = {
 
-    val configuredVisibility: immutable.Seq[(PropertyAccessor, JsonAutoDetect.Visibility)] =
+    val configuredVisibility: Seq[(PropertyAccessor, JsonAutoDetect.Visibility)] =
       configPairs(config, "visibility").map {
         case (property, visibility) =>
           PropertyAccessor.valueOf(property) -> JsonAutoDetect.Visibility.valueOf(visibility)
@@ -339,13 +338,13 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       case _ => true
     }
 
-  private def features(config: Config, section: String): immutable.Seq[(String, Boolean)] = {
+  private def features(config: Config, section: String): Seq[(String, Boolean)] = {
     import scala.jdk.CollectionConverters._
     val cfg = config.getConfig(section)
     cfg.root.keySet().asScala.map(key => key -> cfg.getBoolean(key)).toList
   }
 
-  private def configPairs(config: Config, section: String): immutable.Seq[(String, String)] = {
+  private def configPairs(config: Config, section: String): Seq[(String, String)] = {
     import scala.jdk.CollectionConverters._
     val cfg = config.getConfig(section)
     cfg.root.keySet().asScala.map(key => key -> cfg.getString(key)).toList
@@ -481,7 +480,7 @@ class JacksonObjectMapperFactory {
    * the mapper. These modules can be amended programmatically by overriding this method and
    * return the modules that are to be applied to the `ObjectMapper`.
    *
-   * When implementing a `JacksonObjectMapperFactory` with Java the `immutable.Seq` can be
+   * When implementing a `JacksonObjectMapperFactory` with Java the `Seq` can be
    * created with `Util.immutableSeq`.
    *
    * @param bindingName bindingName name of this `ObjectMapper`
@@ -490,7 +489,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredModules(
       @nowarn("msg=never used") bindingName: String,
-      configuredModules: immutable.Seq[Module]): immutable.Seq[Module] =
+      configuredModules: Seq[Module]): Seq[Module] =
     configuredModules
 
   /**
@@ -498,7 +497,7 @@ class JacksonObjectMapperFactory {
    * the mapper. These features can be amended programmatically by overriding this method and
    * return the features that are to be applied to the `ObjectMapper`.
    *
-   * When implementing a `JacksonObjectMapperFactory` with Java the `immutable.Seq` can be
+   * When implementing a `JacksonObjectMapperFactory` with Java the `Seq` can be
    * created with `Util.immutableSeq`.
    *
    * @param bindingName bindingName name of this `ObjectMapper`
@@ -507,8 +506,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredSerializationFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(SerializationFeature, Boolean)])
-      : immutable.Seq[(SerializationFeature, Boolean)] =
+      configuredFeatures: Seq[(SerializationFeature, Boolean)])
+      : Seq[(SerializationFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -516,7 +515,7 @@ class JacksonObjectMapperFactory {
    * the mapper. These features can be amended programmatically by overriding this method and
    * return the features that are to be applied to the `ObjectMapper`.
    *
-   * When implementing a `JacksonObjectMapperFactory` with Java the `immutable.Seq` can be
+   * When implementing a `JacksonObjectMapperFactory` with Java the `Seq` can be
    * created with `Util.immutableSeq`.
    *
    * @param bindingName bindingName name of this `ObjectMapper`
@@ -525,8 +524,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredDeserializationFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(DeserializationFeature, Boolean)])
-      : immutable.Seq[(DeserializationFeature, Boolean)] =
+      configuredFeatures: Seq[(DeserializationFeature, Boolean)])
+      : Seq[(DeserializationFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -534,7 +533,7 @@ class JacksonObjectMapperFactory {
    * the mapper. These features can be amended programmatically by overriding this method and
    * return the features that are to be applied to the `ObjectMapper`.
    *
-   * When implementing a `JacksonObjectMapperFactory` with Java the `immutable.Seq` can be
+   * When implementing a `JacksonObjectMapperFactory` with Java the `Seq` can be
    * created with `Util.immutableSeq`.
    *
    * @param bindingName bindingName name of this `ObjectMapper`
@@ -543,8 +542,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredEnumFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(EnumFeature, Boolean)])
-      : immutable.Seq[(EnumFeature, Boolean)] =
+      configuredFeatures: Seq[(EnumFeature, Boolean)])
+      : Seq[(EnumFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -557,7 +556,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredMapperFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(MapperFeature, Boolean)]): immutable.Seq[(MapperFeature, Boolean)] =
+      configuredFeatures: Seq[(MapperFeature, Boolean)]): Seq[(MapperFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -570,7 +569,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredJsonParserFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(JsonParser.Feature, Boolean)]): immutable.Seq[(JsonParser.Feature, Boolean)] =
+      configuredFeatures: Seq[(JsonParser.Feature, Boolean)]): Seq[(JsonParser.Feature, Boolean)] =
     configuredFeatures
 
   /**
@@ -583,8 +582,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredJsonGeneratorFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(JsonGenerator.Feature, Boolean)])
-      : immutable.Seq[(JsonGenerator.Feature, Boolean)] =
+      configuredFeatures: Seq[(JsonGenerator.Feature, Boolean)])
+      : Seq[(JsonGenerator.Feature, Boolean)] =
     configuredFeatures
 
   /**
@@ -597,7 +596,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredStreamReadFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(StreamReadFeature, Boolean)]): immutable.Seq[(StreamReadFeature, Boolean)] =
+      configuredFeatures: Seq[(StreamReadFeature, Boolean)]): Seq[(StreamReadFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -610,7 +609,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredStreamWriteFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(StreamWriteFeature, Boolean)]): immutable.Seq[(StreamWriteFeature, Boolean)] =
+      configuredFeatures: Seq[(StreamWriteFeature, Boolean)]): Seq[(StreamWriteFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -623,7 +622,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredJsonReadFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(JsonReadFeature, Boolean)]): immutable.Seq[(JsonReadFeature, Boolean)] =
+      configuredFeatures: Seq[(JsonReadFeature, Boolean)]): Seq[(JsonReadFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -636,7 +635,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredJsonWriteFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(JsonWriteFeature, Boolean)]): immutable.Seq[(JsonWriteFeature, Boolean)] =
+      configuredFeatures: Seq[(JsonWriteFeature, Boolean)]): Seq[(JsonWriteFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -650,8 +649,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredVisibility(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(PropertyAccessor, JsonAutoDetect.Visibility)])
-      : immutable.Seq[(PropertyAccessor, JsonAutoDetect.Visibility)] =
+      configuredFeatures: Seq[(PropertyAccessor, JsonAutoDetect.Visibility)])
+      : Seq[(PropertyAccessor, JsonAutoDetect.Visibility)] =
     configuredFeatures
 
 }

--- a/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
+++ b/serialization-jackson/src/test/scala/org/apache/pekko/serialization/jackson/JacksonSerializerSpec.scala
@@ -27,7 +27,6 @@ import java.util.UUID
 import java.util.logging.FileHandler
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 
@@ -517,8 +516,8 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredSerializationFeatures(
             bindingName: String,
-            configuredFeatures: immutable.Seq[(SerializationFeature, Boolean)])
-            : immutable.Seq[(SerializationFeature, Boolean)] = {
+            configuredFeatures: Seq[(SerializationFeature, Boolean)])
+            : Seq[(SerializationFeature, Boolean)] = {
           if (bindingName == "jackson-json")
             configuredFeatures :+ (SerializationFeature.INDENT_OUTPUT -> true)
           else
@@ -527,7 +526,7 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredModules(
             bindingName: String,
-            configuredModules: immutable.Seq[Module]): immutable.Seq[Module] =
+            configuredModules: Seq[Module]): Seq[Module] =
           if (bindingName == "jackson-json")
             configuredModules.filterNot(_.isInstanceOf[JavaTimeModule]) :+ customJavaTimeModule
           else
@@ -535,7 +534,7 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredMapperFeatures(
             bindingName: String,
-            configuredFeatures: immutable.Seq[(MapperFeature, Boolean)]): immutable.Seq[(MapperFeature, Boolean)] =
+            configuredFeatures: Seq[(MapperFeature, Boolean)]): Seq[(MapperFeature, Boolean)] =
           if (bindingName == "jackson-json")
             configuredFeatures :+ (MapperFeature.SORT_PROPERTIES_ALPHABETICALLY -> true)
           else
@@ -543,8 +542,8 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredJsonParserFeatures(
             bindingName: String,
-            configuredFeatures: immutable.Seq[(JsonParser.Feature, Boolean)])
-            : immutable.Seq[(JsonParser.Feature, Boolean)] =
+            configuredFeatures: Seq[(JsonParser.Feature, Boolean)])
+            : Seq[(JsonParser.Feature, Boolean)] =
           if (bindingName == "jackson-json")
             configuredFeatures :+ (JsonParser.Feature.ALLOW_SINGLE_QUOTES -> true)
           else
@@ -552,8 +551,8 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredJsonGeneratorFeatures(
             bindingName: String,
-            configuredFeatures: immutable.Seq[(JsonGenerator.Feature, Boolean)])
-            : immutable.Seq[(JsonGenerator.Feature, Boolean)] =
+            configuredFeatures: Seq[(JsonGenerator.Feature, Boolean)])
+            : Seq[(JsonGenerator.Feature, Boolean)] =
           if (bindingName == "jackson-json")
             configuredFeatures :+ (JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN -> true)
           else

--- a/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonObjectMapperProvider.scala
+++ b/serialization-jackson3/src/main/scala/org/apache/pekko/serialization/jackson3/JacksonObjectMapperProvider.scala
@@ -17,7 +17,6 @@ import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 import scala.util.{ Failure, Success }
@@ -329,7 +328,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       objectMapperFactory: JacksonObjectMapperFactory,
       config: Config): MapperBuilder[ObjectMapper, ?] = {
 
-    val configuredVisibility: immutable.Seq[(PropertyAccessor, JsonAutoDetect.Visibility)] =
+    val configuredVisibility: Seq[(PropertyAccessor, JsonAutoDetect.Visibility)] =
       configPairs(config, "visibility").map {
         case (property, visibility) =>
           PropertyAccessor.valueOf(property) -> JsonAutoDetect.Visibility.valueOf(visibility)
@@ -385,7 +384,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
     builder
   }
 
-  private def configPairs(config: Config, section: String): immutable.Seq[(String, String)] = {
+  private def configPairs(config: Config, section: String): Seq[(String, String)] = {
     val cfg = config.getConfig(section)
     cfg.root.keySet().asScala.map(key => key -> cfg.getString(key)).toList
   }
@@ -444,7 +443,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       case _ => true
     }
 
-  private def features(config: Config, section: String): immutable.Seq[(String, Boolean)] = {
+  private def features(config: Config, section: String): Seq[(String, Boolean)] = {
     val cfg = config.getConfig(section)
     cfg.root.keySet().asScala.map(key => key -> cfg.getBoolean(key)).toList
   }
@@ -618,7 +617,7 @@ class JacksonObjectMapperFactory {
    * the mapper. These modules can be amended programmatically by overriding this method and
    * return the modules that are to be applied to the `ObjectMapper`.
    *
-   * When implementing a `JacksonObjectMapperFactory` with Java the `immutable.Seq` can be
+   * When implementing a `JacksonObjectMapperFactory` with Java the `Seq` can be
    * created with [[pekko.japi.Util.immutableSeq]].
    *
    * @param bindingName bindingName name of this `ObjectMapper`
@@ -627,7 +626,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredModules(
       @nowarn("msg=never used") bindingName: String,
-      configuredModules: immutable.Seq[JacksonModule]): immutable.Seq[JacksonModule] =
+      configuredModules: Seq[JacksonModule]): Seq[JacksonModule] =
     configuredModules
 
   /**
@@ -635,7 +634,7 @@ class JacksonObjectMapperFactory {
    * the mapper. These features can be amended programmatically by overriding this method and
    * return the features that are to be applied to the `ObjectMapper`.
    *
-   * When implementing a `JacksonObjectMapperFactory` with Java the `immutable.Seq` can be
+   * When implementing a `JacksonObjectMapperFactory` with Java the `Seq` can be
    * created with [[pekko.japi.Util.immutableSeq]].
    *
    * @param bindingName bindingName name of this `ObjectMapper`
@@ -644,8 +643,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredSerializationFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(SerializationFeature, Boolean)])
-      : immutable.Seq[(SerializationFeature, Boolean)] =
+      configuredFeatures: Seq[(SerializationFeature, Boolean)])
+      : Seq[(SerializationFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -653,7 +652,7 @@ class JacksonObjectMapperFactory {
    * the mapper. These features can be amended programmatically by overriding this method and
    * return the features that are to be applied to the `ObjectMapper`.
    *
-   * When implementing a `JacksonObjectMapperFactory` with Java the `immutable.Seq` can be
+   * When implementing a `JacksonObjectMapperFactory` with Java the `Seq` can be
    * created with [[pekko.japi.Util.immutableSeq]].
    *
    * @param bindingName bindingName name of this `ObjectMapper`
@@ -662,8 +661,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredDeserializationFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(DeserializationFeature, Boolean)])
-      : immutable.Seq[(DeserializationFeature, Boolean)] =
+      configuredFeatures: Seq[(DeserializationFeature, Boolean)])
+      : Seq[(DeserializationFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -671,7 +670,7 @@ class JacksonObjectMapperFactory {
    * the mapper. These features can be amended programmatically by overriding this method and
    * return the features that are to be applied to the `ObjectMapper`.
    *
-   * When implementing a `JacksonObjectMapperFactory` with Java the `immutable.Seq` can be
+   * When implementing a `JacksonObjectMapperFactory` with Java the `Seq` can be
    * created with [[pekko.japi.Util.immutableSeq]].
    *
    * @param bindingName bindingName name of this `ObjectMapper`
@@ -680,8 +679,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredDateTimeFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(DateTimeFeature, Boolean)])
-      : immutable.Seq[(DateTimeFeature, Boolean)] =
+      configuredFeatures: Seq[(DateTimeFeature, Boolean)])
+      : Seq[(DateTimeFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -689,7 +688,7 @@ class JacksonObjectMapperFactory {
    * the mapper. These features can be amended programmatically by overriding this method and
    * return the features that are to be applied to the `ObjectMapper`.
    *
-   * When implementing a `JacksonObjectMapperFactory` with Java the `immutable.Seq` can be
+   * When implementing a `JacksonObjectMapperFactory` with Java the `Seq` can be
    * created with [[pekko.japi.Util.immutableSeq]].
    *
    * @param bindingName bindingName name of this `ObjectMapper`
@@ -698,8 +697,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredEnumFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(EnumFeature, Boolean)])
-      : immutable.Seq[(EnumFeature, Boolean)] =
+      configuredFeatures: Seq[(EnumFeature, Boolean)])
+      : Seq[(EnumFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -712,7 +711,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredMapperFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(MapperFeature, Boolean)]): immutable.Seq[(MapperFeature, Boolean)] =
+      configuredFeatures: Seq[(MapperFeature, Boolean)]): Seq[(MapperFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -725,7 +724,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredJsonParserFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(StreamReadFeature, Boolean)]): immutable.Seq[(StreamReadFeature, Boolean)] =
+      configuredFeatures: Seq[(StreamReadFeature, Boolean)]): Seq[(StreamReadFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -738,8 +737,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredJsonGeneratorFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(StreamWriteFeature, Boolean)])
-      : immutable.Seq[(StreamWriteFeature, Boolean)] =
+      configuredFeatures: Seq[(StreamWriteFeature, Boolean)])
+      : Seq[(StreamWriteFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -752,7 +751,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredStreamReadFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(StreamReadFeature, Boolean)]): immutable.Seq[(StreamReadFeature, Boolean)] =
+      configuredFeatures: Seq[(StreamReadFeature, Boolean)]): Seq[(StreamReadFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -765,7 +764,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredStreamWriteFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(StreamWriteFeature, Boolean)]): immutable.Seq[(StreamWriteFeature, Boolean)] =
+      configuredFeatures: Seq[(StreamWriteFeature, Boolean)]): Seq[(StreamWriteFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -778,7 +777,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredJsonReadFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(JsonReadFeature, Boolean)]): immutable.Seq[(JsonReadFeature, Boolean)] =
+      configuredFeatures: Seq[(JsonReadFeature, Boolean)]): Seq[(JsonReadFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -791,7 +790,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredJsonWriteFeatures(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(JsonWriteFeature, Boolean)]): immutable.Seq[(JsonWriteFeature, Boolean)] =
+      configuredFeatures: Seq[(JsonWriteFeature, Boolean)]): Seq[(JsonWriteFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -805,8 +804,8 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredVisibility(
       @nowarn("msg=never used") bindingName: String,
-      configuredFeatures: immutable.Seq[(PropertyAccessor, JsonAutoDetect.Visibility)])
-      : immutable.Seq[(PropertyAccessor, JsonAutoDetect.Visibility)] =
+      configuredFeatures: Seq[(PropertyAccessor, JsonAutoDetect.Visibility)])
+      : Seq[(PropertyAccessor, JsonAutoDetect.Visibility)] =
     configuredFeatures
 
 }

--- a/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
+++ b/serialization-jackson3/src/test/scala/org/apache/pekko/serialization/jackson3/JacksonSerializerSpec.scala
@@ -22,7 +22,6 @@ import java.util.{ Arrays, Optional, UUID }
 import java.util.logging.FileHandler
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 
@@ -460,8 +459,8 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredSerializationFeatures(
             bindingName: String,
-            configuredFeatures: immutable.Seq[(SerializationFeature, Boolean)])
-            : immutable.Seq[(SerializationFeature, Boolean)] = {
+            configuredFeatures: Seq[(SerializationFeature, Boolean)])
+            : Seq[(SerializationFeature, Boolean)] = {
           if (bindingName == "jackson-json")
             configuredFeatures :+ (SerializationFeature.INDENT_OUTPUT -> true)
           else
@@ -470,7 +469,7 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredModules(
             bindingName: String,
-            configuredModules: immutable.Seq[JacksonModule]): immutable.Seq[JacksonModule] =
+            configuredModules: Seq[JacksonModule]): Seq[JacksonModule] =
           if (bindingName == "jackson-json")
             configuredModules :+ customJavaTimeModule
           else
@@ -478,7 +477,7 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredMapperFeatures(
             bindingName: String,
-            configuredFeatures: immutable.Seq[(MapperFeature, Boolean)]): immutable.Seq[(MapperFeature, Boolean)] =
+            configuredFeatures: Seq[(MapperFeature, Boolean)]): Seq[(MapperFeature, Boolean)] =
           if (bindingName == "jackson-json")
             configuredFeatures :+ (MapperFeature.SORT_PROPERTIES_ALPHABETICALLY -> true)
           else
@@ -486,8 +485,8 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredJsonParserFeatures(
             bindingName: String,
-            configuredFeatures: immutable.Seq[(StreamReadFeature, Boolean)])
-            : immutable.Seq[(StreamReadFeature, Boolean)] =
+            configuredFeatures: Seq[(StreamReadFeature, Boolean)])
+            : Seq[(StreamReadFeature, Boolean)] =
           if (bindingName == "jackson-json")
             configuredFeatures
           // configuredFeatures :+ (StreamReadFeature.ALLOW_SINGLE_QUOTES -> true)
@@ -496,8 +495,8 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
         override def overrideConfiguredJsonGeneratorFeatures(
             bindingName: String,
-            configuredFeatures: immutable.Seq[(StreamWriteFeature, Boolean)])
-            : immutable.Seq[(StreamWriteFeature, Boolean)] =
+            configuredFeatures: Seq[(StreamWriteFeature, Boolean)])
+            : Seq[(StreamWriteFeature, Boolean)] =
           if (bindingName == "jackson-json")
             configuredFeatures :+ (StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN -> true)
           else

--- a/stream-testkit/src/main/scala/org/apache/pekko/stream/testkit/StreamTestKit.scala
+++ b/stream-testkit/src/main/scala/org/apache/pekko/stream/testkit/StreamTestKit.scala
@@ -206,7 +206,7 @@ object TestPublisher {
      */
     def receiveWhile[T](max: Duration = Duration.Undefined,
         idle: Duration = Duration.Inf,
-        messages: Int = Int.MaxValue)(f: PartialFunction[PublisherEvent, T]): immutable.Seq[T] =
+        messages: Int = Int.MaxValue)(f: PartialFunction[PublisherEvent, T]): Seq[T] =
       executeAfterSubscription {
         probe.receiveWhile(max, idle, messages)(f.asInstanceOf[PartialFunction[AnyRef, T]])
       }
@@ -543,8 +543,8 @@ object TestSubscriber {
     /**
      * Expect and return the next `n` stream elements.
      */
-    def expectNextN(n: Long): immutable.Seq[I] = {
-      val b = immutable.Seq.newBuilder[I]
+    def expectNextN(n: Long): Seq[I] = {
+      val b = Seq.newBuilder[I]
       var i = 0
       while (i < n) {
         val next = probe.expectMsgType[OnNext[I]]
@@ -559,7 +559,7 @@ object TestSubscriber {
      * Fluent DSL
      * Expect the given elements to be signalled in order.
      */
-    def expectNextN(all: immutable.Seq[I]): this.type = {
+    def expectNextN(all: Seq[I]): this.type = {
       all.foreach(e => probe.expectMsg(OnNext(e)))
       this
     }
@@ -578,9 +578,9 @@ object TestSubscriber {
      * Fluent DSL
      * Expect the given elements to be signalled in any order.
      */
-    def expectNextUnorderedN(all: immutable.Seq[I]): this.type = {
+    def expectNextUnorderedN(all: Seq[I]): this.type = {
       @annotation.tailrec
-      def expectOneOf(all: immutable.Seq[I]): Unit = all match {
+      def expectOneOf(all: Seq[I]): Unit = all match {
         case Nil =>
         case _   =>
           val next = expectNext()
@@ -875,7 +875,7 @@ object TestSubscriber {
     def receiveWhile[T](
         max: Duration = Duration.Undefined,
         idle: Duration = Duration.Inf,
-        messages: Int = Int.MaxValue)(f: PartialFunction[SubscriberEvent, T]): immutable.Seq[T] =
+        messages: Int = Int.MaxValue)(f: PartialFunction[SubscriberEvent, T]): Seq[T] =
       probe.receiveWhile(max, idle, messages)(f.asInstanceOf[PartialFunction[AnyRef, T]])
 
     /**
@@ -894,7 +894,7 @@ object TestSubscriber {
     /**
      * Drains a given number of messages
      */
-    def receiveWithin(max: FiniteDuration, messages: Int = Int.MaxValue): immutable.Seq[I] =
+    def receiveWithin(max: FiniteDuration, messages: Int = Int.MaxValue): Seq[I] =
       probe
         .receiveWhile(max, max, messages) {
           case OnNext(i) => Some(i.asInstanceOf[I])
@@ -916,11 +916,11 @@ object TestSubscriber {
      *
      * '''Use with caution: Be warned that this may not be a good idea if the stream is infinite or its elements are very large!'''
      */
-    def toStrict(atMost: FiniteDuration): immutable.Seq[I] = {
+    def toStrict(atMost: FiniteDuration): Seq[I] = {
       val deadline = Deadline.now + atMost
-      val b = immutable.Seq.newBuilder[I]
+      val b = Seq.newBuilder[I]
 
-      @tailrec def drain(): immutable.Seq[I] =
+      @tailrec def drain(): Seq[I] =
         this.expectEvent(deadline.timeLeft) match {
           case OnError(ex) =>
             throw new AssertionError(

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/TcpSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/TcpSpec.scala
@@ -84,7 +84,7 @@ class FailingDnsResolver extends DnsProvider {
         request: DnsProtocol.Resolve,
         system: ActorSystem,
         sender: ActorRef): Option[DnsProtocol.Resolved] = {
-      sender ! DnsProtocol.Resolved(request.name, immutable.Seq.empty, immutable.Seq.empty)
+      sender ! DnsProtocol.Resolved(request.name, Seq.empty, Seq.empty)
       None
     }
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/io/TlsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/io/TlsSpec.scala
@@ -19,7 +19,6 @@ import java.security.cert.CertificateException
 import java.util.concurrent.TimeoutException
 import javax.net.ssl._
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
@@ -283,7 +282,7 @@ abstract class AbstractTlsSpec(useLegacyActor: Boolean)
         def leftClosing: TLSClosing = IgnoreComplete
         def rightClosing: TLSClosing = IgnoreComplete
 
-        def inputs: immutable.Seq[SslTlsOutbound]
+        def inputs: Seq[SslTlsOutbound]
         def output: ByteString
 
         protected def send(str: String) = SendBytes(ByteString(str))
@@ -325,7 +324,7 @@ abstract class AbstractTlsSpec(useLegacyActor: Boolean)
       }
 
       object CompletedImmediately extends PayloadScenario {
-        override def inputs: immutable.Seq[SslTlsOutbound] = Nil
+        override def inputs: Seq[SslTlsOutbound] = Nil
         override def output = ByteString.empty
 
         override def leftClosing: TLSClosing = EagerClose

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AggregateWithBoundarySpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/AggregateWithBoundarySpec.scala
@@ -34,7 +34,7 @@ class AggregateWithBoundarySpec extends StreamSpec {
 
   "split aggregator by size" in {
 
-    val stream = collection.immutable.Seq(1, 2, 3, 4, 5, 6, 7)
+    val stream = Seq(1, 2, 3, 4, 5, 6, 7)
     val groupSize = 3
     val result = Source(stream)
       .aggregateWithBoundary(allocate = () => ListBuffer.empty[Int])(aggregate = (buffer, i) => {
@@ -48,7 +48,7 @@ class AggregateWithBoundarySpec extends StreamSpec {
   }
 
   "split aggregator by size and harvest" in {
-    val stream = collection.immutable.Seq(1, 2, 3, 4, 5, 6, 7)
+    val stream = Seq(1, 2, 3, 4, 5, 6, 7)
     val groupSize = 3
     val result = Source(stream)
       .aggregateWithBoundary(allocate = () => ListBuffer.empty[Int])(
@@ -65,7 +65,7 @@ class AggregateWithBoundarySpec extends StreamSpec {
   }
 
   "split aggregator by custom weight condition" in {
-    val stream = collection.immutable.Seq(1, 2, 3, 4, 5, 6, 7)
+    val stream = Seq(1, 2, 3, 4, 5, 6, 7)
     val weight = 10
 
     val result = Source(stream)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/BidiFlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/BidiFlowSpec.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.stream.scaladsl
 import java.nio.charset.StandardCharsets
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -112,7 +111,7 @@ class BidiFlowSpec extends StreamSpec {
         flow             ~> merge
         FlowShape(flow.in, merge.out)
       })
-      val right = Flow.fromGraph(GraphDSL.createGraph(Sink.head[immutable.Seq[Long]]) { implicit b => sink =>
+      val right = Flow.fromGraph(GraphDSL.createGraph(Sink.head[Seq[Long]]) { implicit b => sink =>
         val flow = b.add(Flow[Long].grouped(10))
         flow ~> sink
         FlowShape(flow.in, b.add(Source.single(ByteString("10"))).out)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/CollectionSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/CollectionSinkSpec.scala
@@ -31,15 +31,15 @@ class CollectionSinkSpec extends StreamSpec("""
     "using Seq as Collection" must {
       "return a Seq[T] from a Source" in {
         val input = 1 to 6
-        val future: Future[immutable.Seq[Int]] = Source(input).runWith(Sink.collection)
-        val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+        val future: Future[Seq[Int]] = Source(input).runWith(Sink.collection)
+        val result: Seq[Int] = Await.result(future, remainingOrDefault)
         result should be(input.toSeq)
       }
 
       "return an empty Seq[T] from an empty Source" in {
-        val input: immutable.Seq[Int] = Nil
-        val future: Future[immutable.Seq[Int]] = Source.fromIterator(() => input.iterator).runWith(Sink.collection)
-        val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+        val input: Seq[Int] = Nil
+        val future: Future[Seq[Int]] = Source.fromIterator(() => input.iterator).runWith(Sink.collection)
+        val result: Seq[Int] = Await.result(future, remainingOrDefault)
         result should be(input)
       }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCompileSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowCompileSpec.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.nowarn
-import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
 import org.apache.pekko

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFutureFlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowFutureFlowSpec.scala
@@ -266,7 +266,7 @@ class FlowFutureFlowSpec extends StreamSpec {
       }
 
       "handle closed downstream when flow future is completed after downstream cancel" in {
-        val prFlow = Promise[Flow[Int, Int, Future[collection.immutable.Seq[Int]]]]()
+        val prFlow = Promise[Flow[Int, Int, Future[Seq[Int]]]]()
         val (fNestedFlowMatVal, fSinkCompletion) = src10()
           .viaMat {
             Flow.futureFlow(prFlow.future)
@@ -314,7 +314,7 @@ class FlowFutureFlowSpec extends StreamSpec {
       }
 
       "handle early downstream failure when flow future is late completed" in {
-        val prFlow = Promise[Flow[Int, Int, Future[collection.immutable.Seq[Int]]]]()
+        val prFlow = Promise[Flow[Int, Int, Future[Seq[Int]]]]()
         val (fSeq1, fSeq2) = src10()
           .viaMat {
             Flow.futureFlow(prFlow.future)
@@ -503,7 +503,7 @@ class FlowFutureFlowSpec extends StreamSpec {
 
       "abrupt termination before future completion" in {
         val mat = Materializer(system)
-        val prFlow = Promise[Flow[Int, Int, Future[collection.immutable.Seq[Int]]]]()
+        val prFlow = Promise[Flow[Int, Int, Future[Seq[Int]]]]()
         val (fSeq1, fSeq2) = src10()
           .viaMat {
             Flow.futureFlow(prFlow.future)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedSpec.scala
@@ -15,8 +15,6 @@ package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom.{ current => random }
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.stream.testkit.ScriptedTest
 import pekko.stream.testkit.StreamSpec
@@ -27,8 +25,8 @@ class FlowGroupedSpec extends StreamSpec("""
 
   "A Grouped" must {
 
-    def randomSeq(n: Int) = immutable.Seq.fill(n)(random.nextInt())
-    def randomTest(n: Int) = { val s = randomSeq(n); s -> immutable.Seq(s) }
+    def randomSeq(n: Int) = Seq.fill(n)(random.nextInt())
+    def randomTest(n: Int) = { val s = randomSeq(n); s -> Seq(s) }
 
     "group evenly" in {
       val testLen = random.nextInt(1, 16)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedWeightedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedWeightedSpec.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -28,7 +27,7 @@ class FlowGroupedWeightedSpec extends StreamSpec("""
 
   "A GroupedWeighted" must {
     "produce no group (empty sink sequence) when source is empty" in {
-      val input = immutable.Seq.empty
+      val input = Seq.empty
       def costFn(@nowarn("msg=never used") e: Int): Long = 999999L // set to an arbitrarily big value
       val future = Source(input).groupedWeighted(1)(costFn).runWith(Sink.seq)
       val result = Await.result(future, remainingOrDefault)
@@ -73,14 +72,14 @@ class FlowGroupedWeightedSpec extends StreamSpec("""
 
     "not emit group when grouped weight is less than minWeight and upstream has not completed" taggedAs TimingTest in {
       val p = TestPublisher.probe[Int]()
-      val c = TestSubscriber.probe[immutable.Seq[Int]]()
+      val c = TestSubscriber.probe[Seq[Int]]()
       // Note that the cost function set to zero here means the stream will accumulate elements until completed
       Source.fromPublisher(p).groupedWeighted(10)(_ => 0L).to(Sink.fromSubscriber(c)).run()
       p.sendNext(1)
       c.expectSubscription().request(1) // create downstream demand so Grouped pulls on upstream
       c.expectNoMessage(50.millis) // message should not be emitted yet
       p.sendComplete() // Force Grouped to emit the small group
-      c.expectNext(50.millis, immutable.Seq(1))
+      c.expectNext(50.millis, Seq(1))
       c.expectComplete()
     }
 
@@ -102,7 +101,7 @@ class FlowGroupedWeightedSpec extends StreamSpec("""
 
     "fail the stage when costFn has a negative result" in {
       val p = TestPublisher.probe[Int]()
-      val c = TestSubscriber.probe[immutable.Seq[Int]]()
+      val c = TestSubscriber.probe[Seq[Int]]()
       Source.fromPublisher(p).groupedWeighted(1)(_ => -1L).to(Sink.fromSubscriber(c)).run()
       c.expectSubscription().request(1) // create downstream demand so Grouped pulls on upstream
       c.expectNoMessage(50.millis) // shouldn't fail until the message is sent

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedWithinSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowGroupedWithinSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom.{ current => random }
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -33,7 +32,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
     "group elements within the duration" taggedAs TimingTest in {
       val input = Iterator.from(1)
       val p = TestPublisher.manualProbe[Int]()
-      val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+      val c = TestSubscriber.manualProbe[Seq[Int]]()
       Source.fromPublisher(p).groupedWithin(1000, 1.second).to(Sink.fromSubscriber(c)).run()
       val pSub = p.expectSubscription()
       val cSub = c.expectSubscription()
@@ -64,7 +63,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
     }
 
     "deliver buffered elements onComplete before the timeout" taggedAs TimingTest in {
-      val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+      val c = TestSubscriber.manualProbe[Seq[Int]]()
       Source(1 to 3).groupedWithin(1000, 10.second).to(Sink.fromSubscriber(c)).run()
       val cSub = c.expectSubscription()
       cSub.request(100)
@@ -76,7 +75,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
     "buffer groups until requested from downstream" taggedAs TimingTest in {
       val input = Iterator.from(1)
       val p = TestPublisher.manualProbe[Int]()
-      val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+      val c = TestSubscriber.manualProbe[Seq[Int]]()
       Source.fromPublisher(p).groupedWithin(1000, 1.second).to(Sink.fromSubscriber(c)).run()
       val pSub = p.expectSubscription()
       val cSub = c.expectSubscription()
@@ -100,7 +99,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
 
     "drop empty groups" taggedAs TimingTest in {
       val p = TestPublisher.manualProbe[Int]()
-      val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+      val c = TestSubscriber.manualProbe[Seq[Int]]()
       Source.fromPublisher(p).groupedWithin(1000, 500.millis).to(Sink.fromSubscriber(c)).run()
       val pSub = p.expectSubscription()
       val cSub = c.expectSubscription()
@@ -120,7 +119,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
 
     "not emit empty group when finished while not being pushed" taggedAs TimingTest in {
       val p = TestPublisher.manualProbe[Int]()
-      val c = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+      val c = TestSubscriber.manualProbe[Seq[Int]]()
       Source.fromPublisher(p).groupedWithin(1000, 50.millis).to(Sink.fromSubscriber(c)).run()
       val pSub = p.expectSubscription()
       val cSub = c.expectSubscription()
@@ -132,7 +131,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
 
     "reset time window when max elements reached" taggedAs TimingTest in {
       val upstream = TestPublisher.probe[Int]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+      val downstream = TestSubscriber.probe[Seq[Int]]()
       Source.fromPublisher(upstream).groupedWithin(3, 2.second).to(Sink.fromSubscriber(downstream)).run()
 
       downstream.request(2)
@@ -156,7 +155,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
 
     "reset time window when exact max elements reached" taggedAs TimingTest in {
       val upstream = TestPublisher.probe[Int]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+      val downstream = TestSubscriber.probe[Seq[Int]]()
       Source.fromPublisher(upstream).groupedWithin(3, 1.second).to(Sink.fromSubscriber(downstream)).run()
 
       downstream.request(2)
@@ -173,7 +172,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
     "group evenly" taggedAs TimingTest in {
       def script =
         Script(TestConfig.RandomTestRange.map { _ =>
-          val x, y, z = random.nextInt(); Seq(x, y, z) -> Seq(immutable.Seq(x, y, z))
+          val x, y, z = random.nextInt(); Seq(x, y, z) -> Seq(Seq(x, y, z))
         }: _*)
       TestConfig.RandomTestRange.foreach(_ => runScript(script)(_.groupedWithin(3, 10.minutes)))
     }
@@ -181,9 +180,9 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
     "group with rest" taggedAs TimingTest in {
       def script =
         Script((TestConfig.RandomTestRange.map { _ =>
-          val x, y, z = random.nextInt(); Seq(x, y, z) -> Seq(immutable.Seq(x, y, z))
+          val x, y, z = random.nextInt(); Seq(x, y, z) -> Seq(Seq(x, y, z))
         }
-        :+ { val x = random.nextInt(); Seq(x) -> Seq(immutable.Seq(x)) }): _*)
+        :+ { val x = random.nextInt(); Seq(x) -> Seq(Seq(x)) }): _*)
       TestConfig.RandomTestRange.foreach(_ => runScript(script)(_.groupedWithin(3, 10.minutes)))
     }
 
@@ -199,7 +198,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
 
   "A GroupedWeightedWithin" must {
     "handle elements larger than the limit" taggedAs TimingTest in {
-      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+      val downstream = TestSubscriber.probe[Seq[Int]]()
       Source(List(1, 2, 3, 101, 4, 5, 6))
         .groupedWeightedWithin(100, 100.millis)(_.toLong)
         .to(Sink.fromSubscriber(downstream))
@@ -216,7 +215,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
 
     "not drop a pending last element on upstream finish" taggedAs TimingTest in {
       val upstream = TestPublisher.probe[Long]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      val downstream = TestSubscriber.probe[Seq[Long]]()
       Source
         .fromPublisher(upstream)
         .groupedWeightedWithin(5, 50.millis)(identity)
@@ -230,17 +229,17 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
       upstream.sendNext(3)
       upstream.sendComplete()
       downstream.request(1)
-      downstream.expectNext(Vector(1, 2): immutable.Seq[Long])
+      downstream.expectNext(Vector(1, 2): Seq[Long])
       downstream.expectNoMessage(100.millis)
       downstream.request(1)
-      downstream.expectNext(Vector(3): immutable.Seq[Long])
+      downstream.expectNext(Vector(3): Seq[Long])
       downstream.expectComplete()
     }
 
     "append zero weighted elements to a full group before timeout received, if downstream hasn't pulled yet" taggedAs
     TimingTest in {
       val upstream = TestPublisher.probe[String]()
-      val downstream = TestSubscriber.probe[immutable.Seq[String]]()
+      val downstream = TestSubscriber.probe[Seq[String]]()
       Source
         .fromPublisher(upstream)
         .groupedWeightedWithin(5, 50.millis)(_.length.toLong)
@@ -254,18 +253,18 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
       upstream.sendNext("")
       upstream.sendNext("")
       downstream.request(1)
-      downstream.expectNext(Vector("333", "22", "", "", ""): immutable.Seq[String])
+      downstream.expectNext(Vector("333", "22", "", "", ""): Seq[String])
       upstream.sendNext("")
       upstream.sendNext("")
       upstream.sendComplete()
       downstream.request(1)
-      downstream.expectNext(Vector("", ""): immutable.Seq[String])
+      downstream.expectNext(Vector("", ""): Seq[String])
       downstream.expectComplete()
     }
 
     "not emit an empty group if first element is heavier than maxWeight" taggedAs TimingTest in {
       val upstream = TestPublisher.probe[Long]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      val downstream = TestSubscriber.probe[Seq[Long]]()
       Source
         .fromPublisher(upstream)
         .groupedWeightedWithin(10, 50.millis)(identity)
@@ -275,14 +274,14 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
       downstream.ensureSubscription()
       downstream.request(1)
       upstream.sendNext(11)
-      downstream.expectNext(Vector(11): immutable.Seq[Long])
+      downstream.expectNext(Vector(11): Seq[Long])
       upstream.sendComplete()
       downstream.expectComplete()
     }
 
     "handle zero cost function to get only timed based grouping without limit" taggedAs TimingTest in {
       val upstream = TestPublisher.probe[String]()
-      val downstream = TestSubscriber.probe[immutable.Seq[String]]()
+      val downstream = TestSubscriber.probe[Seq[String]]()
       Source
         .fromPublisher(upstream)
         .groupedWeightedWithin(1, 100.millis)(ConstantFun.zeroLong)
@@ -296,14 +295,14 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
       upstream.sendNext("333")
       upstream.sendNext("22")
       downstream.expectNoMessage(50.millis)
-      downstream.expectNext(Vector("333", "22", "333", "22"): immutable.Seq[String])
+      downstream.expectNext(Vector("333", "22", "333", "22"): Seq[String])
       upstream.sendComplete()
       downstream.expectComplete()
     }
 
     "group by max weight and max number of elements reached" taggedAs TimingTest in {
       val upstream = TestPublisher.probe[Long]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      val downstream = TestSubscriber.probe[Seq[Long]]()
       Source
         .fromPublisher(upstream)
         .groupedWeightedWithin(10, 3, 30.seconds)(identity)
@@ -323,19 +322,19 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
       upstream.sendComplete()
       downstream.request(1)
       // split because of maxNumber: 3 element
-      downstream.expectNext(Vector(1, 2, 3): immutable.Seq[Long])
+      downstream.expectNext(Vector(1, 2, 3): Seq[Long])
       downstream.request(1)
       // split because of maxWeight: 9=4+5, one more element did not fit
-      downstream.expectNext(Vector(4, 5): immutable.Seq[Long])
+      downstream.expectNext(Vector(4, 5): Seq[Long])
       downstream.request(1)
       // split because of maxWeight: 6, one more element did not fit
-      downstream.expectNext(Vector(6): immutable.Seq[Long])
+      downstream.expectNext(Vector(6): Seq[Long])
       downstream.request(1)
       // split because of maxWeight: 11
-      downstream.expectNext(Vector(11): immutable.Seq[Long])
+      downstream.expectNext(Vector(11): Seq[Long])
       downstream.request(1)
       // no split
-      downstream.expectNext(Vector(7, 2): immutable.Seq[Long])
+      downstream.expectNext(Vector(7, 2): Seq[Long])
       downstream.expectComplete()
     }
 
@@ -344,7 +343,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
     "stop when cost function throws and supervision is Stop" in {
       val ex = new RuntimeException("cost function boom")
       val upstream = TestPublisher.probe[Long]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      val downstream = TestSubscriber.probe[Seq[Long]]()
       Source
         .fromPublisher(upstream)
         .groupedWeightedWithin(100, 3, 30.seconds) { elem =>
@@ -377,7 +376,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
     "resume when cost function throws and keep current group" in {
       val ex = new RuntimeException("cost function boom")
       val upstream = TestPublisher.probe[Long]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      val downstream = TestSubscriber.probe[Seq[Long]]()
       Source
         .fromPublisher(upstream)
         .groupedWeightedWithin(100, 3, 30.seconds) { elem =>
@@ -398,16 +397,16 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
       upstream.sendComplete()
 
       downstream.request(1)
-      downstream.expectNext(Vector(1L, 2L, 3L): immutable.Seq[Long])
+      downstream.expectNext(Vector(1L, 2L, 3L): Seq[Long])
       downstream.request(1)
-      downstream.expectNext(Vector(4L, 5L): immutable.Seq[Long])
+      downstream.expectNext(Vector(4L, 5L): Seq[Long])
       downstream.expectComplete()
     }
 
     "resume keeps weight accounting when cost function throws" in {
       val ex = new RuntimeException("cost function boom")
       val upstream = TestPublisher.probe[Long]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      val downstream = TestSubscriber.probe[Seq[Long]]()
       Source
         .fromPublisher(upstream)
         // maxWeight=5, large maxNumber so grouping is weight-driven; identity cost
@@ -427,16 +426,16 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
       upstream.sendComplete()
 
       downstream.request(1)
-      downstream.expectNext(Vector(2L, 2L): immutable.Seq[Long])
+      downstream.expectNext(Vector(2L, 2L): Seq[Long])
       downstream.request(1)
-      downstream.expectNext(Vector(3L): immutable.Seq[Long])
+      downstream.expectNext(Vector(3L): Seq[Long])
       downstream.expectComplete()
     }
 
     "restart when cost function throws and drop current group" in {
       val ex = new RuntimeException("cost function boom")
       val upstream = TestPublisher.probe[Long]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Long]]()
+      val downstream = TestSubscriber.probe[Seq[Long]]()
       Source
         .fromPublisher(upstream)
         .groupedWeightedWithin(100, 3, 30.seconds) { elem =>
@@ -458,9 +457,9 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
       upstream.sendComplete()
 
       downstream.request(1)
-      downstream.expectNext(Vector(3L, 4L, 5L): immutable.Seq[Long])
+      downstream.expectNext(Vector(3L, 4L, 5L): Seq[Long])
       downstream.request(1)
-      downstream.expectNext(Vector(6L): immutable.Seq[Long])
+      downstream.expectNext(Vector(6L): Seq[Long])
       downstream.expectComplete()
     }
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowJoinSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowJoinSpec.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.stream.FlowShape
 import pekko.stream.OverflowStrategy
@@ -98,7 +96,7 @@ class FlowJoinSpec extends StreamSpec("""
     }
 
     "allow for zip cycle" in {
-      val source = Source(immutable.Seq("traveler1", "traveler2"))
+      val source = Source(Seq("traveler1", "traveler2"))
 
       val flow = Flow.fromGraph(GraphDSL.createGraph(TestSink[(String, String)]()) { implicit b => sink =>
         import GraphDSL.Implicits._

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
@@ -17,7 +17,6 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.LockSupport
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -323,7 +322,7 @@ class FlowMapAsyncPartitionedSpec extends StreamSpec with WithLogCapturing {
 
       probe.request(100)
       val failure = new Exception("BOOM två")
-      scala.util.Random.shuffle((0 until 6): immutable.Seq[Int]).foreach { n =>
+      scala.util.Random.shuffle((0 until 6): Seq[Int]).foreach { n =>
         if (n == 2) promises(n).failure(failure)
         else promises(n).success(n)
       }
@@ -360,7 +359,7 @@ class FlowMapAsyncPartitionedSpec extends StreamSpec with WithLogCapturing {
           .runWith(Sink.seq)
 
       val failure = new Exception("BOOM TWEE!")
-      scala.util.Random.shuffle((0 until 6): immutable.Seq[Int]).foreach { n =>
+      scala.util.Random.shuffle((0 until 6): Seq[Int]).foreach { n =>
         if (n == 2) promises(n).failure(failure)
         else promises(n).success(n)
       }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowOrElseSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowOrElseSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 import org.apache.pekko

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrefixAndTailSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowPrefixAndTailSpec.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -33,7 +32,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     val testException = new Exception("test") with NoStackTrace
 
-    def newHeadSink = Sink.head[(immutable.Seq[Int], Source[Int, ?])]
+    def newHeadSink = Sink.head[(Seq[Int], Source[Int, ?])]
 
     "work on empty input" in {
       val futureSink = newHeadSink
@@ -61,7 +60,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
       val (takes, tail) = Await.result(fut, 3.seconds.dilated)
       takes should be(1 to 5)
 
-      val futureSink2 = Sink.head[immutable.Seq[Int]]
+      val futureSink2 = Sink.head[Seq[Int]]
       val fut2 = tail.grouped(6).runWith(futureSink2)
       Await.result(fut2, 3.seconds.dilated) should be(6 to 10)
     }
@@ -72,7 +71,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
       val (takes, tail) = Await.result(fut, 3.seconds.dilated)
       takes should be(Nil)
 
-      val futureSink2 = Sink.head[immutable.Seq[Int]]
+      val futureSink2 = Sink.head[Seq[Int]]
       val fut2 = tail.grouped(11).runWith(futureSink2)
       Await.result(fut2, 3.seconds.dilated) should be(1 to 10)
     }
@@ -83,7 +82,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
       val (takes, tail) = Await.result(fut, 3.seconds.dilated)
       takes should be(Nil)
 
-      val futureSink2 = Sink.head[immutable.Seq[Int]]
+      val futureSink2 = Sink.head[Seq[Int]]
       val fut2 = tail.grouped(11).runWith(futureSink2)
       Await.result(fut2, 3.seconds.dilated) should be(1 to 10)
     }
@@ -172,7 +171,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "handle onError when no substream open" in {
       val publisher = TestPublisher.manualProbe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
+      val subscriber = TestSubscriber.manualProbe[(Seq[Int], Source[Int, ?])]()
 
       Source.fromPublisher(publisher).prefixAndTail(3).to(Sink.fromSubscriber(subscriber)).run()
 
@@ -190,7 +189,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "handle onError when substream is open" in {
       val publisher = TestPublisher.manualProbe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
+      val subscriber = TestSubscriber.manualProbe[(Seq[Int], Source[Int, ?])]()
 
       Source.fromPublisher(publisher).prefixAndTail(1).to(Sink.fromSubscriber(subscriber)).run()
 
@@ -217,7 +216,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "handle master stream cancellation" in {
       val publisher = TestPublisher.manualProbe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
+      val subscriber = TestSubscriber.manualProbe[(Seq[Int], Source[Int, ?])]()
 
       Source.fromPublisher(publisher).prefixAndTail(3).to(Sink.fromSubscriber(subscriber)).run()
 
@@ -235,7 +234,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "handle substream cancellation" in {
       val publisher = TestPublisher.manualProbe[Int]()
-      val subscriber = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
+      val subscriber = TestSubscriber.manualProbe[(Seq[Int], Source[Int, ?])]()
 
       Source.fromPublisher(publisher).prefixAndTail(1).to(Sink.fromSubscriber(subscriber)).run()
 
@@ -261,7 +260,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
     "pass along early cancellation" in {
       val up = TestPublisher.manualProbe[Int]()
-      val down = TestSubscriber.manualProbe[(immutable.Seq[Int], Source[Int, ?])]()
+      val down = TestSubscriber.manualProbe[(Seq[Int], Source[Int, ?])]()
 
       val flowSubscriber = Source.asSubscriber[Int].prefixAndTail(1).to(Sink.fromSubscriber(down)).run()
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowScanAsyncSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowScanAsyncSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -215,7 +214,7 @@ class FlowScanAsyncSpec extends StreamSpec with Matchers {
     }
 
     def whenFailedScan(
-        elements: immutable.Seq[Int],
+        elements: Seq[Int],
         zero: Int,
         throwable: Throwable = new Exception("non fatal exception"),
         decider: Supervision.Decider = Supervision.stoppingDecider): Probe[Int] = {
@@ -232,7 +231,7 @@ class FlowScanAsyncSpec extends StreamSpec with Matchers {
     }
 
     def whenEventualFuture(
-        promises: immutable.Seq[Promise[Int]],
+        promises: Seq[Promise[Int]],
         zero: Int,
         decider: Supervision.Decider): (TestPublisher.Probe[Int], TestSubscriber.Probe[Int]) = {
       require(promises.nonEmpty, "must be at least one promise")
@@ -252,7 +251,7 @@ class FlowScanAsyncSpec extends StreamSpec with Matchers {
     }
 
     def whenFailedFuture(
-        elements: immutable.Seq[Int],
+        elements: Seq[Int],
         zero: Int,
         throwable: Throwable = new Exception("non fatal exception"),
         decider: Supervision.Decider = Supervision.stoppingDecider): Probe[Int] = {
@@ -269,7 +268,7 @@ class FlowScanAsyncSpec extends StreamSpec with Matchers {
     }
 
     def whenNullElement(
-        elements: immutable.Seq[String],
+        elements: Seq[String],
         zero: String,
         decider: Supervision.Decider = Supervision.stoppingDecider): Probe[String] = {
       val nullFutureScanFlow: Flow[String, String, ?] = Flow[String].scanAsync(zero) { (_: String, next: String) =>

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowScanSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowScanSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom.{ current => random }
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -33,8 +32,8 @@ class FlowScanSpec extends StreamSpec("""
 
   "A Scan" must {
 
-    def scan(s: Source[Int, NotUsed], duration: Duration = remainingOrDefault): immutable.Seq[Int] =
-      Await.result(s.scan(0)(_ + _).runFold(immutable.Seq.empty[Int])(_ :+ _), duration)
+    def scan(s: Source[Int, NotUsed], duration: Duration = remainingOrDefault): Seq[Int] =
+      Await.result(s.scan(0)(_ + _).runFold(Seq.empty[Int])(_ :+ _), duration)
 
     "Scan" in {
       val v = Vector.fill(random.nextInt(100, 1000))(random.nextInt())

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSpec.scala
@@ -17,7 +17,6 @@ import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -301,12 +300,12 @@ class FlowSpec extends StreamSpec(ConfigFactory.parseString("""
         Source.fromIterator[Fruit](fruits).splitWhen(_ => true)
       val f3: SubFlow[Fruit, ?, Source[Fruit, NotUsed]#Repr, ?] =
         Source.fromIterator[Fruit](fruits).groupBy(2, _ => true)
-      val f4: Source[(immutable.Seq[Fruit], Source[Fruit, ?]), ?] = Source.fromIterator[Fruit](fruits).prefixAndTail(1)
+      val f4: Source[(Seq[Fruit], Source[Fruit, ?]), ?] = Source.fromIterator[Fruit](fruits).prefixAndTail(1)
       val d1: SubFlow[Fruit, ?, Flow[String, Fruit, NotUsed]#Repr, ?] =
         Flow[String].map(_ => new Apple).splitWhen(_ => true)
       val d2: SubFlow[Fruit, ?, Flow[String, Fruit, NotUsed]#Repr, ?] =
         Flow[String].map(_ => new Apple).groupBy(2, _ => true)
-      val d3: Flow[String, (immutable.Seq[Apple], Source[Fruit, ?]), ?] =
+      val d3: Flow[String, (Seq[Apple], Source[Fruit, ?]), ?] =
         Flow[String].map(_ => new Apple).prefixAndTail(1)
     }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSupervisionSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/FlowSupervisionSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -32,7 +31,7 @@ class FlowSupervisionSpec extends StreamSpec {
 
   val failingMap = Flow[Int].map(n => if (n == 3) throw exc else n)
 
-  def run(f: Flow[Int, Int, NotUsed]): immutable.Seq[Int] =
+  def run(f: Flow[Int, Int, NotUsed]): Seq[Int] =
     Await.result(Source((1 to 5).toSeq ++ (1 to 5)).via(f).limit(1000).runWith(Sink.seq), 3.seconds)
 
   "Stream supervision" must {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergePrioritizedNSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergePrioritizedNSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -138,7 +137,7 @@ class GraphMergePrioritizedNSpec extends StreamSpec {
   }
 
   private def threeSourceMerge[T](
-      sourceAndPriorities: immutable.Seq[(Source[T, NotUsed], Int)],
+      sourceAndPriorities: Seq[(Source[T, NotUsed], Int)],
       probe: ManualProbe[T]) = {
 
     Source

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSequenceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSequenceSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -36,10 +35,10 @@ class GraphMergeSequenceSpec extends TwoStreamsSetup {
 
   }
 
-  private def merge(seqs: immutable.Seq[Long]*): immutable.Seq[Long] =
+  private def merge(seqs: Seq[Long]*): Seq[Long] =
     mergeSources(seqs.map(Source(_)): _*)
 
-  private def mergeSources(sources: Source[Long, NotUsed]*): immutable.Seq[Long] = {
+  private def mergeSources(sources: Source[Long, NotUsed]*): Seq[Long] = {
     val future = Source
       .fromGraph(GraphDSL.create() { implicit builder =>
         import GraphDSL.Implicits._

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSortedSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphMergeSortedSpec.scala
@@ -37,7 +37,7 @@ class GraphMergeSortedSpec extends TwoStreamsSetup with ScalaCheckPropertyChecks
   }
 
   implicit def noShrink[T]: Shrink[T] =
-    Shrink[T](_ => Stream.empty) // do not shrink failures, it only destroys evidence
+    Shrink.withLazyList[T](_ => LazyList.empty) // do not shrink failures, it only destroys evidence
 
   "MergeSorted" must {
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphOpsIntegrationSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphOpsIntegrationSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -30,8 +29,8 @@ object GraphOpsIntegrationSpec {
 
     case class ShufflePorts[In, Out](in1: Inlet[In], in2: Inlet[In], out1: Outlet[Out], out2: Outlet[Out])
         extends Shape {
-      override def inlets: immutable.Seq[Inlet[?]] = List(in1, in2)
-      override def outlets: immutable.Seq[Outlet[?]] = List(out1, out2)
+      override def inlets: Seq[Inlet[?]] = List(in1, in2)
+      override def outlets: Seq[Outlet[?]] = List(out1, out2)
 
       override def deepCopy() = ShufflePorts(in1.carbonCopy(), in2.carbonCopy(), out1.carbonCopy(), out2.carbonCopy())
     }
@@ -219,9 +218,8 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
       implicit val ex = system.dispatcher
 
       // #graph-from-list
-      val sinks = immutable
-        .Seq("a", "b", "c")
-        .map(prefix => Flow[String].filter(str => str.startsWith(prefix)).toMat(Sink.head[String])(Keep.right))
+      val sinks = Seq("a", "b", "c").map(prefix =>
+        Flow[String].filter(str => str.startsWith(prefix)).toMat(Sink.head[String])(Keep.right))
 
       val g: RunnableGraph[Seq[Future[String]]] = RunnableGraph.fromGraph(GraphDSL.create(sinks) {
         implicit b => sinkList =>
@@ -248,9 +246,9 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
     "be possible to use with generated components if list has no tail" in {
       implicit val ex = system.dispatcher
 
-      val sinks = immutable.Seq(Sink.seq[Int])
+      val sinks = Seq(Sink.seq[Int])
 
-      val g: RunnableGraph[Seq[Future[immutable.Seq[Int]]]] = RunnableGraph.fromGraph(GraphDSL.create(sinks) {
+      val g: RunnableGraph[Seq[Future[Seq[Int]]]] = RunnableGraph.fromGraph(GraphDSL.create(sinks) {
         implicit b => sinkList =>
           import GraphDSL.Implicits._
           val broadcast = b.add(Broadcast[Int](sinkList.size))
@@ -261,9 +259,9 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
           ClosedShape
       })
 
-      val matList: Seq[Future[immutable.Seq[Int]]] = g.run()
+      val matList: Seq[Future[Seq[Int]]] = g.run()
 
-      val result: Seq[immutable.Seq[Int]] = Await.result(Future.sequence(matList), 3.seconds)
+      val result: Seq[Seq[Int]] = Await.result(Future.sequence(matList), 3.seconds)
 
       result.size shouldBe 1
       result.foreach(_ shouldBe List(1, 2, 3))

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipNSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipNSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -24,20 +23,20 @@ import pekko.stream.testkit.scaladsl.StreamTestKit._
 class GraphZipNSpec extends TwoStreamsSetup {
   import GraphDSL.Implicits._
 
-  override type Outputs = immutable.Seq[Int]
+  override type Outputs = Seq[Int]
 
   override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
     val zipN = b.add(ZipN[Int](2))
 
     override def left: Inlet[Int] = zipN.in(0)
     override def right: Inlet[Int] = zipN.in(1)
-    override def out: Outlet[immutable.Seq[Int]] = zipN.out
+    override def out: Outlet[Seq[Int]] = zipN.out
   }
 
   "ZipN" must {
 
     "work in the happy case" in assertAllStagesStopped {
-      val probe = TestSubscriber.manualProbe[immutable.Seq[Int]]()
+      val probe = TestSubscriber.manualProbe[Seq[Int]]()
 
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
@@ -55,13 +54,13 @@ class GraphZipNSpec extends TwoStreamsSetup {
       val subscription = probe.expectSubscription()
 
       subscription.request(2)
-      probe.expectNext(immutable.Seq(1, 2))
-      probe.expectNext(immutable.Seq(2, 3))
+      probe.expectNext(Seq(1, 2))
+      probe.expectNext(Seq(2, 3))
 
       subscription.request(1)
-      probe.expectNext(immutable.Seq(3, 4))
+      probe.expectNext(Seq(3, 4))
       subscription.request(1)
-      probe.expectNext(immutable.Seq(4, 5))
+      probe.expectNext(Seq(4, 5))
 
       probe.expectComplete()
     }
@@ -69,7 +68,7 @@ class GraphZipNSpec extends TwoStreamsSetup {
     "complete if one side is available but other already completed" in {
       val upstream1 = TestPublisher.probe[Int]()
       val upstream2 = TestPublisher.probe[Int]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+      val downstream = TestSubscriber.probe[Seq[Int]]()
 
       RunnableGraph
         .fromGraph(GraphDSL.createGraph(Sink.fromSubscriber(downstream)) { implicit b => out =>
@@ -88,7 +87,7 @@ class GraphZipNSpec extends TwoStreamsSetup {
       upstream2.sendNext(2)
       upstream2.sendComplete()
 
-      downstream.requestNext(immutable.Seq(1, 2))
+      downstream.requestNext(Seq(1, 2))
       downstream.expectComplete()
       upstream1.expectCancellation()
     }
@@ -96,7 +95,7 @@ class GraphZipNSpec extends TwoStreamsSetup {
     "complete even if no pending demand" in {
       val upstream1 = TestPublisher.probe[Int]()
       val upstream2 = TestPublisher.probe[Int]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+      val downstream = TestSubscriber.probe[Seq[Int]]()
 
       RunnableGraph
         .fromGraph(GraphDSL.createGraph(Sink.fromSubscriber(downstream)) { implicit b => out =>
@@ -114,7 +113,7 @@ class GraphZipNSpec extends TwoStreamsSetup {
 
       upstream1.sendNext(1)
       upstream2.sendNext(2)
-      downstream.expectNext(immutable.Seq(1, 2))
+      downstream.expectNext(Seq(1, 2))
 
       upstream2.sendComplete()
       downstream.expectComplete()
@@ -124,7 +123,7 @@ class GraphZipNSpec extends TwoStreamsSetup {
     "complete if both sides complete before requested with elements pending" in {
       val upstream1 = TestPublisher.probe[Int]()
       val upstream2 = TestPublisher.probe[Int]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+      val downstream = TestSubscriber.probe[Seq[Int]]()
 
       RunnableGraph
         .fromGraph(GraphDSL.createGraph(Sink.fromSubscriber(downstream)) { implicit b => out =>
@@ -144,14 +143,14 @@ class GraphZipNSpec extends TwoStreamsSetup {
       upstream1.sendComplete()
       upstream2.sendComplete()
 
-      downstream.requestNext(immutable.Seq(1, 2))
+      downstream.requestNext(Seq(1, 2))
       downstream.expectComplete()
     }
 
     "complete if one side complete before requested with elements pending" in {
       val upstream1 = TestPublisher.probe[Int]()
       val upstream2 = TestPublisher.probe[Int]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+      val downstream = TestSubscriber.probe[Seq[Int]]()
 
       RunnableGraph
         .fromGraph(GraphDSL.createGraph(Sink.fromSubscriber(downstream)) { implicit b => out =>
@@ -172,14 +171,14 @@ class GraphZipNSpec extends TwoStreamsSetup {
       upstream1.sendComplete()
       upstream2.sendComplete()
 
-      downstream.requestNext(immutable.Seq(1, 2))
+      downstream.requestNext(Seq(1, 2))
       downstream.expectComplete()
     }
 
     "complete if one side complete before requested with elements pending 2" in {
       val upstream1 = TestPublisher.probe[Int]()
       val upstream2 = TestPublisher.probe[Int]()
-      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+      val downstream = TestSubscriber.probe[Seq[Int]]()
 
       RunnableGraph
         .fromGraph(GraphDSL.createGraph(Sink.fromSubscriber(downstream)) { implicit b => out =>
@@ -201,7 +200,7 @@ class GraphZipNSpec extends TwoStreamsSetup {
 
       upstream2.sendNext(2)
       upstream2.sendComplete()
-      downstream.requestNext(immutable.Seq(1, 2))
+      downstream.requestNext(Seq(1, 2))
       downstream.expectComplete()
     }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipWithNSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/GraphZipWithNSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -28,7 +27,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
   override type Outputs = Int
 
   override def fixture(b: GraphDSL.Builder[?]): Fixture = new Fixture {
-    val zip = b.add(ZipWithN((_: immutable.Seq[Int]).sum)(2))
+    val zip = b.add(ZipWithN((_: Seq[Int]).sum)(2))
     override def left: Inlet[Int] = zip.in(0)
     override def right: Inlet[Int] = zip.in(1)
     override def out: Outlet[Int] = zip.out
@@ -41,7 +40,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
 
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val zip = b.add(ZipWithN((_: immutable.Seq[Int]).sum)(2))
+          val zip = b.add(ZipWithN((_: Seq[Int]).sum)(2))
           Source(1 to 4)         ~> zip.in(0)
           Source(10 to 40 by 10) ~> zip.in(1)
 
@@ -70,7 +69,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
 
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val zip = b.add(ZipWithN((_: immutable.Seq[Int]).foldLeft(1)(_ / _))(2))
+          val zip = b.add(ZipWithN((_: Seq[Int]).foldLeft(1)(_ / _))(2))
 
           Source(1 to 4)  ~> zip.in(0)
           Source(-2 to 2) ~> zip.in(1)
@@ -98,7 +97,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
     "fail stream when zipper throws and supervision is Stop" in {
       val ex = new RuntimeException("boom")
       val result = Source
-        .zipWithN[Int, Int](s => if (s.head == 3) throw ex else s.sum)(immutable.Seq(Source(1 to 4), Source(1 to 4)))
+        .zipWithN[Int, Int](s => if (s.head == 3) throw ex else s.sum)(Seq(Source(1 to 4), Source(1 to 4)))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
         .runWith(Sink.seq)
       result.failed.futureValue shouldBe ex
@@ -107,7 +106,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
     "fail stream when zipper throws and supervision defaults to Stop" in {
       val ex = new RuntimeException("boom")
       val result = Source
-        .zipWithN[Int, Int](s => if (s.head == 3) throw ex else s.sum)(immutable.Seq(Source(1 to 4), Source(1 to 4)))
+        .zipWithN[Int, Int](s => if (s.head == 3) throw ex else s.sum)(Seq(Source(1 to 4), Source(1 to 4)))
         .runWith(Sink.seq)
       result.failed.futureValue shouldBe ex
     }
@@ -115,7 +114,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
     "resume when zipper throws and drop failed zipped element" in {
       val future = Source
         .zipWithN[Int, Int](s => if (s.head == 3) throw new RuntimeException("boom") else s.sum)(
-          immutable.Seq(Source(1 to 4), Source(1 to 4)))
+          Seq(Source(1 to 4), Source(1 to 4)))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
         .runWith(Sink.seq)
       Await.result(future, 3.seconds) shouldBe Seq(2, 4, 8)
@@ -124,7 +123,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
     "restart when zipper throws and drop failed zipped element" in {
       val future = Source
         .zipWithN[Int, Int](s => if (s.head == 3) throw new RuntimeException("boom") else s.sum)(
-          immutable.Seq(Source(1 to 4), Source(1 to 4)))
+          Seq(Source(1 to 4), Source(1 to 4)))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
         .runWith(Sink.seq)
       Await.result(future, 3.seconds) shouldBe Seq(2, 4, 8)
@@ -169,7 +168,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
 
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val zip = b.add(ZipWithN((_: immutable.Seq[Int]).sum)(3))
+          val zip = b.add(ZipWithN((_: Seq[Int]).sum)(3))
 
           Source.single(1) ~> zip.in(0)
           Source.single(2) ~> zip.in(1)
@@ -194,7 +193,7 @@ class GraphZipWithNSpec extends TwoStreamsSetup {
 
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val zip = b.add(ZipWithN((_: immutable.Seq[Int]).sum)(30))
+          val zip = b.add(ZipWithN((_: Seq[Int]).sum)(30))
 
           (0 to 29).foreach { n =>
             Source.single(n) ~> zip.in(n)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/HubSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
 
@@ -307,7 +306,7 @@ class HubSpec extends StreamSpec {
     }
 
     "work with different producers separated over time" in {
-      val downstream = TestSubscriber.probe[immutable.Seq[Int]]()
+      val downstream = TestSubscriber.probe[Seq[Int]]()
       val sink = MergeHub.source[Int](16).grouped(100).toMat(Sink.fromSubscriber(downstream))(Keep.left).run()
 
       Source(1 to 100).runWith(sink)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/JsonFramingSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/JsonFramingSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable.Seq
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LazyFlowSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LazyFlowSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
 
@@ -39,7 +38,7 @@ class LazyFlowSpec extends StreamSpec("""
   "Flow.lazyFlow" must {
     // more complete test coverage is for lazyFutureFlow since this is composition of that
     "work in the happy case" in {
-      val result: (Future[NotUsed], Future[immutable.Seq[String]]) =
+      val result: (Future[NotUsed], Future[Seq[String]]) =
         Source(List(1, 2, 3))
           .viaMat(Flow.lazyFlow(() => Flow.fromFunction((n: Int) => n.toString)))(Keep.right)
           .toMat(Sink.seq)(Keep.both)
@@ -67,7 +66,7 @@ class LazyFlowSpec extends StreamSpec("""
   "Flow.futureFlow" must {
     // more complete test coverage is for lazyFutureFlow since this is composition of that
     "work in the happy case" in {
-      val result: (Future[NotUsed], Future[immutable.Seq[String]]) =
+      val result: (Future[NotUsed], Future[Seq[String]]) =
         Source(List(1, 2, 3))
           .viaMat(Flow.futureFlow(Future.successful(Flow.fromFunction((n: Int) => n.toString))))(Keep.right)
           .toMat(Sink.seq)(Keep.both)
@@ -95,7 +94,7 @@ class LazyFlowSpec extends StreamSpec("""
   "Flow.lazyFutureFlow" must {
 
     "work in the happy case" in {
-      val result: (Future[NotUsed], Future[immutable.Seq[String]]) =
+      val result: (Future[NotUsed], Future[Seq[String]]) =
         Source(List(1, 2, 3))
           .viaMat(Flow.lazyFutureFlow(() => Future.successful(Flow.fromFunction((n: Int) => n.toString))))(Keep.right)
           .toMat(Sink.seq)(Keep.both)
@@ -109,7 +108,7 @@ class LazyFlowSpec extends StreamSpec("""
 
     "complete without creating internal flow when there was no elements in the stream" in {
       val probe = TestProbe()
-      val result: (Future[NotUsed], Future[immutable.Seq[Int]]) = Source
+      val result: (Future[NotUsed], Future[Seq[Int]]) = Source
         .empty[Int]
         .viaMat(Flow.lazyFutureFlow { () =>
           probe.ref ! "constructed"
@@ -128,7 +127,7 @@ class LazyFlowSpec extends StreamSpec("""
 
     "complete without creating internal flow when the stream failed with no elements" in {
       val probe = TestProbe()
-      val result: (Future[NotUsed], Future[immutable.Seq[Int]]) = Source
+      val result: (Future[NotUsed], Future[Seq[Int]]) = Source
         .failed[Int](TE("no-elements"))
         .viaMat(Flow.lazyFutureFlow { () =>
           probe.ref ! "constructed"
@@ -146,7 +145,7 @@ class LazyFlowSpec extends StreamSpec("""
     }
 
     "fail the flow when the factory function fails" in {
-      val result: (Future[NotUsed], Future[immutable.Seq[String]]) =
+      val result: (Future[NotUsed], Future[Seq[String]]) =
         Source(List(1, 2, 3))
           .viaMat(Flow.lazyFutureFlow(() => throw TE("no-flow-for-you")))(Keep.right)
           .toMat(Sink.seq)(Keep.both)
@@ -160,7 +159,7 @@ class LazyFlowSpec extends StreamSpec("""
     }
 
     "fail the flow when the future is initially failed" in {
-      val result: (Future[NotUsed], Future[immutable.Seq[String]]) =
+      val result: (Future[NotUsed], Future[Seq[String]]) =
         Source(List(1, 2, 3))
           .viaMat(Flow.lazyFutureFlow(() => Future.failed(TE("no-flow-for-you"))))(Keep.right)
           .toMat(Sink.seq)(Keep.both)
@@ -175,7 +174,7 @@ class LazyFlowSpec extends StreamSpec("""
 
     "fail the flow when the future is failed after the fact" in {
       val promise = Promise[Flow[Int, String, NotUsed]]()
-      val result: (Future[NotUsed], Future[immutable.Seq[String]]) =
+      val result: (Future[NotUsed], Future[Seq[String]]) =
         Source(List(1, 2, 3))
           .viaMat(Flow.lazyFutureFlow(() => promise.future))(Keep.right)
           .toMat(Sink.seq)(Keep.both)
@@ -195,7 +194,7 @@ class LazyFlowSpec extends StreamSpec("""
       val flowPromise = Promise[Flow[Int, String, NotUsed]]()
       val firstElementArrived = Promise[Done]()
 
-      val result: Future[immutable.Seq[String]] =
+      val result: Future[Seq[String]] =
         Source(List(1))
           .via(Flow.lazyFutureFlow { () =>
             firstElementArrived.success(Done)
@@ -211,7 +210,7 @@ class LazyFlowSpec extends StreamSpec("""
     }
 
     "fail the flow when the future materialization fails" in {
-      val result: (Future[NotUsed], Future[immutable.Seq[String]]) =
+      val result: (Future[NotUsed], Future[Seq[String]]) =
         Source(List(1, 2, 3))
           .viaMat(Flow.lazyFutureFlow(() =>
             Future.successful(Flow[Int].map(_.toString).mapMaterializedValue(_ => throw TE("mat-failed")))))(Keep.right)
@@ -227,7 +226,7 @@ class LazyFlowSpec extends StreamSpec("""
     }
 
     "fail the flow when there was elements but the inner flow failed" in {
-      val result: (Future[NotUsed], Future[immutable.Seq[String]]) =
+      val result: (Future[NotUsed], Future[Seq[String]]) =
         Source(List(1, 2, 3))
           .viaMat(Flow.lazyFutureFlow(() => Future.successful(Flow[Int].map(_ => throw TE("inner-stream-fail")))))(
             Keep.right)
@@ -244,7 +243,7 @@ class LazyFlowSpec extends StreamSpec("""
     "fail the mat val when the stream is abruptly terminated before it got materialized" in {
       val expendableMaterializer = Materializer(system)
       val promise = Promise[Flow[Int, String, NotUsed]]()
-      val result: (Future[NotUsed], Future[immutable.Seq[String]]) =
+      val result: (Future[NotUsed], Future[Seq[String]]) =
         Source
           .maybe[Int]
           .viaMat(Flow.lazyFutureFlow(() => promise.future))(Keep.right)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LazySourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/LazySourceSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.stream.scaladsl
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.Promise
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SeqSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SeqSinkSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.Future
 
@@ -30,22 +29,22 @@ class SeqSinkSpec extends StreamSpec("""
   "Sink.toSeq" must {
     "return a Seq[T] from a Source" in {
       val input = 1 to 6
-      val future: Future[immutable.Seq[Int]] = Source(input).runWith(Sink.seq)
-      val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+      val future: Future[Seq[Int]] = Source(input).runWith(Sink.seq)
+      val result: Seq[Int] = Await.result(future, remainingOrDefault)
       result should be(input.toSeq)
     }
 
     "return an empty Seq[T] from an empty Source" in {
-      val input: immutable.Seq[Int] = Nil
-      val future: Future[immutable.Seq[Int]] = Source.fromIterator(() => input.iterator).runWith(Sink.seq)
-      val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+      val input: Seq[Int] = Nil
+      val future: Future[Seq[Int]] = Source.fromIterator(() => input.iterator).runWith(Sink.seq)
+      val result: Seq[Int] = Await.result(future, remainingOrDefault)
       result should be(input)
     }
 
     "fail the future on abrupt termination" in {
       val mat = Materializer(system)
       val probe = TestPublisher.probe()
-      val future: Future[immutable.Seq[Int]] =
+      val future: Future[Seq[Int]] =
         Source.fromPublisher(probe).runWith(Sink.seq)(mat)
       mat.shutdown()
       future.failed.futureValue shouldBe an[AbruptTerminationException]

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SinkSpec.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
@@ -200,16 +199,16 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       // Broadcast has TypePreservingFanOut, so the single-sink case is safely bypassed.
       implicit val ex: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.parasitic
       val result = Source(List(1, 2, 3))
-        .runWith(Sink.combine(immutable.Seq(Sink.seq[Int]))(Broadcast[Int](_)))
-      Future.sequence(result).futureValue should ===(List(immutable.Seq(1, 2, 3)))
+        .runWith(Sink.combine(Seq(Sink.seq[Int]))(Broadcast[Int](_)))
+      Future.sequence(result).futureValue should ===(List(Seq(1, 2, 3)))
     }
 
     "combine single sink with Balance should work (type-preserving bypass)" in {
       // Balance has TypePreservingFanOut, so the single-sink case is safely bypassed.
       implicit val ex: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.parasitic
       val result = Source(List(1, 2, 3))
-        .runWith(Sink.combine(immutable.Seq(Sink.seq[Int]))(Balance[Int](_)))
-      Future.sequence(result).futureValue should ===(List(immutable.Seq(1, 2, 3)))
+        .runWith(Sink.combine(Seq(Sink.seq[Int]))(Balance[Int](_)))
+      Future.sequence(result).futureValue should ===(List(Seq(1, 2, 3)))
     }
 
     "combine single sink with Partition should route through strategy (not type-preserving)" in {
@@ -218,8 +217,8 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       // Single-sink Partition goes through the fan-out graph, honoring partitioner semantics.
       implicit val ex: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.parasitic
       val result = Source(List(1, 2, 3))
-        .runWith(Sink.combine(immutable.Seq(Sink.seq[Int]))(Partition[Int](_, _ => 0)))
-      Future.sequence(result).futureValue should ===(List(immutable.Seq(1, 2, 3)))
+        .runWith(Sink.combine(Seq(Sink.seq[Int]))(Partition[Int](_, _ => 0)))
+      Future.sequence(result).futureValue should ===(List(Seq(1, 2, 3)))
     }
 
     "combine single sink with wrapped Broadcast (.named) should still work" in {
@@ -227,8 +226,8 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       // (e.g., .named()), routing through the strategy is still correct.
       implicit val ex: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.parasitic
       val result = Source(List(1, 2, 3))
-        .runWith(Sink.combine(immutable.Seq(Sink.seq[Int]))(n => Broadcast[Int](n).named("myBroadcast")))
-      Future.sequence(result).futureValue should ===(List(immutable.Seq(1, 2, 3)))
+        .runWith(Sink.combine(Seq(Sink.seq[Int]))(n => Broadcast[Int](n).named("myBroadcast")))
+      Future.sequence(result).futureValue should ===(List(Seq(1, 2, 3)))
     }
 
     "suitably override attribute handling methods" in {

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/SourceSpec.scala
@@ -32,7 +32,6 @@ import pekko.stream.testkit.scaladsl.TestSink
 import pekko.testkit.EventFilter
 import pekko.util.ByteString
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 @nowarn // tests assigning to typed val
@@ -45,12 +44,12 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
     "produce exactly one element" in {
       implicit val ec = system.dispatcher
       // #source-single
-      val s: Future[immutable.Seq[Int]] = Source.single(1).runWith(Sink.seq)
+      val s: Future[Seq[Int]] = Source.single(1).runWith(Sink.seq)
       s.foreach(list => println(s"Collected elements: $list")) // prints: Collected elements: List(1)
 
       // #source-single
 
-      s.futureValue should ===(immutable.Seq(1))
+      s.futureValue should ===(Seq(1))
 
     }
 
@@ -108,12 +107,12 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
   "Composite Source" must {
     "merge from many inputs" in {
-      val probes = immutable.Seq.fill(5)(TestPublisher.manualProbe[Int]())
+      val probes = Seq.fill(5)(TestPublisher.manualProbe[Int]())
       val source = Source.asSubscriber[Int]
       val out = TestSubscriber.manualProbe[Int]()
 
       val s = Source
-        .fromGraph(GraphDSL.createGraph(source, source, source, source, source)(immutable.Seq(_, _, _, _, _)) {
+        .fromGraph(GraphDSL.createGraph(source, source, source, source, source)(Seq(_, _, _, _, _)) {
           implicit b => (i0, i1, i2, i3, i4) =>
             import GraphDSL.Implicits._
             val m = b.add(Merge[Int](5))
@@ -144,7 +143,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
     }
 
     "combine from many inputs with simplified API" in {
-      val probes = immutable.Seq.fill(3)(TestPublisher.manualProbe[Int]())
+      val probes = Seq.fill(3)(TestPublisher.manualProbe[Int]())
       val source = for (i <- 0 to 2) yield Source.fromPublisher(probes(i))
       val out = TestSubscriber.manualProbe[Int]()
 
@@ -181,44 +180,44 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
     "combine single source with MergeLatest should emit wrapped elements" in {
       Source
-        .combine(immutable.Seq(Source.single(1)))(MergeLatest(_))
+        .combine(Seq(Source.single(1)))(MergeLatest(_))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(List(1)))
+        .futureValue should ===(Seq(List(1)))
     }
 
     "combine single source with MergeLatest should emit all wrapped elements" in {
       Source
-        .combine(immutable.Seq(Source(List(1, 2, 3))))(MergeLatest(_))
+        .combine(Seq(Source(List(1, 2, 3))))(MergeLatest(_))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(List(1), List(2), List(3)))
+        .futureValue should ===(Seq(List(1), List(2), List(3)))
     }
 
     "combine single source with ZipWithN should apply zipper function" in {
       Source
-        .combine(immutable.Seq(Source(List(1, 2, 3))))(n => ZipWithN[Int, Int](_.sum)(n))
+        .combine(Seq(Source(List(1, 2, 3))))(n => ZipWithN[Int, Int](_.sum)(n))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
     }
 
     "combine single source with Merge should still work (type-preserving)" in {
       Source
-        .combine(immutable.Seq(Source.single(1)))(Merge(_))
+        .combine(Seq(Source.single(1)))(Merge(_))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1))
+        .futureValue should ===(Seq(1))
     }
 
     "combine single source with Concat should still work (type-preserving)" in {
       Source
-        .combine(immutable.Seq(Source(List(1, 2, 3))))(Concat(_))
+        .combine(Seq(Source(List(1, 2, 3))))(Concat(_))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
     }
 
     "combine single source with Interleave should still work (type-preserving)" in {
       Source
-        .combine(immutable.Seq(Source(List(1, 2, 3))))(Interleave(_, 1))
+        .combine(Seq(Source(List(1, 2, 3))))(Interleave(_, 1))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
     }
 
     "combine single source with wrapped Merge (.named) should still work" in {
@@ -227,16 +226,16 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
       // routes through the fan-in graph instead of bypassing — functionally correct,
       // just slightly less optimal.
       Source
-        .combine(immutable.Seq(Source(List(1, 2, 3))))(n => Merge[Int](n).named("my-merge"))
+        .combine(Seq(Source(List(1, 2, 3))))(n => Merge[Int](n).named("my-merge"))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
     }
 
     "combine single source with wrapped MergeLatest (.named) should emit wrapped elements" in {
       Source
-        .combine(immutable.Seq(Source(List(1, 2, 3))))(n => MergeLatest[Int](n).named("my-merge-latest"))
+        .combine(Seq(Source(List(1, 2, 3))))(n => MergeLatest[Int](n).named("my-merge-latest"))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(List(1), List(2), List(3)))
+        .futureValue should ===(Seq(List(1), List(2), List(3)))
     }
 
     "combine single source with MergeSequence should still work (type-preserving)" in {
@@ -244,37 +243,37 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
       // trait. This means single-source MergeSequence goes through the fan-in strategy (safe
       // default). The test uses 0-based sequences to satisfy MergeSequence's ordering validation.
       Source
-        .combine(immutable.Seq(Source(List(0L, 1L, 2L))))(n => MergeSequence[Long](n)(identity))
+        .combine(Seq(Source(List(0L, 1L, 2L))))(n => MergeSequence[Long](n)(identity))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(0L, 1L, 2L))
+        .futureValue should ===(Seq(0L, 1L, 2L))
     }
 
     "combine single source with MergePrioritized should still work (type-preserving)" in {
       Source
-        .combine(immutable.Seq(Source(List(1, 2, 3))))(n => MergePrioritized(Seq.fill(n)(1)))
+        .combine(Seq(Source(List(1, 2, 3))))(n => MergePrioritized(Seq.fill(n)(1)))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
     }
 
     "combine single source materialized value should be a singleton list" in {
       val (mat, result) = Source
-        .combine(immutable.Seq(Source.single(1).mapMaterializedValue(_ => "mat-value")))(MergeLatest(_))
+        .combine(Seq(Source.single(1).mapMaterializedValue(_ => "mat-value")))(MergeLatest(_))
         .toMat(Sink.seq)(Keep.both)
         .run()
-      mat should ===(immutable.Seq("mat-value"))
-      result.futureValue should ===(immutable.Seq(List(1)))
+      mat should ===(Seq("mat-value"))
+      result.futureValue should ===(Seq(List(1)))
     }
 
     "combine empty sources list should produce empty source" in {
       val result = Source
-        .combine(immutable.Seq.empty[Source[Int, NotUsed]])(MergeLatest(_))
+        .combine(Seq.empty[Source[Int, NotUsed]])(MergeLatest(_))
         .runWith(Sink.seq)
         .futureValue
-      result should ===(immutable.Seq.empty)
+      result should ===(Seq.empty)
     }
 
     "combine from two inputs with simplified API" in {
-      val probes = immutable.Seq.fill(2)(TestPublisher.manualProbe[Int]())
+      val probes = Seq.fill(2)(TestPublisher.manualProbe[Int]())
       val source = Source.fromPublisher(probes(0)) :: Source.fromPublisher(probes(1)) :: Nil
       val out = TestSubscriber.manualProbe[Int]()
 
@@ -296,10 +295,10 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
     }
 
     "combine using Concat strategy two inputs with simplified API" in {
-      val sources = immutable.Seq(Source(List(1, 2, 3)), Source(List(10, 20, 30)))
+      val sources = Seq(Source(List(1, 2, 3)), Source(List(10, 20, 30)))
 
       Source.combine(sources(0), sources(1))(Concat(_)).runWith(Sink.seq).futureValue should ===(
-        immutable.Seq(1, 2, 3, 10, 20, 30))
+        Seq(1, 2, 3, 10, 20, 30))
     }
 
     "combine using Concat strategy 3 inputs with simplified API" in {
@@ -308,7 +307,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
       val others = Source(List("b", "c"))
       Source.combine(first, second, others)(x => Concat[String](x))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq("a", "b", "c"))
+        .futureValue should ===(Seq("a", "b", "c"))
     }
 
     "combine from two inputs with combinedMat and take a materialized value" in {
@@ -382,7 +381,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
         .flatMapConcat(_ => Source.repeat(42))
         .take(3)
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(42, 42, 42))
+        .futureValue should ===(Seq(42, 42, 42))
     }
 
     "work when recovered through value-presented source fast path" in {
@@ -391,19 +390,19 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
         .recoverWithRetries(1, { case _ => Source.repeat(42) })
         .take(3)
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(42, 42, 42))
+        .futureValue should ===(Seq(42, 42, 42))
     }
   }
 
   "Range Source" must {
     "emit inclusive and exclusive ranges" in {
-      Source(1 to 4).runWith(Sink.seq).futureValue should ===(immutable.Seq(1, 2, 3, 4))
-      Source(1 until 4).runWith(Sink.seq).futureValue should ===(immutable.Seq(1, 2, 3))
+      Source(1 to 4).runWith(Sink.seq).futureValue should ===(Seq(1, 2, 3, 4))
+      Source(1 until 4).runWith(Sink.seq).futureValue should ===(Seq(1, 2, 3))
     }
 
     "emit stepped and empty ranges" in {
-      Source(5 to 1 by -2).runWith(Sink.seq).futureValue should ===(immutable.Seq(5, 3, 1))
-      Source(1 to 5 by -1).runWith(Sink.seq).futureValue should ===(immutable.Seq.empty)
+      Source(5 to 1 by -2).runWith(Sink.seq).futureValue should ===(Seq(5, 3, 1))
+      Source(1 to 5 by -1).runWith(Sink.seq).futureValue should ===(Seq.empty)
     }
 
     "work when flattened through value-presented source fast path" in {
@@ -411,7 +410,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
         .single("range")
         .flatMapConcat(_ => Source(1 to 3))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
     }
 
     "work when recovered through value-presented source fast path" in {
@@ -419,7 +418,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
         .failed[Int](TE("boom"))
         .recoverWithRetries(1, { case _ => Source(1 to 3) })
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
     }
   }
 
@@ -475,18 +474,18 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
     "be able to iterate properly" in {
       Source.iterate[Int](0)(_ => true, _ + 1)
         .take(10)
-        .runWith(Sink.seq).futureValue should ===(immutable.Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+        .runWith(Sink.seq).futureValue should ===(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
     }
 
     "be able to generate an empty sequence" in {
-      Source.iterate[Int](0)(_ => false, _ + 1).runWith(Sink.seq).futureValue should ===(immutable.Seq())
+      Source.iterate[Int](0)(_ => false, _ + 1).runWith(Sink.seq).futureValue should ===(Seq())
     }
   }
 
   "Iterator Source" must {
     "properly iterate" in {
       Source.fromIterator(() => Iterator.iterate(false)(!_)).grouped(10).runWith(Sink.head).futureValue should ===(
-        immutable.Seq(false, true, false, true, false, true, false, true, false, true))
+        Seq(false, true, false, true, false, true, false, true, false, true))
     }
 
     "work when flattened through value-presented source fast path" in {
@@ -494,7 +493,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
         .single("iterator")
         .flatMapConcat(_ => Source.fromIterator(() => Iterator(1, 2, 3)))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
     }
 
     "work when recovered through value-presented source fast path" in {
@@ -502,19 +501,19 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
         .failed[Int](TE("boom"))
         .recoverWithRetries(1, { case _ => Source.fromIterator(() => Iterator(1, 2, 3)) })
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
     }
 
     "fail stream when iterator throws" in {
       Source
-        .fromIterator(() => (1 to 1000).toIterator.map(k => if (k < 10) k else throw TE("a")))
+        .fromIterator(() => (1 to 1000).iterator.map(k => if (k < 10) k else throw TE("a")))
         .runWith(Sink.ignore)
         .failed
         .futureValue
         .getClass should ===(classOf[TE])
 
       Source
-        .fromIterator(() => (1 to 1000).toIterator.map(_ => throw TE("b")))
+        .fromIterator(() => (1 to 1000).iterator.map(_ => throw TE("b")))
         .runWith(Sink.ignore)
         .failed
         .futureValue
@@ -534,7 +533,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
       // using stopping decider with recover
       Source
-        .fromIterator(() => (1 to 5).toIterator.map(k => if (k != 3) k else throw TE("a")))
+        .fromIterator(() => (1 to 5).iterator.map(k => if (k != 3) k else throw TE("a")))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
         .recoverWithRetries(1, { case _ => Source.empty })
         .grouped(10)
@@ -543,7 +542,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
       // failing on every elements, using stopping decider
       Source
-        .fromIterator(() => (1 to 5).toIterator.map(_ => throw TE("b")))
+        .fromIterator(() => (1 to 5).iterator.map(_ => throw TE("b")))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
         .grouped(10)
         .runWith(Sink.headOption)
@@ -552,7 +551,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
       // failing on every elements, using stopping decider and recover
       Source
-        .fromIterator(() => (1 to 5).toIterator.map(_ => throw TE("b")))
+        .fromIterator(() => (1 to 5).iterator.map(_ => throw TE("b")))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.stoppingDecider))
         .recoverWithRetries(1, { case _ => Source.empty })
         .grouped(10)
@@ -561,7 +560,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
       // using resuming decider
       Source
-        .fromIterator(() => (1 to 5).toIterator.map(k => if (k != 3) k else throw TE("a")))
+        .fromIterator(() => (1 to 5).iterator.map(k => if (k != 3) k else throw TE("a")))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
         .grouped(10)
         .runWith(Sink.head)
@@ -569,7 +568,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
       // using restarting decider
       Source
-        .fromIterator(() => (1 to 5).toIterator.map(k => if (k != 3) k else throw TE("a")))
+        .fromIterator(() => (1 to 5).iterator.map(k => if (k != 3) k else throw TE("a")))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
         .grouped(10)
         .runWith(Sink.head)
@@ -577,7 +576,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
       //  with failing on every elements, using restarting decider
       Source
-        .fromIterator(() => (1 to 5).toIterator.map(_ => throw TE("b")))
+        .fromIterator(() => (1 to 5).iterator.map(_ => throw TE("b")))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
         .grouped(10)
         .runWith(Sink.headOption)
@@ -590,7 +589,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
         .fromIterator[Int](() => throw TE("factory"))
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq.empty)
+        .futureValue should ===(Seq.empty)
     }
 
     "restart iterator factory when iterator factory throws and decider restarts" in {
@@ -603,7 +602,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
         }
         .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
         .runWith(Sink.seq)
-        .futureValue should ===(immutable.Seq(1, 2, 3))
+        .futureValue should ===(Seq(1, 2, 3))
       attempts should ===(2)
     }
 
@@ -624,18 +623,18 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
   "ZipN Source" must {
     "properly zipN" in {
-      val sources = immutable.Seq(Source(List(1, 2, 3)), Source(List(10, 20, 30)), Source(List(100, 200, 300)))
+      val sources = Seq(Source(List(1, 2, 3)), Source(List(10, 20, 30)), Source(List(100, 200, 300)))
 
       Source.zipN(sources).runWith(Sink.seq).futureValue should ===(
-        immutable.Seq(immutable.Seq(1, 10, 100), immutable.Seq(2, 20, 200), immutable.Seq(3, 30, 300)))
+        Seq(Seq(1, 10, 100), Seq(2, 20, 200), Seq(3, 30, 300)))
     }
   }
 
   "ZipWithN Source" must {
     "properly zipWithN" in {
-      val sources = immutable.Seq(Source(List(1, 2, 3)), Source(List(10, 20, 30)), Source(List(100, 200, 300)))
+      val sources = Seq(Source(List(1, 2, 3)), Source(List(10, 20, 30)), Source(List(100, 200, 300)))
 
-      Source.zipWithN[Int, Int](_.sum)(sources).runWith(Sink.seq).futureValue should ===(immutable.Seq(111, 222, 333))
+      Source.zipWithN[Int, Int](_.sum)(sources).runWith(Sink.seq).futureValue should ===(Seq(111, 222, 333))
     }
   }
 
@@ -688,7 +687,7 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
   "A Source.run" must {
     "ignore elements it outputs and only signal the completion of the processing" in {
-      Source.fromIterator(() => (1 to 5).toIterator).map(_ * 10).run().futureValue shouldBe Done
+      Source.fromIterator(() => (1 to 5).iterator).map(_ * 10).run().futureValue shouldBe Done
     }
   }
 

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StreamRefsSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/StreamRefsSpec.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.Promise
 import scala.concurrent.duration._
@@ -319,7 +318,7 @@ class StreamRefsSpec extends PekkoSpec(StreamRefsSpec.config()) {
       remoteActor.tell("give-subscribe-timeout", remoteProbe.ref)
       val remoteSource: SourceRef[String] = remoteProbe.expectMsgType[SourceRef[String]]
       // materialize directly and start consuming, timeout is 500ms
-      val eventualStrings: Future[immutable.Seq[String]] = remoteSource
+      val eventualStrings: Future[Seq[String]] = remoteSource
         .throttle(1, 100.millis, 1, ThrottleMode.Shaping)
         .take(60) // 60 * 100 millis - data flowing for 6 seconds - both 500ms and 5s timeouts should have passed
         .runWith(Sink.seq)

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/TakeLastSinkSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/TakeLastSinkSpec.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.{ Await, Future }
 
 import org.apache.pekko
@@ -37,8 +36,8 @@ class TakeLastSinkSpec
   "Sink.takeLast" must {
     "return the last 3 elements" in {
       val input = 1 to 6
-      val future: Future[immutable.Seq[Int]] = Source(input).runWith(Sink.takeLast(3))
-      val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+      val future: Future[Seq[Int]] = Source(input).runWith(Sink.takeLast(3))
+      val result: Seq[Int] = Await.result(future, remainingOrDefault)
       result should be(Seq(4, 5, 6))
     }
 
@@ -79,30 +78,30 @@ class TakeLastSinkSpec
 
     "return the number of elements taken when the stream completes" in {
       val input = 1 to 4
-      val future: Future[immutable.Seq[Int]] = Source(input).runWith(Sink.takeLast(5))
-      val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+      val future: Future[Seq[Int]] = Source(input).runWith(Sink.takeLast(5))
+      val result: Seq[Int] = Await.result(future, remainingOrDefault)
       result should be(Seq(1, 2, 3, 4))
     }
 
     "fail future when stream abruptly terminated" in {
       val mat = ActorMaterializer()
       val probe = TestPublisher.probe()
-      val future: Future[immutable.Seq[Int]] =
+      val future: Future[Seq[Int]] =
         Source.fromPublisher(probe).runWith(Sink.takeLast(2))(mat)
       mat.shutdown()
       future.failed.futureValue shouldBe an[AbruptTerminationException]
     }
 
     "yield empty seq for empty stream" in {
-      val future: Future[immutable.Seq[Int]] = Source.empty[Int].runWith(Sink.takeLast(3))
-      val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+      val future: Future[Seq[Int]] = Source.empty[Int].runWith(Sink.takeLast(3))
+      val result: Seq[Int] = Await.result(future, remainingOrDefault)
       result should be(Seq.empty)
     }
 
     "return the last element" in {
       val input = 1 to 4
-      val future: Future[immutable.Seq[Int]] = Source(input).runWith(Sink.takeLast(1))
-      val result: immutable.Seq[Int] = Await.result(future, remainingOrDefault)
+      val future: Future[Seq[Int]] = Source(input).runWith(Sink.takeLast(1))
+      val result: Seq[Int] = Await.result(future, remainingOrDefault)
       result should be(Seq(4))
     }
   }

--- a/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/WithContextUsageSpec.scala
+++ b/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/WithContextUsageSpec.scala
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.stream.scaladsl
 
-import scala.collection.immutable
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.testkit.StreamSpec
@@ -204,7 +202,7 @@ case class Offset(value: Int)
 
 case class Record(key: String, value: String)
 case class Committed[R](record: R, offset: Int)
-case class MultiRecord(records: immutable.Seq[Record])
+case class MultiRecord(records: Seq[Record])
 
 object Consumer {
   def committableSource(

--- a/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
+++ b/stream-typed-tests/src/test/scala/org/apache/pekko/stream/MapAsyncPartitionedSpec.scala
@@ -172,8 +172,8 @@ class MapAsyncPartitionedSpec
           .runWith(Sink.seq)
           .futureValue
 
-      val actual = result.groupBy(_._1).mapValues2(_.map(_._2)).toMap
-      val expected = elements.toSeq.groupBy(_.key).mapValues2(_.map(_.value)).toMap
+      val actual = result.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
+      val expected = elements.toSeq.groupBy(_.key).view.mapValues(_.map(_.value)).toMap
 
       actual shouldBe expected
     }
@@ -188,8 +188,8 @@ class MapAsyncPartitionedSpec
           .runWith(Sink.seq)
           .futureValue
 
-      val actual = result.groupBy(_._1).mapValues2(_.map(_._2)).toMap
-      val expected = elements.toSeq.groupBy(_.key).mapValues2(_.map(_.value)).toMap
+      val actual = result.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
+      val expected = elements.toSeq.groupBy(_.key).view.mapValues(_.map(_.value)).toMap
 
       actual shouldBe expected
     }
@@ -204,8 +204,8 @@ class MapAsyncPartitionedSpec
           .runWith(Sink.seq)
           .futureValue
 
-      val actual = result.groupBy(_._1).mapValues2(_.map(_._2)).toMap
-      val expected = elements.toSeq.groupBy(_.key).mapValues2(_.map(_.value)).toMap
+      val actual = result.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
+      val expected = elements.toSeq.groupBy(_.key).view.mapValues(_.map(_.value)).toMap
 
       actual shouldBe expected
     }
@@ -516,11 +516,6 @@ class MapAsyncPartitionedSpec
       .expectNext((1, 1))
       .expectNext((2, 2))
       .expectComplete()
-  }
-
-  private implicit class MapWrapper[K, V](map: Map[K, V]) {
-    @nowarn("msg=deprecated")
-    def mapValues2[W](f: V => W) = map.mapValues(f)
   }
 
 }

--- a/stream-typed/src/test/scala/docs/scaladsl/ActorFlowSpec.scala
+++ b/stream-typed/src/test/scala/docs/scaladsl/ActorFlowSpec.scala
@@ -29,7 +29,6 @@ import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import pekko.stream.testkit.TestSubscriber
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
@@ -76,7 +75,7 @@ class ActorFlowSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
     })
 
     "produce asked elements" in {
-      val in: Future[immutable.Seq[Reply]] =
+      val in: Future[Seq[Reply]] =
         Source
           .repeat("hello")
           .via(ActorFlow.ask(replier)((el, replyTo: ActorRef[Reply]) => Asking(el, replyTo)))
@@ -87,7 +86,7 @@ class ActorFlowSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
     }
 
     "produce asked elements with context " in {
-      val in: Future[immutable.Seq[(Reply, Long)]] =
+      val in: Future[Seq[(Reply, Long)]] =
         Source
           .repeat("hello")
           .zipWithIndex
@@ -99,7 +98,7 @@ class ActorFlowSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
     }
 
     "produced status success elements unwrap " in {
-      val in: Future[immutable.Seq[String]] =
+      val in: Future[Seq[String]] =
         Source
           .repeat("hello")
           .via(ActorFlow.askWithStatus(replierWithSuccess)((el, replyTo: ActorRef[StatusReply[String]]) =>
@@ -111,7 +110,7 @@ class ActorFlowSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
     }
 
     "produced status success elements unwrap with context " in {
-      val in: Future[immutable.Seq[(String, Long)]] =
+      val in: Future[Seq[(String, Long)]] =
         Source
           .repeat("hello")
           .zipWithIndex
@@ -124,7 +123,7 @@ class ActorFlowSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
     }
 
     "produce status error elements unwrap " in {
-      val in: Future[immutable.Seq[String]] =
+      val in: Future[Seq[String]] =
         Source
           .repeat("hello")
           .via(ActorFlow.askWithStatus(replierWithError)((el, replyTo: ActorRef[StatusReply[String]]) =>
@@ -138,7 +137,7 @@ class ActorFlowSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
     }
 
     "produce status error elements unwrap with context" in {
-      val in: Future[immutable.Seq[(String, Long)]] =
+      val in: Future[Seq[(String, Long)]] =
         Source
           .repeat("hello")
           .zipWithIndex
@@ -171,7 +170,7 @@ class ActorFlowSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
       val askFlowExplicit: Flow[String, Reply, NotUsed] =
         ActorFlow.ask(ref)(makeMessage = (el, replyTo: ActorRef[Reply]) => Asking(el, replyTo))
 
-      val in: Future[immutable.Seq[String]] =
+      val in: Future[Seq[String]] =
         Source(1 to 50).map(_.toString).via(askFlow).map(_.msg).runWith(Sink.seq)
       // #ask
       askFlowExplicit.map(identity)

--- a/stream/src/main/mima-filters/2.0.x.backwards.excludes/scala-2.13-idioms.excludes
+++ b/stream/src/main/mima-filters/2.0.x.backwards.excludes/scala-2.13-idioms.excludes
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Shape is @InternalApi private[pekko]. Rewriting `immutable.Seq[?]` as `Seq[?]`
+# keeps the erased descriptor but changes the Java generic signature from
+# Seq<?> to Seq<Object>, which MiMa reports.
+ProblemFilters.exclude[IncompatibleSignatureProblem]("org.apache.pekko.stream.Shape.hasOnePort")

--- a/stream/src/main/scala/org/apache/pekko/stream/FanInShape.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/FanInShape.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.immutable
 
 import org.apache.pekko.annotation.DoNotInherit
 
@@ -23,14 +22,14 @@ object FanInShape {
   /** Not for user extension */
   @DoNotInherit sealed trait Init[O] {
     def outlet: Outlet[O]
-    def inlets: immutable.Seq[Inlet[?]]
+    def inlets: Seq[Inlet[?]]
     def name: String
   }
   final case class Name[O](override val name: String) extends Init[O] {
     override def outlet: Outlet[O] = Outlet(s"$name.out")
-    override def inlets: immutable.Seq[Inlet[?]] = Nil
+    override def inlets: Seq[Inlet[?]] = Nil
   }
-  final case class Ports[O](override val outlet: Outlet[O], override val inlets: immutable.Seq[Inlet[?]])
+  final case class Ports[O](override val outlet: Outlet[O], override val inlets: Seq[Inlet[?]])
       extends Init[O] {
     override def name: String = "FanIn"
   }
@@ -46,12 +45,12 @@ abstract class FanInShape[+O] private (
   def this(init: FanInShape.Init[O]) = this(init.outlet, init.inlets.iterator, init.name)
 
   final def out: Outlet[O @uncheckedVariance] = _out
-  final override def outlets: immutable.Seq[Outlet[O @uncheckedVariance]] = _out :: Nil
+  final override def outlets: Seq[Outlet[O @uncheckedVariance]] = _out :: Nil
 
   /**
    * Not meant for overriding outside of Apache Pekko.
    */
-  override def inlets: immutable.Seq[Inlet[?]] = _inlets
+  override def inlets: Seq[Inlet[?]] = _inlets
 
   /**
    * Performance of subclass `UniformFanInShape` relies on `_inlets` being a `Vector`, not a `List`.

--- a/stream/src/main/scala/org/apache/pekko/stream/FanOutShape.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/FanOutShape.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.immutable
 
 import org.apache.pekko.annotation.DoNotInherit
 
@@ -23,14 +22,14 @@ object FanOutShape {
   /** Not for user extension */
   @DoNotInherit sealed trait Init[I] {
     def inlet: Inlet[I]
-    def outlets: immutable.Seq[Outlet[?]]
+    def outlets: Seq[Outlet[?]]
     def name: String
   }
   final case class Name[I](override val name: String) extends Init[I] {
     override def inlet: Inlet[I] = Inlet(s"$name.in")
-    override def outlets: immutable.Seq[Outlet[?]] = Nil
+    override def outlets: Seq[Outlet[?]] = Nil
   }
-  final case class Ports[I](override val inlet: Inlet[I], override val outlets: immutable.Seq[Outlet[?]])
+  final case class Ports[I](override val inlet: Inlet[I], override val outlets: Seq[Outlet[?]])
       extends Init[I] {
     override def name: String = "FanOut"
   }
@@ -50,8 +49,8 @@ abstract class FanOutShape[-I] private (
   /**
    * Not meant for overriding outside of Apache Pekko.
    */
-  override def outlets: immutable.Seq[Outlet[?]] = _outlets
-  final override def inlets: immutable.Seq[Inlet[I @uncheckedVariance]] = in :: Nil
+  override def outlets: Seq[Outlet[?]] = _outlets
+  final override def inlets: Seq[Inlet[I @uncheckedVariance]] = in :: Nil
 
   /**
    * Performance of subclass `UniformFanOutShape` relies on `_outlets` being a `Vector`, not a `List`.

--- a/stream/src/main/scala/org/apache/pekko/stream/Shape.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/Shape.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 
 import org.apache.pekko
@@ -169,7 +168,7 @@ final class Outlet[T] private (val s: String) extends OutPort {
    * `inlets` and `outlets` can be `Vector` or `List` so this method
    * checks the size of 1 in an optimized way.
    */
-  def hasOnePort(ports: immutable.Seq[?]): Boolean = {
+  def hasOnePort(ports: Seq[?]): Boolean = {
     ports.nonEmpty &&
     (ports match {
       case l: List[?] => l.tail.isEmpty // assuming List is most common
@@ -189,12 +188,12 @@ abstract class Shape {
   /**
    * Scala API: get a list of all input ports
    */
-  def inlets: immutable.Seq[Inlet[?]]
+  def inlets: Seq[Inlet[?]]
 
   /**
    * Scala API: get a list of all output ports
    */
-  def outlets: immutable.Seq[Outlet[?]]
+  def outlets: Seq[Outlet[?]]
 
   /**
    * Create a copy of this Shape object, returning the same type as the
@@ -255,8 +254,8 @@ abstract class AbstractShape extends Shape {
    */
   def allOutlets: java.util.List[Outlet[?]]
 
-  final override lazy val inlets: immutable.Seq[Inlet[?]] = allInlets.asScala.toList
-  final override lazy val outlets: immutable.Seq[Outlet[?]] = allOutlets.asScala.toList
+  final override lazy val inlets: Seq[Inlet[?]] = allInlets.asScala.toList
+  final override lazy val outlets: Seq[Outlet[?]] = allOutlets.asScala.toList
 
   final override def getInlets = allInlets
   final override def getOutlets = allOutlets
@@ -269,8 +268,8 @@ abstract class AbstractShape extends Shape {
  */
 @DoNotInherit sealed abstract class ClosedShape extends Shape
 object ClosedShape extends ClosedShape {
-  override val inlets: immutable.Seq[Inlet[?]] = EmptyImmutableSeq
-  override val outlets: immutable.Seq[Outlet[?]] = EmptyImmutableSeq
+  override val inlets: Seq[Inlet[?]] = EmptyImmutableSeq
+  override val outlets: Seq[Outlet[?]] = EmptyImmutableSeq
   override def deepCopy() = this
 
   /**
@@ -287,7 +286,7 @@ object ClosedShape extends ClosedShape {
  * implementation of the [[Graph]] builders and typically replaced by a more
  * meaningful type of Shape when the building is finished.
  */
-case class AmorphousShape(inlets: immutable.Seq[Inlet[?]], outlets: immutable.Seq[Outlet[?]]) extends Shape {
+case class AmorphousShape(inlets: Seq[Inlet[?]], outlets: Seq[Outlet[?]]) extends Shape {
   override def deepCopy() = AmorphousShape(inlets.map(_.carbonCopy()), outlets.map(_.carbonCopy()))
 }
 
@@ -296,8 +295,8 @@ case class AmorphousShape(inlets: immutable.Seq[Inlet[?]], outlets: immutable.Se
  * of data.
  */
 final case class SourceShape[+T](out: Outlet[T @uncheckedVariance]) extends Shape {
-  override val inlets: immutable.Seq[Inlet[?]] = EmptyImmutableSeq
-  override val outlets: immutable.Seq[Outlet[?]] = out :: Nil
+  override val inlets: Seq[Inlet[?]] = EmptyImmutableSeq
+  override val outlets: Seq[Outlet[?]] = out :: Nil
 
   override def deepCopy(): SourceShape[T] = SourceShape(out.carbonCopy())
 }
@@ -314,8 +313,8 @@ object SourceShape {
  * course).
  */
 final case class FlowShape[-I, +O](in: Inlet[I @uncheckedVariance], out: Outlet[O @uncheckedVariance]) extends Shape {
-  override val inlets: immutable.Seq[Inlet[?]] = in :: Nil
-  override val outlets: immutable.Seq[Outlet[?]] = out :: Nil
+  override val inlets: Seq[Inlet[?]] = in :: Nil
+  override val outlets: Seq[Outlet[?]] = out :: Nil
 
   override def deepCopy(): FlowShape[I, O] = FlowShape(in.carbonCopy(), out.carbonCopy())
 }
@@ -330,8 +329,8 @@ object FlowShape {
  * A Sink [[Shape]] has exactly one input and no outputs, it models a data sink.
  */
 final case class SinkShape[-T](in: Inlet[T @uncheckedVariance]) extends Shape {
-  override val inlets: immutable.Seq[Inlet[?]] = in :: Nil
-  override val outlets: immutable.Seq[Outlet[?]] = EmptyImmutableSeq
+  override val inlets: Seq[Inlet[?]] = in :: Nil
+  override val outlets: Seq[Outlet[?]] = EmptyImmutableSeq
 
   override def deepCopy(): SinkShape[T] = SinkShape(in.carbonCopy())
 }
@@ -362,8 +361,8 @@ final case class BidiShape[-In1, +Out1, -In2, +Out2](
     out2: Outlet[Out2 @uncheckedVariance])
     extends Shape {
   // #implementation-details-elided
-  override val inlets: immutable.Seq[Inlet[?]] = in1 :: in2 :: Nil
-  override val outlets: immutable.Seq[Outlet[?]] = out1 :: out2 :: Nil
+  override val inlets: Seq[Inlet[?]] = in1 :: in2 :: Nil
+  override val outlets: Seq[Outlet[?]] = out1 :: out2 :: Nil
 
   /**
    * Java API for creating from a pair of unidirectional flows.

--- a/stream/src/main/scala/org/apache/pekko/stream/SslTlsOptions.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/SslTlsOptions.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.stream
 import javax.net.ssl._
 
 import scala.annotation.varargs
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
@@ -221,8 +220,8 @@ object TLSProtocol {
    * switches off client authentication.
    */
   case class NegotiateNewSession(
-      enabledCipherSuites: Option[immutable.Seq[String]],
-      enabledProtocols: Option[immutable.Seq[String]],
+      enabledCipherSuites: Option[Seq[String]],
+      enabledProtocols: Option[Seq[String]],
       clientAuth: Option[TLSClientAuth],
       sslParameters: Option[SSLParameters])
       extends SslTlsOutbound {

--- a/stream/src/main/scala/org/apache/pekko/stream/UniformFanInShape.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/UniformFanInShape.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.immutable
 
 object UniformFanInShape {
   def apply[I, O](outlet: Outlet[O], inlets: Inlet[I]*): UniformFanInShape[I, O] =
@@ -39,8 +38,8 @@ class UniformFanInShape[-T, +O](val n: Int, _init: FanInShape.Init[O]) extends F
     new UniformFanInShape(n, init)
   override def deepCopy(): UniformFanInShape[T, O] = super.deepCopy().asInstanceOf[UniformFanInShape[T, O]]
 
-  final override def inlets: immutable.Seq[Inlet[T @uncheckedVariance]] =
-    super.inlets.asInstanceOf[immutable.Seq[Inlet[T]]]
+  final override def inlets: Seq[Inlet[T @uncheckedVariance]] =
+    super.inlets.asInstanceOf[Seq[Inlet[T]]]
 
   def in(n: Int): Inlet[T @uncheckedVariance] = inlets(n)
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/UniformFanOutShape.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/UniformFanOutShape.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.immutable
 
 object UniformFanOutShape {
   def apply[I, O](inlet: Inlet[I], outlets: Outlet[O]*): UniformFanOutShape[I, O] =
@@ -33,8 +32,8 @@ class UniformFanOutShape[-I, +O](n: Int, _init: FanOutShape.Init[I @uncheckedVar
     new UniformFanOutShape(n, init)
   override def deepCopy(): UniformFanOutShape[I, O] = super.deepCopy().asInstanceOf[UniformFanOutShape[I, O]]
 
-  final override def outlets: immutable.Seq[Outlet[O @uncheckedVariance]] =
-    super.outlets.asInstanceOf[immutable.Seq[Outlet[O]]]
+  final override def outlets: Seq[Outlet[O @uncheckedVariance]] =
+    super.outlets.asInstanceOf[Seq[Outlet[O]]]
 
   def out(n: Int): Outlet[O @uncheckedVariance] = outlets(n)
 }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorMaterializerImpl.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorMaterializerImpl.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.stream.impl
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 
@@ -208,7 +207,7 @@ private[pekko] class SubFusingActorMaterializerImpl(
       with NoSerializationVerificationNeeded
 
   final case class GetChildrenSnapshots(timeout: FiniteDuration)
-  final case class ChildrenSnapshots(seq: immutable.Seq[StreamSnapshot])
+  final case class ChildrenSnapshots(seq: Seq[StreamSnapshot])
       extends DeadLetterSuppression
       with NoSerializationVerificationNeeded
   private final case class CollectorCompleted(ref: ActorRef)

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/ActorPublisher.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/ActorPublisher.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.stream.impl
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.util.control.NoStackTrace
 
 import org.apache.pekko
@@ -58,7 +57,7 @@ import org.reactivestreams.Subscription
   // SubscribePending message. The AtomicReference is set to null by the shutdown method, which is
   // called by the actor from postStop. Pending (unregistered) subscription attempts are denied by
   // the shutdown method. Subscription attempts after shutdown can be denied immediately.
-  private val pendingSubscribers = new AtomicReference[immutable.Seq[Subscriber[? >: T]]](Nil)
+  private val pendingSubscribers = new AtomicReference[Seq[Subscriber[? >: T]]](Nil)
 
   protected val wakeUpMsg: Any = SubscribePending
 
@@ -79,7 +78,7 @@ import org.reactivestreams.Subscription
     doSubscribe()
   }
 
-  def takePendingSubscribers(): immutable.Seq[Subscriber[? >: T]] = {
+  def takePendingSubscribers(): Seq[Subscriber[? >: T]] = {
     val pending = pendingSubscribers.getAndSet(Nil)
     if (pending eq null) Nil else pending.reverse
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanOut.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanOut.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.impl
 
 import scala.annotation.nowarn
-import scala.collection.immutable
 
 import org.apache.pekko
 import pekko.actor._
@@ -48,7 +47,7 @@ import org.reactivestreams.Subscription
     override def createSubscription(): Subscription = new SubstreamSubscription(actor, id)
   }
 
-  final case class ExposedPublishers(publishers: immutable.Seq[ActorPublisher[Any]])
+  final case class ExposedPublishers(publishers: Seq[ActorPublisher[Any]])
       extends DeadLetterSuppression
       with NoSerializationVerificationNeeded
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/FanoutPublisherBridgeStage.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/FanoutPublisherBridgeStage.scala
@@ -20,7 +20,6 @@ package org.apache.pekko.stream.impl
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.util.control.NoStackTrace
 
 import org.apache.pekko
@@ -192,7 +191,7 @@ import org.reactivestreams.{ Publisher, Subscriber }
     extends Publisher[T] {
   import ReactiveStreamsCompliance._
 
-  private val pendingSubscribers = new AtomicReference[immutable.Seq[Subscriber[? >: T]]](Nil)
+  private val pendingSubscribers = new AtomicReference[Seq[Subscriber[? >: T]]](Nil)
   private val shutdownStarted = new AtomicBoolean(false)
 
   @volatile private var shutdownReason: Option[Throwable] = None
@@ -210,8 +209,8 @@ import org.reactivestreams.{ Publisher, Subscriber }
     doSubscribe()
   }
 
-  def takePendingSubscribers(): immutable.Seq[Subscriber[? >: T]] = {
-    @tailrec def swapPendingSubscribers(): immutable.Seq[Subscriber[? >: T]] = {
+  def takePendingSubscribers(): Seq[Subscriber[? >: T]] = {
+    @tailrec def swapPendingSubscribers(): Seq[Subscriber[? >: T]] = {
       val current = pendingSubscribers.get()
       if (current eq null) Nil
       else if (pendingSubscribers.compareAndSet(current, Nil)) current.reverse

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/Sinks.scala
@@ -139,7 +139,7 @@ import org.reactivestreams.Subscriber
  * INTERNAL API
  */
 @InternalApi private[pekko] final class TakeLastStage[T](n: Int)
-    extends GraphStageWithMaterializedValue[SinkShape[T], Future[immutable.Seq[T]]] {
+    extends GraphStageWithMaterializedValue[SinkShape[T], Future[Seq[T]]] {
   if (n <= 0)
     throw new IllegalArgumentException("requirement failed: n must be greater than 0")
 
@@ -148,7 +148,7 @@ import org.reactivestreams.Subscriber
   override val shape: SinkShape[T] = SinkShape.of(in)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
-    val p: Promise[immutable.Seq[T]] = Promise()
+    val p: Promise[Seq[T]] = Promise()
     (new GraphStageLogic(shape) with InHandler {
         private val buffer = mutable.Queue.empty[T]
         private var count = 0

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
@@ -367,7 +366,7 @@ import org.reactivestreams.Subscription
     // SubscribePending message. The AtomicReference is set to null by the shutdown method, which is
     // called by the actor from postStop. Pending (unregistered) subscription attempts are denied by
     // the shutdown method. Subscription attempts after shutdown can be denied immediately.
-    private val pendingSubscribers = new AtomicReference[immutable.Seq[Subscriber[Any]]](Nil)
+    private val pendingSubscribers = new AtomicReference[Seq[Subscriber[Any]]](Nil)
 
     protected val wakeUpMsg: Any = new SubscribePending(boundary)
 
@@ -389,7 +388,7 @@ import org.reactivestreams.Subscription
       doSubscribe()
     }
 
-    def takePendingSubscribers(): immutable.Seq[Subscriber[Any]] = {
+    def takePendingSubscribers(): Seq[Subscriber[Any]] = {
       val pending = pendingSubscribers.getAndSet(Nil)
       if (pending eq null) Nil else pending.reverse
     }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/FlatMapPrefix.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/FlatMapPrefix.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.impl.fusing
 
-import scala.collection.immutable
 import scala.concurrent.{ Future, Promise }
 import scala.util.control.NonFatal
 
@@ -26,7 +25,7 @@ import pekko.stream.scaladsl.{ Flow, Keep, Source }
 import pekko.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler }
 import pekko.util.OptionVal
 
-@InternalApi private[pekko] final class FlatMapPrefix[In, Out, M](n: Int, f: immutable.Seq[In] => Flow[In, Out, M])
+@InternalApi private[pekko] final class FlatMapPrefix[In, Out, M](n: Int, f: Seq[In] => Flow[In, Out, M])
     extends GraphStageWithMaterializedValue[FlowShape[In, Out], Future[M]] {
 
   require(n >= 0, s"FlatMapPrefix: n ($n) must be non-negative.")

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GroupedAdjacentByWeighted.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/GroupedAdjacentByWeighted.scala
@@ -17,7 +17,6 @@
 
 package org.apache.pekko.stream.impl.fusing
 
-import scala.collection.immutable
 import scala.util.control.NonFatal
 
 import org.apache.pekko
@@ -37,16 +36,16 @@ private[pekko] final case class GroupedAdjacentByWeighted[T, R](
     f: T => R,
     maxWeight: Long,
     costFn: T => Long)
-    extends GraphStage[FlowShape[T, immutable.Seq[T]]] {
+    extends GraphStage[FlowShape[T, Seq[T]]] {
 
   require(f != null, "f must not be null")
   require(maxWeight > 0, "maxWeight must be greater than 0")
   require(costFn != null, "costFn must not be null")
 
   private val in = Inlet[T]("GroupedAdjacentByWeighted.in")
-  private val out = Outlet[immutable.Seq[T]]("GroupedAdjacentByWeighted.out")
+  private val out = Outlet[Seq[T]]("GroupedAdjacentByWeighted.out")
 
-  override val shape: FlowShape[T, immutable.Seq[T]] = FlowShape(in, out)
+  override val shape: FlowShape[T, Seq[T]] = FlowShape(in, out)
   override def initialAttributes: Attributes = DefaultAttributes.groupedAdjacentByWeighted
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
@@ -56,7 +55,7 @@ private[pekko] final case class GroupedAdjacentByWeighted[T, R](
       // used to track if elements has been added to the current group, zero weight is allowed
       private var hasElements: Boolean = false
       private var currentKey: OptionVal[R] = OptionVal.none
-      private var pendingGroup: OptionVal[immutable.Seq[T]] = OptionVal.none
+      private var pendingGroup: OptionVal[Seq[T]] = OptionVal.none
       private lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
 
       override def onPush(): Unit = {
@@ -139,7 +138,7 @@ private[pekko] final case class GroupedAdjacentByWeighted[T, R](
         currentKey = OptionVal.none
       }
 
-      private def pushOrQueue(group: immutable.Seq[T]): Unit = pendingGroup match {
+      private def pushOrQueue(group: Seq[T]): Unit = pendingGroup match {
         case OptionVal.Some(pending) =>
           push(out, pending)
           pendingGroup = OptionVal.Some(group)

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -17,7 +17,6 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.annotation.nowarn
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
 import scala.concurrent.Future
 import scala.concurrent.duration.{ FiniteDuration, _ }

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/Ops.scala
@@ -797,12 +797,12 @@ private[stream] object Collect {
  * INTERNAL API
  */
 @InternalApi private[pekko] final case class GroupedWeighted[T](minWeight: Long, costFn: T => Long)
-    extends GraphStage[FlowShape[T, immutable.Seq[T]]] {
+    extends GraphStage[FlowShape[T, Seq[T]]] {
   require(minWeight > 0, "minWeight must be greater than 0")
 
   val in = Inlet[T]("GroupedWeighted.in")
-  val out = Outlet[immutable.Seq[T]]("GroupedWeighted.out")
-  override val shape: FlowShape[T, immutable.Seq[T]] = FlowShape(in, out)
+  val out = Outlet[Seq[T]]("GroupedWeighted.out")
+  override val shape: FlowShape[T, Seq[T]] = FlowShape(in, out)
 
   override def initialAttributes: Attributes = DefaultAttributes.groupedWeighted
 
@@ -890,13 +890,13 @@ private[stream] object Collect {
  * INTERNAL API
  */
 @InternalApi private[pekko] final case class Sliding[T](val n: Int, val step: Int)
-    extends GraphStage[FlowShape[T, immutable.Seq[T]]] {
+    extends GraphStage[FlowShape[T, Seq[T]]] {
   require(n > 0, "n must be greater than 0")
   require(step > 0, "step must be greater than 0")
 
   val in = Inlet[T]("Sliding.in")
-  val out = Outlet[immutable.Seq[T]]("Sliding.out")
-  override val shape: FlowShape[T, immutable.Seq[T]] = FlowShape(in, out)
+  val out = Outlet[Seq[T]]("Sliding.out")
+  override val shape: FlowShape[T, Seq[T]] = FlowShape(in, out)
 
   override protected val initialAttributes: Attributes = DefaultAttributes.sliding
 
@@ -1884,13 +1884,13 @@ private[stream] object Collect {
     val maxNumber: Int,
     val costFn: T => Long,
     val interval: FiniteDuration)
-    extends GraphStage[FlowShape[T, immutable.Seq[T]]] {
+    extends GraphStage[FlowShape[T, Seq[T]]] {
   require(maxWeight > 0, "maxWeight must be greater than 0")
   require(maxNumber > 0, "maxNumber must be greater than 0")
   require(interval > Duration.Zero)
 
   val in = Inlet[T]("in")
-  val out = Outlet[immutable.Seq[T]]("out")
+  val out = Outlet[Seq[T]]("out")
 
   override def initialAttributes = DefaultAttributes.groupedWeightedWithin and SourceLocation.forLambda(costFn)
 

--- a/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/impl/fusing/StreamOfStreams.scala
@@ -267,10 +267,10 @@ import pekko.util.OptionVal
  * INTERNAL API
  */
 @InternalApi private[pekko] final class PrefixAndTail[T](val n: Int)
-    extends GraphStage[FlowShape[T, (immutable.Seq[T], Source[T, NotUsed])]] {
+    extends GraphStage[FlowShape[T, (Seq[T], Source[T, NotUsed])]] {
   val in: Inlet[T] = Inlet("PrefixAndTail.in")
-  val out: Outlet[(immutable.Seq[T], Source[T, NotUsed])] = Outlet("PrefixAndTail.out")
-  override val shape: FlowShape[T, (immutable.Seq[T], Source[T, NotUsed])] = FlowShape(in, out)
+  val out: Outlet[(Seq[T], Source[T, NotUsed])] = Outlet("PrefixAndTail.out")
+  override val shape: FlowShape[T, (Seq[T], Source[T, NotUsed])] = FlowShape(in, out)
 
   override def initialAttributes = DefaultAttributes.prefixAndTail
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -20,7 +20,6 @@ import java.util.concurrent.CompletionStage
 import scala.annotation.nowarn
 import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.varargs
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.jdk.DurationConverters._
 import scala.jdk.FutureConverters._

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Flow.scala
@@ -3567,7 +3567,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
       case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
-    else immutable.Seq()
+    else Seq()
     new Flow(delegate.interleaveAll(seq, segmentSize, eagerClose))
   }
 
@@ -3650,7 +3650,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
       case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
-    else immutable.Seq()
+    else Seq()
     new javadsl.Flow(delegate.mergeAll(seq, eagerComplete))
   }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Sink.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.{ CompletableFuture, CompletionStage }
 import java.util.stream.Collector
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.jdk.FutureConverters._
 import scala.jdk.OptionConverters._
@@ -441,7 +440,7 @@ object Sink {
       fanOutStrategy: function.Function[java.lang.Integer, Graph[UniformFanOutShape[T, U], NotUsed]])
       : Sink[T, NotUsed] = {
     import scala.jdk.CollectionConverters._
-    val seq = if (rest ne null) rest.asScala.map(_.asScala).toSeq else immutable.Seq()
+    val seq = if (rest ne null) rest.asScala.map(_.asScala).toSeq else Seq()
     new Sink(scaladsl.Sink.combine(output1.asScala, output2.asScala, seq: _*)(num => fanOutStrategy.apply(num)))
   }
 
@@ -472,7 +471,7 @@ object Sink {
       case sink: Sink[U @unchecked, M @unchecked] => sink.asScala
       case other                                  => other
     }
-    else immutable.Seq()
+    else Seq()
     import scala.jdk.CollectionConverters._
     new Sink(scaladsl.Sink.combine(seq)(size => fanOutStrategy(size)).mapMaterializedValue(_.asJava))
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/Source.scala
@@ -544,7 +544,7 @@ object Source {
       fanInStrategy: function.Function[java.lang.Integer, ? <: Graph[UniformFanInShape[T, U], NotUsed]])
       : Source[U, NotUsed] = {
     import scala.jdk.CollectionConverters._
-    val seq = if (rest ne null) rest.asScala.map(_.asScala).toSeq else immutable.Seq()
+    val seq = if (rest ne null) rest.asScala.map(_.asScala).toSeq else Seq()
     new Source(scaladsl.Source.combine(first.asScala, second.asScala, seq: _*)(num => fanInStrategy.apply(num)))
   }
 
@@ -574,7 +574,7 @@ object Source {
       case source: Source[T @unchecked, M @unchecked] => source.asScala
       case other                                      => other
     }
-    else immutable.Seq()
+    else Seq()
     new Source(scaladsl.Source.combine(seq)(size => fanInStrategy(size)).mapMaterializedValue(_.asJava))
   }
 
@@ -583,7 +583,7 @@ object Source {
    */
   def zipN[T](@Nullable sources: java.util.List[Source[T, ? <: Any]]): Source[java.util.List[T], NotUsed] = {
     import scala.jdk.CollectionConverters._
-    val seq = if (sources ne null) sources.asScala.map(_.asScala).toSeq else immutable.Seq()
+    val seq = if (sources ne null) sources.asScala.map(_.asScala).toSeq else Seq()
     new Source(scaladsl.Source.zipN(seq).map(_.asJava))
   }
 
@@ -600,7 +600,7 @@ object Source {
       zipper: function.Function[java.util.List[T], O],
       @Nullable sources: java.util.List[Source[T, ? <: Any]]): Source[O, NotUsed] = {
     import scala.jdk.CollectionConverters._
-    val seq = if (sources ne null) sources.asScala.map(_.asScala).toSeq else immutable.Seq()
+    val seq = if (sources ne null) sources.asScala.map(_.asScala).toSeq else Seq()
     new Source(scaladsl.Source.zipWithN[T, O](seq => zipper.apply(seq.asJava))(seq))
   }
 
@@ -865,7 +865,7 @@ object Source {
       if (sourcesAndPriorities ne null)
         sourcesAndPriorities.asScala.map(pair => (pair.first.asScala, pair.second.intValue())).toSeq
       else
-        immutable.Seq()
+        Seq()
     new Source(scaladsl.Source.mergePrioritizedN(seq, eagerComplete))
   }
 }
@@ -1694,7 +1694,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
       case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
-    else immutable.Seq()
+    else Seq()
     new Source(delegate.interleaveAll(seq, segmentSize, eagerClose))
   }
 
@@ -1775,7 +1775,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
       case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
-    else immutable.Seq()
+    else Seq()
     new Source(delegate.mergeAll(seq, eagerComplete))
   }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -2441,7 +2441,7 @@ final class SubFlow[In, Out, Mat](
       case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
-    else immutable.Seq()
+    else Seq()
     new SubFlow(delegate.mergeAll(seq, eagerComplete))
   }
 
@@ -2500,7 +2500,7 @@ final class SubFlow[In, Out, Mat](
       case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
-    else immutable.Seq()
+    else Seq()
     new SubFlow(delegate.interleaveAll(seq, segmentSize, eagerClose))
   }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubFlow.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.CompletionStage
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.varargs
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
 import scala.jdk.FutureConverters._

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -2407,7 +2407,7 @@ final class SubSource[Out, Mat](
       case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
-    else immutable.Seq()
+    else Seq()
     new SubSource(delegate.mergeAll(seq, eagerComplete))
   }
 
@@ -2467,7 +2467,7 @@ final class SubSource[Out, Mat](
       case source: Source[Out @unchecked, ?] => source.asScala
       case other                             => other
     }
-    else immutable.Seq()
+    else Seq()
     new SubSource(delegate.interleaveAll(seq, segmentSize, eagerClose))
   }
 

--- a/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/javadsl/SubSource.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.CompletionStage
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.varargs
-import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
 import scala.jdk.FutureConverters._

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -1837,7 +1837,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def grouped(n: Int): Repr[immutable.Seq[Out]] =
+  def grouped(n: Int): Repr[Seq[Out]] =
     via(GroupedWeighted[Out](n, ConstantFun.oneLong).withAttributes(DefaultAttributes.grouped))
 
   /**
@@ -1856,7 +1856,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def groupedWeighted(minWeight: Long)(costFn: Out => Long): Repr[immutable.Seq[Out]] =
+  def groupedWeighted(minWeight: Long)(costFn: Out => Long): Repr[Seq[Out]] =
     via(GroupedWeighted[Out](minWeight, costFn))
 
   /**
@@ -1878,7 +1878,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * @since 1.2.0
    */
-  def groupedAdjacentBy[T](f: Out => T): Repr[immutable.Seq[Out]] =
+  def groupedAdjacentBy[T](f: Out => T): Repr[Seq[Out]] =
     via(GroupedAdjacentByWeighted(f, Long.MaxValue, ConstantFun.oneLong))
 
   /**
@@ -1901,7 +1901,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * @since 1.2.0
    */
-  def groupedAdjacentByWeighted[T](f: Out => T, maxWeight: Long)(costFn: Out => Long): Repr[immutable.Seq[Out]] =
+  def groupedAdjacentByWeighted[T](f: Out => T, maxWeight: Long)(costFn: Out => Long): Repr[Seq[Out]] =
     via(GroupedAdjacentByWeighted(f, maxWeight, costFn))
 
   /**
@@ -1968,7 +1968,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def sliding(n: Int, step: Int = 1): Repr[immutable.Seq[Out]] = via(Sliding(n, step))
+  def sliding(n: Int, step: Int = 1): Repr[Seq[Out]] = via(Sliding(n, step))
 
   /**
    * Similar to `fold` but is not a terminal operation,
@@ -2205,7 +2205,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream completes
    */
-  def groupedWithin(n: Int, d: FiniteDuration): Repr[immutable.Seq[Out]] =
+  def groupedWithin(n: Int, d: FiniteDuration): Repr[Seq[Out]] =
     via(
       new GroupedWeightedWithin[Out](Long.MaxValue, n, ConstantFun.zeroLong, d)
         .withAttributes(DefaultAttributes.groupedWithin))
@@ -2232,7 +2232,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream completes
    */
-  def groupedWeightedWithin(maxWeight: Long, d: FiniteDuration)(costFn: Out => Long): Repr[immutable.Seq[Out]] =
+  def groupedWeightedWithin(maxWeight: Long, d: FiniteDuration)(costFn: Out => Long): Repr[Seq[Out]] =
     via(new GroupedWeightedWithin[Out](maxWeight, Int.MaxValue, costFn, d))
 
   /**
@@ -2259,7 +2259,7 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream completes
    */
   def groupedWeightedWithin(maxWeight: Long, maxNumber: Int, d: FiniteDuration)(
-      costFn: Out => Long): Repr[immutable.Seq[Out]] =
+      costFn: Out => Long): Repr[Seq[Out]] =
     via(new GroupedWeightedWithin[Out](maxWeight, maxNumber, costFn, d))
 
   /**
@@ -2636,7 +2636,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels or substream cancels
    */
-  def prefixAndTail[U >: Out](n: Int): Repr[(immutable.Seq[Out], Source[U, NotUsed])] =
+  def prefixAndTail[U >: Out](n: Int): Repr[(Seq[Out], Source[U, NotUsed])] =
     via(new PrefixAndTail[Out](n))
 
   /**
@@ -2661,7 +2661,7 @@ trait FlowOps[+Out, +Mat] {
    *  @param n the number of elements to accumulate before materializing the downstream flow.
    *  @param f a function that produces the downstream flow based on the upstream's prefix.
    */
-  def flatMapPrefix[Out2, Mat2](n: Int)(f: immutable.Seq[Out] => Flow[Out, Out2, Mat2]): Repr[Out2] = {
+  def flatMapPrefix[Out2, Mat2](n: Int)(f: Seq[Out] => Flow[Out, Out2, Mat2]): Repr[Out2] = {
     via(new FlatMapPrefix(n, f))
   }
 
@@ -3469,7 +3469,7 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream cancels
    */
   def interleaveAll[U >: Out](
-      those: immutable.Seq[Graph[SourceShape[U], ?]],
+      those: Seq[Graph[SourceShape[U], ?]],
       segmentSize: Int,
       eagerClose: Boolean): Repr[U] = those match {
     case those if those.isEmpty => this.asInstanceOf[Repr[U]]
@@ -3519,7 +3519,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def mergeAll[U >: Out](those: immutable.Seq[Graph[SourceShape[U], ?]], eagerComplete: Boolean): Repr[U] =
+  def mergeAll[U >: Out](those: Seq[Graph[SourceShape[U], ?]], eagerComplete: Boolean): Repr[U] =
     those match {
       case those if those.isEmpty => this.asInstanceOf[Repr[U]]
       case _                      =>
@@ -3542,12 +3542,12 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Completes when''' all upstreams complete (eagerClose=false) or one upstream completes (eagerClose=true)
    */
-  def mergeLatest[U >: Out, M](that: Graph[SourceShape[U], M], eagerComplete: Boolean = false): Repr[immutable.Seq[U]] =
+  def mergeLatest[U >: Out, M](that: Graph[SourceShape[U], M], eagerComplete: Boolean = false): Repr[Seq[U]] =
     via(mergeLatestGraph(that, eagerComplete))
 
   protected def mergeLatestGraph[U >: Out, M](
       that: Graph[SourceShape[U], M],
-      eagerComplete: Boolean): Graph[FlowShape[Out @uncheckedVariance, immutable.Seq[U]], M] =
+      eagerComplete: Boolean): Graph[FlowShape[Out @uncheckedVariance, Seq[U]], M] =
     GraphDSL.createGraph(that) { implicit b => r =>
       val merge = b.add(MergeLatest[U](2, eagerComplete))
       r ~> merge.in(1)
@@ -4168,7 +4168,7 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * mat version of [[#flatMapPrefix]], this method gives access to a future materialized value of the downstream flow.
    * see [[#flatMapPrefix]] for details.
    */
-  def flatMapPrefixMat[Out2, Mat2, Mat3](n: Int)(f: immutable.Seq[Out] => Flow[Out, Out2, Mat2])(
+  def flatMapPrefixMat[Out2, Mat2, Mat3](n: Int)(f: Seq[Out] => Flow[Out, Out2, Mat2])(
       matF: (Mat, Future[Mat2]) => Mat3): ReprMat[Out2, Mat3] = {
     viaMat(new FlatMapPrefix(n, f))(matF)
   }
@@ -4320,7 +4320,7 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def mergeLatestMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2], eagerClose: Boolean)(
-      matF: (Mat, Mat2) => Mat3): ReprMat[immutable.Seq[U], Mat3] =
+      matF: (Mat, Mat2) => Mat3): ReprMat[Seq[U], Mat3] =
     viaMat(mergeLatestGraph(that, eagerClose))(matF)
 
   /**

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/FlowWithContextOps.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.stream.scaladsl
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -388,7 +387,7 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
    *
    * @see `FlowOps.grouped`
    */
-  def grouped(n: Int): Repr[immutable.Seq[Out], immutable.Seq[Ctx]] =
+  def grouped(n: Int): Repr[Seq[Out], Seq[Ctx]] =
     via(flow.grouped(n).map { elsWithContext =>
       val (els, ctxs) = elsWithContext.unzip
       (els, ctxs)
@@ -401,7 +400,7 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
    *
    * @see `FlowOps.sliding`
    */
-  def sliding(n: Int, step: Int = 1): Repr[immutable.Seq[Out], immutable.Seq[Ctx]] =
+  def sliding(n: Int, step: Int = 1): Repr[Seq[Out], Seq[Ctx]] =
     via(flow.sliding(n, step).map { elsWithContext =>
       val (els, ctxs) = elsWithContext.unzip
       (els, ctxs)

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Graph.scala
@@ -1258,7 +1258,7 @@ object ZipN {
  *
  * '''Cancels when''' downstream cancels
  */
-final class ZipN[A](n: Int) extends ZipWithN[A, immutable.Seq[A]](ConstantFun.scalaIdentityFunction)(n) {
+final class ZipN[A](n: Int) extends ZipWithN[A, Seq[A]](ConstantFun.scalaIdentityFunction)(n) {
   override def initialAttributes = DefaultAttributes.zipN
   override def toString = "ZipN"
 }
@@ -1268,7 +1268,7 @@ object ZipWithN {
   /**
    * Create a new `ZipWithN`.
    */
-  def apply[A, O](zipper: immutable.Seq[A] => O)(n: Int) = new ZipWithN[A, O](zipper)(n)
+  def apply[A, O](zipper: Seq[A] => O)(n: Int) = new ZipWithN[A, O](zipper)(n)
 }
 
 /**
@@ -1290,7 +1290,7 @@ object ZipWithN {
  * the stream fails. If the supervision decision is [[pekko.stream.Supervision.Resume]] or
  * [[pekko.stream.Supervision.Restart]] the zipped element is dropped and the stream continues.
  */
-class ZipWithN[A, O](zipper: immutable.Seq[A] => O)(n: Int) extends GraphStage[UniformFanInShape[A, O]] {
+class ZipWithN[A, O](zipper: Seq[A] => O)(n: Int) extends GraphStage[UniformFanInShape[A, O]] {
   override def initialAttributes = DefaultAttributes.zipWithN
   override val shape = new UniformFanInShape[A, O](n)
   def out: Outlet[O] = shape.out
@@ -1686,15 +1686,15 @@ object GraphDSL extends GraphApply {
    * Creates a new [[Graph]] by importing the given graph list `graphs` and passing their [[Shape]]s
    * along with the [[GraphDSL.Builder]] to the given create function.
    */
-  def create[S <: Shape, IS <: Shape, Mat](graphs: immutable.Seq[Graph[IS, Mat]])(
-      buildBlock: GraphDSL.Builder[immutable.Seq[Mat]] => immutable.Seq[IS] => S): Graph[S, immutable.Seq[Mat]] = {
+  def create[S <: Shape, IS <: Shape, Mat](graphs: Seq[Graph[IS, Mat]])(
+      buildBlock: GraphDSL.Builder[Seq[Mat]] => Seq[IS] => S): Graph[S, Seq[Mat]] = {
     require(graphs.nonEmpty, "The input list must have one or more Graph elements")
     val builder = new GraphDSL.Builder
     val toList = (m1: Mat) => Seq(m1)
     val combine = (s: Seq[Mat], m2: Mat) => s :+ m2
     val sListH = builder.add(graphs.head, toList)
     val sListT = graphs.tail.map(g => builder.add(g, combine))
-    val s = buildBlock(builder)(immutable.Seq(sListH) ++ sListT)
+    val s = buildBlock(builder)(Seq(sListH) ++ sListT)
 
     new GenericGraph(s, builder.result(s))
   }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Sink.scala
@@ -237,13 +237,13 @@ object Sink {
   }
 
   /**
-   * A `Sink` that materializes into a `Future` of `immutable.Seq[T]` containing the last `n` collected elements.
+   * A `Sink` that materializes into a `Future` of `Seq[T]` containing the last `n` collected elements.
    *
    * If the stream completes before signaling at least n elements, the `Future` will complete with all elements seen so far.
    * If the stream never completes, the `Future` will never complete.
    * If there is a failure signaled in the stream the `Future` will be completed with failure.
    */
-  def takeLast[T](n: Int): Sink[T, Future[immutable.Seq[T]]] =
+  def takeLast[T](n: Int): Sink[T, Future[Seq[T]]] =
     Sink.fromGraph(new TakeLastStage[T](n)).withAttributes(DefaultAttributes.takeLastSink)
 
   /**
@@ -256,7 +256,7 @@ object Sink {
    *
    * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], `Flow.takeWhile`
    */
-  def seq[T]: Sink[T, Future[immutable.Seq[T]]] = Sink.fromGraph(new SeqStage[T, Vector[T]])
+  def seq[T]: Sink[T, Future[Seq[T]]] = Sink.fromGraph(new SeqStage[T, Vector[T]])
 
   /**
    * A `Sink` that counts all incoming elements until upstream terminates.
@@ -392,11 +392,11 @@ object Sink {
    * The fanoutGraph's outlets size must match the provides sinks'.
    * @since 1.1.0
    */
-  def combine[T, U, M](sinks: immutable.Seq[Graph[SinkShape[U], M]])(
-      fanOutStrategy: Int => Graph[UniformFanOutShape[T, U], NotUsed]): Sink[T, immutable.Seq[M]] =
+  def combine[T, U, M](sinks: Seq[Graph[SinkShape[U], M]])(
+      fanOutStrategy: Int => Graph[UniformFanOutShape[T, U], NotUsed]): Sink[T, Seq[M]] =
     sinks match {
-      case immutable.Seq()     => Sink.cancelled.mapMaterializedValue(_ => Nil)
-      case immutable.Seq(sink) =>
+      case Seq()     => Sink.cancelled.mapMaterializedValue(_ => Nil)
+      case Seq(sink) =>
         // Single-sink optimization: bypass the fan-out strategy if and only if the strategy
         // is type-preserving (T == U), marked by the TypePreservingFanOut trait.
         // For type-transforming strategies, we MUST route through the strategy even for a

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Source.scala
@@ -408,7 +408,7 @@ object Source {
    * Iterator, but every Subscriber directly attached to the Publisher of this
    * stream will see an individual flow of elements (always starting from the
    * beginning) regardless of when they subscribed.
-   * @see [[apply(immutable.Seq)]]
+   * @see [[apply(Seq)]]
    */
   @inline def apply[T](iterable: immutable.Iterable[T]): Source[T, NotUsed] = {
     // unknown size is -1
@@ -434,7 +434,7 @@ object Source {
    * @see [[apply(immutable.Iterable)]]
    * @since 2.0.0
    */
-  @inline def apply[T](seq: immutable.Seq[T]): Source[T, NotUsed] = {
+  @inline def apply[T](seq: Seq[T]): Source[T, NotUsed] = {
     // unknown size is -1
     (seq.knownSize: @switch) match {
       case 0 => empty[T]
@@ -816,11 +816,11 @@ object Source {
    * Combines several sources with fan-in strategy like [[Merge]] or [[Concat]] into a single [[Source]].
    * @since 1.1.0
    */
-  def combine[T, U, M](sources: immutable.Seq[Graph[SourceShape[T], M]])(
-      fanInStrategy: Int => Graph[UniformFanInShape[T, U], NotUsed]): Source[U, immutable.Seq[M]] =
+  def combine[T, U, M](sources: Seq[Graph[SourceShape[T], M]])(
+      fanInStrategy: Int => Graph[UniformFanInShape[T, U], NotUsed]): Source[U, Seq[M]] =
     sources match {
-      case immutable.Seq()       => Source.empty.mapMaterializedValue(_ => Nil)
-      case immutable.Seq(source) =>
+      case Seq()       => Source.empty.mapMaterializedValue(_ => Nil)
+      case Seq(source) =>
         // Single-source optimization: bypass the fan-in strategy if and only if the strategy
         // is type-preserving (T == U), marked by the TypePreservingFanIn trait.
         //
@@ -885,8 +885,8 @@ object Source {
   /**
    * Combine the elements of multiple streams into a stream of sequences.
    */
-  def zipN[T](sources: immutable.Seq[Source[T, ?]]): Source[immutable.Seq[T], NotUsed] =
-    zipWithN(ConstantFun.scalaIdentityFunction[immutable.Seq[T]])(sources).addAttributes(DefaultAttributes.zipN)
+  def zipN[T](sources: Seq[Source[T, ?]]): Source[Seq[T], NotUsed] =
+    zipWithN(ConstantFun.scalaIdentityFunction[Seq[T]])(sources).addAttributes(DefaultAttributes.zipN)
 
   /**
    * Combine the elements of multiple streams into a stream of sequences using a combiner function.
@@ -897,12 +897,12 @@ object Source {
    * the stream fails. If the supervision decision is [[pekko.stream.Supervision.Resume]] or
    * [[pekko.stream.Supervision.Restart]] the zipped element is dropped and the stream continues.
    */
-  def zipWithN[T, O](zipper: immutable.Seq[T] => O)(sources: immutable.Seq[Source[T, ?]]): Source[O, NotUsed] = {
+  def zipWithN[T, O](zipper: Seq[T] => O)(sources: Seq[Source[T, ?]]): Source[O, NotUsed] = {
     val source = sources match {
-      case immutable.Seq()       => empty[O]
-      case immutable.Seq(source) => source.map(t => zipper(immutable.Seq(t))).mapMaterializedValue(_ => NotUsed)
-      case s1 +: s2 +: ss        => combine(s1, s2, ss: _*)(ZipWithN(zipper))
-      case _                     => throw new IllegalArgumentException() // just to please compiler completeness check
+      case Seq()          => empty[O]
+      case Seq(source)    => source.map(t => zipper(Seq(t))).mapMaterializedValue(_ => NotUsed)
+      case s1 +: s2 +: ss => combine(s1, s2, ss: _*)(ZipWithN(zipper))
+      case _              => throw new IllegalArgumentException() // just to please compiler completeness check
     }
 
     source.addAttributes(DefaultAttributes.zipWithN)
@@ -1139,12 +1139,12 @@ object Source {
    * '''Cancels when''' downstream cancels
    */
   def mergePrioritizedN[T](
-      sourcesAndPriorities: immutable.Seq[(Source[T, ?], Int)],
+      sourcesAndPriorities: Seq[(Source[T, ?], Int)],
       eagerComplete: Boolean): Source[T, NotUsed] = {
     sourcesAndPriorities match {
-      case immutable.Seq()            => Source.empty
-      case immutable.Seq((source, _)) => source.mapMaterializedValue(_ => NotUsed)
-      case sourcesAndPriorities       =>
+      case Seq()                => Source.empty
+      case Seq((source, _))     => source.mapMaterializedValue(_ => NotUsed)
+      case sourcesAndPriorities =>
         val (sources, priorities) = sourcesAndPriorities.unzip
         combine(sources.head, sources(1), sources.drop(2): _*)(_ => MergePrioritized(priorities, eagerComplete))
     }

--- a/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Tcp.scala
@@ -285,7 +285,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
       remoteAddress: InetSocketAddress,
       createSSLEngine: () => SSLEngine,
       localAddress: Option[InetSocketAddress],
-      options: immutable.Seq[SocketOption],
+      options: Seq[SocketOption],
       connectTimeout: Duration,
       idleTimeout: Duration,
       verifySession: SSLSession => Try[Unit],
@@ -333,7 +333,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
       port: Int,
       createSSLEngine: () => SSLEngine,
       backlog: Int,
-      options: immutable.Seq[SocketOption],
+      options: Seq[SocketOption],
       idleTimeout: Duration,
       verifySession: SSLSession => Try[Unit],
       closing: TLSClosing): Source[IncomingConnection, Future[ServerBinding]] = {
@@ -387,7 +387,7 @@ final class Tcp(system: ExtendedActorSystem) extends pekko.actor.Extension {
       port: Int,
       createSSLEngine: () => SSLEngine,
       backlog: Int,
-      options: immutable.Seq[SocketOption],
+      options: Seq[SocketOption],
       idleTimeout: Duration,
       verifySession: SSLSession => Try[Unit],
       closing: TLSClosing)(implicit m: Materializer): Future[ServerBinding] = {

--- a/stream/src/main/scala/org/apache/pekko/stream/snapshot/MaterializerState.scala
+++ b/stream/src/main/scala/org/apache/pekko/stream/snapshot/MaterializerState.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.snapshot
 
-import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 
@@ -42,7 +41,7 @@ object MaterializerState {
    * Dump stream snapshots of all streams of the default system materializer.
    */
   @ApiMayChange
-  def streamSnapshots(system: ActorSystem): Future[immutable.Seq[StreamSnapshot]] = {
+  def streamSnapshots(system: ActorSystem): Future[Seq[StreamSnapshot]] = {
     SystemMaterializer(system).materializer match {
       case impl: PhasedFusingActorMaterializer =>
         requestFromSupervisor(impl.supervisor)(impl.system.dispatchers.internalDispatcher)
@@ -54,7 +53,7 @@ object MaterializerState {
    * Dump stream snapshots of all streams of the given materializer.
    */
   @ApiMayChange
-  def streamSnapshots(mat: Materializer): Future[immutable.Seq[StreamSnapshot]] = {
+  def streamSnapshots(mat: Materializer): Future[Seq[StreamSnapshot]] = {
     mat match {
       case impl: PhasedFusingActorMaterializer =>
         requestFromSupervisor(impl.supervisor)(impl.system.dispatchers.internalDispatcher)
@@ -65,7 +64,7 @@ object MaterializerState {
   /** INTERNAL API */
   @InternalApi
   private[pekko] def requestFromSupervisor(supervisor: ActorRef)(
-      implicit ec: ExecutionContext): Future[immutable.Seq[StreamSnapshot]] = {
+      implicit ec: ExecutionContext): Future[Seq[StreamSnapshot]] = {
     // Arbitrary timeout: operation should always be quick, when it times out it will be because the materializer stopped
     implicit val timeout: Timeout = 10.seconds
     supervisor
@@ -111,7 +110,7 @@ sealed trait StreamSnapshot {
  */
 @DoNotInherit @ApiMayChange
 sealed trait InterpreterSnapshot {
-  def logics: immutable.Seq[LogicSnapshot]
+  def logics: Seq[LogicSnapshot]
 }
 
 /**
@@ -131,12 +130,12 @@ sealed trait RunningInterpreter extends InterpreterSnapshot {
   /**
    * Each of the materialized graph stage logics running inside the interpreter
    */
-  def logics: immutable.Seq[LogicSnapshot]
+  def logics: Seq[LogicSnapshot]
 
   /**
    * Each connection between logics in the interpreter
    */
-  def connections: immutable.Seq[ConnectionSnapshot]
+  def connections: Seq[ConnectionSnapshot]
 
   /**
    * Total number of non-stopped logics in the interpreter
@@ -146,7 +145,7 @@ sealed trait RunningInterpreter extends InterpreterSnapshot {
   /**
    * All logics that has completed and is no longer executing
    */
-  def stoppedLogics: immutable.Seq[LogicSnapshot]
+  def stoppedLogics: Seq[LogicSnapshot]
 }
 
 /**
@@ -194,7 +193,7 @@ final private[pekko] case class StreamSnapshotImpl(
  * INTERNAL API
  */
 @InternalApi
-private[pekko] final case class UninitializedInterpreterImpl(logics: immutable.Seq[LogicSnapshot])
+private[pekko] final case class UninitializedInterpreterImpl(logics: Seq[LogicSnapshot])
     extends UninitializedInterpreter
 
 /**
@@ -202,11 +201,11 @@ private[pekko] final case class UninitializedInterpreterImpl(logics: immutable.S
  */
 @InternalApi
 private[pekko] final case class RunningInterpreterImpl(
-    logics: immutable.Seq[LogicSnapshot],
-    connections: immutable.Seq[ConnectionSnapshot],
+    logics: Seq[LogicSnapshot],
+    connections: Seq[ConnectionSnapshot],
     queueStatus: String,
     runningLogicsCount: Int,
-    stoppedLogics: immutable.Seq[LogicSnapshot])
+    stoppedLogics: Seq[LogicSnapshot])
     extends RunningInterpreter
     with HideImpl
 

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestEventListener.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestEventListener.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.testkit
 
 import java.lang.{ Iterable => JIterable }
 
-import scala.collection.immutable
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
@@ -55,9 +54,9 @@ import pekko.util.BoxedType
  */
 object TestEvent {
   object Mute {
-    def apply(filter: EventFilter, filters: EventFilter*): Mute = new Mute(filter +: filters.to(immutable.Seq))
+    def apply(filter: EventFilter, filters: EventFilter*): Mute = new Mute(filter +: filters.to(Seq))
   }
-  final case class Mute(filters: immutable.Seq[EventFilter]) extends TestEvent with NoSerializationVerificationNeeded {
+  final case class Mute(filters: Seq[EventFilter]) extends TestEvent with NoSerializationVerificationNeeded {
 
     /**
      * Java API: create a Mute command from a list of filters
@@ -65,9 +64,9 @@ object TestEvent {
     def this(filters: JIterable[EventFilter]) = this(immutableSeq(filters))
   }
   object UnMute {
-    def apply(filter: EventFilter, filters: EventFilter*): UnMute = new UnMute(filter +: filters.to(immutable.Seq))
+    def apply(filter: EventFilter, filters: EventFilter*): UnMute = new UnMute(filter +: filters.to(Seq))
   }
-  final case class UnMute(filters: immutable.Seq[EventFilter])
+  final case class UnMute(filters: Seq[EventFilter])
       extends TestEvent
       with NoSerializationVerificationNeeded {
 

--- a/testkit/src/main/scala/org/apache/pekko/testkit/TestKit.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/TestKit.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.annotation.nowarn
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
@@ -629,7 +628,7 @@ trait TestKitBase {
   /**
    * Same as `expectMsgAllOf(remainingOrDefault, obj...)`, but correctly treating the timeFactor.
    */
-  def expectMsgAllOf[T](obj: T*): immutable.Seq[T] = expectMsgAllOf_internal(remainingOrDefault, obj: _*)
+  def expectMsgAllOf[T](obj: T*): Seq[T] = expectMsgAllOf_internal(remainingOrDefault, obj: _*)
 
   /**
    * Receive a number of messages from the test actor matching the given
@@ -644,7 +643,7 @@ trait TestKitBase {
    *   expectMsgAllOf(1 second, Result1(), Result2())
    * </pre>
    */
-  def expectMsgAllOf[T](max: FiniteDuration, obj: T*): immutable.Seq[T] = expectMsgAllOf_internal(max.dilated, obj: _*)
+  def expectMsgAllOf[T](max: FiniteDuration, obj: T*): Seq[T] = expectMsgAllOf_internal(max.dilated, obj: _*)
 
   private def checkMissingAndUnexpected(
       missing: Seq[Any],
@@ -657,18 +656,18 @@ trait TestKitBase {
       (if (unexpected.isEmpty) "" else unexpected.mkString(unexpectedMessage + " [", ", ", "]")))
   }
 
-  private def expectMsgAllOf_internal[T](max: FiniteDuration, obj: T*): immutable.Seq[T] = {
+  private def expectMsgAllOf_internal[T](max: FiniteDuration, obj: T*): Seq[T] = {
     val recv = receiveN_internal(obj.size, max)
     val missing = obj.filterNot(x => recv.exists(x == _))
     val unexpected = recv.filterNot(x => obj.exists(x == _))
     checkMissingAndUnexpected(missing, unexpected, "not found", "found unexpected")
-    recv.asInstanceOf[immutable.Seq[T]]
+    recv.asInstanceOf[Seq[T]]
   }
 
   /**
    * Same as `expectMsgAllClassOf(remainingOrDefault, obj...)`, but correctly treating the timeFactor.
    */
-  def expectMsgAllClassOf[T](obj: Class[? <: T]*): immutable.Seq[T] =
+  def expectMsgAllClassOf[T](obj: Class[? <: T]*): Seq[T] =
     internalExpectMsgAllClassOf(remainingOrDefault, obj: _*)
 
   /**
@@ -679,21 +678,21 @@ trait TestKitBase {
    * Wait time is bounded by the given duration, with an AssertionFailure
    * being thrown in case of timeout.
    */
-  def expectMsgAllClassOf[T](max: FiniteDuration, obj: Class[? <: T]*): immutable.Seq[T] =
+  def expectMsgAllClassOf[T](max: FiniteDuration, obj: Class[? <: T]*): Seq[T] =
     internalExpectMsgAllClassOf(max.dilated, obj: _*)
 
-  private def internalExpectMsgAllClassOf[T](max: FiniteDuration, obj: Class[? <: T]*): immutable.Seq[T] = {
+  private def internalExpectMsgAllClassOf[T](max: FiniteDuration, obj: Class[? <: T]*): Seq[T] = {
     val recv = receiveN_internal(obj.size, max)
     val missing = obj.filterNot(x => recv.exists(_.getClass eq BoxedType(x)))
     val unexpected = recv.filterNot(x => obj.exists(c => BoxedType(c) eq x.getClass))
     checkMissingAndUnexpected(missing, unexpected, "not found", "found non-matching object(s)")
-    recv.asInstanceOf[immutable.Seq[T]]
+    recv.asInstanceOf[Seq[T]]
   }
 
   /**
    * Same as `expectMsgAllConformingOf(remainingOrDefault, obj...)`, but correctly treating the timeFactor.
    */
-  def expectMsgAllConformingOf[T](obj: Class[? <: T]*): immutable.Seq[T] =
+  def expectMsgAllConformingOf[T](obj: Class[? <: T]*): Seq[T] =
     internalExpectMsgAllConformingOf(remainingOrDefault, obj: _*)
 
   /**
@@ -707,15 +706,15 @@ trait TestKitBase {
    * Beware that one object may satisfy all given class constraints, which
    * may be counter-intuitive.
    */
-  def expectMsgAllConformingOf[T](max: FiniteDuration, obj: Class[? <: T]*): immutable.Seq[T] =
+  def expectMsgAllConformingOf[T](max: FiniteDuration, obj: Class[? <: T]*): Seq[T] =
     internalExpectMsgAllConformingOf(max.dilated, obj: _*)
 
-  private def internalExpectMsgAllConformingOf[T](max: FiniteDuration, obj: Class[? <: T]*): immutable.Seq[T] = {
+  private def internalExpectMsgAllConformingOf[T](max: FiniteDuration, obj: Class[? <: T]*): Seq[T] = {
     val recv = receiveN_internal(obj.size, max)
     val missing = obj.filterNot(x => recv.exists(BoxedType(x).isInstance(_)))
     val unexpected = recv.filterNot(x => obj.exists(c => BoxedType(c).isInstance(x)))
     checkMissingAndUnexpected(missing, unexpected, "not found", "found non-matching object(s)")
-    recv.asInstanceOf[immutable.Seq[T]]
+    recv.asInstanceOf[Seq[T]]
   }
 
   /**
@@ -785,7 +784,7 @@ trait TestKitBase {
    * }}}
    */
   def receiveWhile[T](max: Duration = Duration.Undefined, idle: Duration = Duration.Inf, messages: Int = Int.MaxValue)(
-      f: PartialFunction[AnyRef, T]): immutable.Seq[T] = {
+      f: PartialFunction[AnyRef, T]): Seq[T] = {
     val stop = now + remainingOrDilated(max)
     var msg: Message = NullMessage
 
@@ -819,14 +818,14 @@ trait TestKitBase {
    * Same as `receiveN(n, remaining)` but correctly taking into account
    * Duration.timeFactor.
    */
-  def receiveN(n: Int): immutable.Seq[AnyRef] = receiveN_internal(n, remainingOrDefault)
+  def receiveN(n: Int): Seq[AnyRef] = receiveN_internal(n, remainingOrDefault)
 
   /**
    * Receive N messages in a row before the given deadline.
    */
-  def receiveN(n: Int, max: FiniteDuration): immutable.Seq[AnyRef] = receiveN_internal(n, max.dilated)
+  def receiveN(n: Int, max: FiniteDuration): Seq[AnyRef] = receiveN_internal(n, max.dilated)
 
-  private def receiveN_internal(n: Int, max: Duration): immutable.Seq[AnyRef] = {
+  private def receiveN_internal(n: Int, max: Duration): Seq[AnyRef] = {
     val stop = max + now
     for { x <- 1 to n } yield {
       val timeout = stop - now

--- a/testkit/src/main/scala/org/apache/pekko/testkit/package.scala
+++ b/testkit/src/main/scala/org/apache/pekko/testkit/package.scala
@@ -15,7 +15,6 @@ package org.apache.pekko
 
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
-import scala.collection.immutable
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.reflect.ClassTag
 
@@ -26,7 +25,7 @@ package object testkit {
   def filterEvents[T](eventFilters: Iterable[EventFilter])(block: => T)(implicit system: ActorSystem): T = {
     def now = System.currentTimeMillis
 
-    system.eventStream.publish(TestEvent.Mute(eventFilters.to(immutable.Seq)))
+    system.eventStream.publish(TestEvent.Mute(eventFilters.to(Seq)))
 
     try {
       val result = block
@@ -41,7 +40,7 @@ package object testkit {
 
       result
     } finally {
-      system.eventStream.publish(TestEvent.UnMute(eventFilters.to(immutable.Seq)))
+      system.eventStream.publish(TestEvent.UnMute(eventFilters.to(Seq)))
     }
   }
 


### PR DESCRIPTION
### Motivation
The codebase still carried a number of Scala 2.12-era idioms that are redundant or deprecated on Scala 2.13/3: `immutable.Seq` qualifiers (`scala.Seq` has been `immutable.Seq` since 2.13), the deprecated `mutable.WrappedArray` alias, `filterKeys`/`mapValues` on `Map`, `Either` left/right projections, and `.toIterator`/`Stream` in user-facing doc snippets.

### Modification
- Replace `immutable.Seq` with `Seq` across ~210 files and drop the now-unused `scala.collection.immutable` imports. `scala.Seq` is a type alias for `scala.collection.immutable.Seq` on 2.13 and 3, so this is source- and binary-compatible (same erasure). `DslFactoriesConsistencySpec` is left as-is since it deliberately distinguishes `collection.Seq` from `immutable.Seq`.
- `ByteStringBuilder.addAll`: match `mutable.ArraySeq.ofByte` and `immutable.ArraySeq.ofByte` instead of the deprecated `WrappedArray.ofByte`. `Array.toSeq`/`toIndexedSeq` produce `immutable.ArraySeq.ofByte` on 2.13, which previously fell through to the generic path.
- Remove a dead commented-out `CanBuildFrom` block in `ByteString`.
- `ManifestInfo`: replace deprecated `filterKeys` (and its `@nowarn`) with `filter`.
- `ShardRegion` scaladoc example: `filterKeys` -> `filter`.
- Rendered doc snippets: `Source(Stream.from(1))` -> `Source(LazyList.from(1))` (`KillSwitchDocSpec`), `buffer.toIterator` -> `buffer.iterator` (`GraphStageDocSpec`).
- Tests: `Shrink.withLazyList` instead of `Shrink(_ => Stream.empty)`, `view.mapValues` instead of a `@nowarn` wrapper, `.iterator` instead of `.toIterator`, and plain `Either` equality instead of `.left.get`/`.right.get` (dropping the `@nowarn` on `MetricNumericConverterSpec`).
- Paradox docs: prose and `@apidoc` scala anchors updated from `immutable.Seq` to `Seq` to match the regenerated scaladoc ids (all 25 `Seq`-bearing anchors verified against `stream/doc` output); four anchors that were already broken on `main` were corrected while touching them.
- MiMa: one `IncompatibleSignatureProblem` filter for `Shape.hasOnePort` (`@InternalApi private[pekko]`): erased descriptor is unchanged, only the Java generic signature moved from `Seq<?>` to `Seq<Object>`.

The 2.12 branches in `project/PekkoDisciplinePlugin.scala` and the `filterKeys`/`mapValues` uses under `project/` (sbt still runs on 2.12) are intentionally left unchanged.

### Result
No remaining Scala 2.12 collection idioms in main, test or doc sources.

### Tests
- native `scalafmt` run on all changed files
- `sbt stream/mimaReportBinaryIssues` passes locally with the filter
- `sbt stream/doc` generated and used to verify the paradox anchors
- full `Test/compile` and tests: relying on CI

### References
None - Scala 2.12 support was dropped previously

